### PR TITLE
Add support for a 'client mode' dht

### DIFF
--- a/dht.go
+++ b/dht.go
@@ -67,41 +67,43 @@ type IpfsDHT struct {
 
 // NewDHT creates a new DHT object with the given peer as the 'local' host
 func NewDHT(ctx context.Context, h host.Host, dstore ds.Batching) *IpfsDHT {
-	dht := new(IpfsDHT)
-	dht.datastore = dstore
-	dht.self = h.ID()
-	dht.peerstore = h.Peerstore()
-	dht.host = h
+	dht := makeDHT(ctx, h, dstore)
 
 	// register for network notifs.
 	dht.host.Network().Notify((*netNotifiee)(dht))
 
-	dht.proc = goprocess.WithTeardown(func() error {
+	dht.proc = goprocessctx.WithContextAndTeardown(ctx, func() error {
 		// remove ourselves from network notifs.
 		dht.host.Network().StopNotify((*netNotifiee)(dht))
 		return nil
 	})
 
-	dht.strmap = make(map[peer.ID]*messageSender)
-	dht.ctx = ctx
+	dht.proc.AddChild(dht.providers.Process())
 
 	h.SetStreamHandler(ProtocolDHT, dht.handleNewStream)
 	h.SetStreamHandler(ProtocolDHTOld, dht.handleNewStream)
 
-	dht.providers = providers.NewProviderManager(dht.ctx, dht.self, dstore)
-	dht.proc.AddChild(dht.providers.Process())
-	goprocessctx.CloseAfterContext(dht.proc, ctx)
-
-	dht.routingTable = kb.NewRoutingTable(20, kb.ConvertPeerID(dht.self), time.Minute, dht.peerstore)
-	dht.birth = time.Now()
-
-	dht.Validator = make(record.Validator)
 	dht.Validator["pk"] = record.PublicKeyValidator
-
-	dht.Selector = make(record.Selector)
 	dht.Selector["pk"] = record.PublicKeySelector
 
 	return dht
+}
+
+func makeDHT(ctx context.Context, h host.Host, dstore ds.Batching) *IpfsDHT {
+	return &IpfsDHT{
+		datastore:    dstore,
+		self:         h.ID(),
+		peerstore:    h.Peerstore(),
+		host:         h,
+		strmap:       make(map[peer.ID]*messageSender),
+		ctx:          ctx,
+		providers:    providers.NewProviderManager(ctx, h.ID(), dstore),
+		birth:        time.Now(),
+		routingTable: kb.NewRoutingTable(KValue, kb.ConvertPeerID(h.ID()), time.Minute, h.Peerstore()),
+
+		Validator: make(record.Validator),
+		Selector:  make(record.Selector),
+	}
 }
 
 // putValueToPeer stores the given key/value pair at the peer 'p'

--- a/package.json
+++ b/package.json
@@ -65,9 +65,9 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmdMfSLMDBDYhtc4oF3NYGCZr5dy4wQb6Ji26N4D4mdxa2",
+      "hash": "QmYkwVGkwoPbMVQEbf6LonZg4SsCxGP3H7PBEtdNCNRyxD",
       "name": "go-libp2p-peerstore",
-      "version": "1.2.4"
+      "version": "1.2.5"
     },
     {
       "author": "whyrusleeping",
@@ -107,15 +107,15 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmTZsN8hysGnbakvK6mS8rwDQ9uwokxmWFBv94pig6zGd1",
+      "hash": "QmVsCNFD32GzZ6Q5XD1TVGPRviNYqDdoNvgq853TU9hhzP",
       "name": "go-libp2p-kbucket",
-      "version": "1.0.2"
+      "version": "1.0.3"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmcoQiBzRaaVv1DZbbXoDWiEtvDN94Ca1DcwnQKK2tP92s",
+      "hash": "QmemZcG8WprPbnVX3AM43GhhSUiA3V6NjcTLAguvWzkdpQ",
       "name": "go-libp2p-routing",
-      "version": "1.0.2"
+      "version": "1.0.3"
     },
     {
       "author": "whyrusleeping",
@@ -125,15 +125,16 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmR61Ut9oN9mEacVUDWpvvhRPYXSxHEAZVbZkiLy9tKmdr",
+      "hash": "QmbiRCGZqhfcSjnm9icGz3oNQQdPLAnLWnKHXixaEWXVCN",
       "name": "go-libp2p",
-      "version": "3.5.3"
+      "version": "3.5.4"
     }
   ],
   "gxVersion": "0.4.0",
   "language": "go",
   "license": "MIT",
   "name": "go-libp2p-kad-dht",
+  "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
   "version": "1.1.1"
 }
 


### PR DESCRIPTION
A client mode dht node will not serve any requests, but will still be able to make requests of the network.

I'm interested in pushing this forward as an experimental feature to reduce idle bandwidth consumption.