### PR TITLE
DRY up NewDHT

### DIFF
--- a/dht.go
+++ b/dht.go
@@ -71,25 +71,11 @@ type IpfsDHT struct {
 
 // NewDHT creates a new DHT object with the given peer as the 'local' host
 func NewDHT(ctx context.Context, h host.Host, dstore ds.Batching) *IpfsDHT {
-	dht := makeDHT(ctx, h, dstore)
-
-	// register for network notifs.
-	dht.host.Network().Notify((*netNotifiee)(dht))
-
-	dht.proc = goprocessctx.WithContextAndTeardown(ctx, func() error {
-		// remove ourselves from network notifs.
-		dht.host.Network().StopNotify((*netNotifiee)(dht))
-		return nil
-	})
-
-	dht.proc.AddChild(dht.providers.Process())
+	dht := NewDHTClient(ctx, h, dstore)
 
 	h.SetStreamHandler(ProtocolDHT, dht.handleNewStream)
 	h.SetStreamHandler(ProtocolDHTOld, dht.handleNewStream)
-
-	dht.Validator["pk"] = record.PublicKeyValidator
-	dht.Selector["pk"] = record.PublicKeySelector
-
+	
 	return dht
 }
 


### PR DESCRIPTION
It looks like `NewDHT` and `NewDHTClient` are doing almost the same thing. They both have the same comment; maybe explaining the difference in the comments would be useful.