### PR TITLE
fix filtering bug in find closest peers

### DIFF
--- a/lookup.go
+++ b/lookup.go
@@ -66,7 +66,7 @@ func (dht *IpfsDHT) GetClosestPeers(ctx context.Context, key string) (<-chan pee
 
 		var filtered []pstore.PeerInfo
 		for _, clp := range closer {
-			if kb.Closer(clp, dht.self, key) && peerset.TryAdd(clp) {
+			if peerset.TryAdd(clp) {
 				select {
 				case out <- clp:
 				case <-ctx.Done():


### PR DESCRIPTION
we were previously filtering out peers that werent as close to us from `GetClosestPeers` calls. This would result in small numbers ( < K ) peers being returned when we expected a full K peers no matter what.

The side effects of that behaviour are things like records not being put to enough peers, and not enough peers being queried during lookups.