### PR TITLE
gx publish v1.0.0

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,0 +1,1 @@
+1.0.0: QmSS5fXJLErnboqmkauLwRrEDAij2MEyvqcwgJ9fF5k2s2

--- a/package.json
+++ b/package.json
@@ -97,5 +97,5 @@
   "language": "go",
   "license": "MIT",
   "name": "go-libp2p-kad-dht",
-  "version": "0.0.0"
+  "version": "1.0.0"
 }


### PR DESCRIPTION
now that this is its own separate project, lets gx publish it out.

This PR is here to serve as a short guide on how to do that.

First, bump the version: `gx version {major|minor|patch}`, where `gx version minor` will bump the minor version. You can also just manually set a version with `gx version x.y.z`.

Then you can do `gx publish`. Make sure your working directory is clean, the publish will grab everything in your directory not ignored by a gitignore or a gxignore file.

Add the package.json changes and the .gx/lastpubver file, commit it and push it up. 

Once it hits master, head over to http://mars.i.ipfs.team:9444/ and update the pin for the package.

cc @geoah (in case youre interested in contributing more :) )