### PR TITLE
dht: degrade 'no addresses' from error to warning

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -69,7 +69,7 @@ func (dht *IpfsDHT) handleGetValue(ctx context.Context, p peer.ID, pmes *pb.Mess
 		for _, pi := range closerinfos {
 			log.Debugf("handleGetValue returning closer peer: '%s'", pi.ID)
 			if len(pi.Addrs) < 1 {
-				log.Errorf(`no addresses on peer being sent!
+				log.Warningf(`no addresses on peer being sent!
 					[local:%s]
 					[sending:%s]
 					[remote:%s]`, dht.self, pi.ID, p)


### PR DESCRIPTION
to reduce confusion as it is a bug with unknown source but end users
don't have to see it as it isn't critical

Closes https://github.com/ipfs/go-ipfs/issues/2495