### PR TITLE
Improve  GetProviders Performance by around 2x

### DIFF
--- a/providers/providers.go
+++ b/providers/providers.go
@@ -118,7 +118,11 @@ func loadProvSet(dstore ds.Datastore, k *cid.Cid) (*providerSet, error) {
 	}
 
 	out := newProviderSet()
-	for e := range res.Next() {
+	for {
+		e, ok := res.NextSync()
+		if !ok {
+			break
+		}
 		if e.Error != nil {
 			log.Error("got an error: ", e.Error)
 			continue

--- a/providers/providers_test.go
+++ b/providers/providers_test.go
@@ -10,9 +10,11 @@ import (
 
 	cid "github.com/ipfs/go-cid"
 	ds "github.com/ipfs/go-datastore"
-	//lds "github.com/ipfs/go-ds-leveldb"
 	u "github.com/ipfs/go-ipfs-util"
 	peer "github.com/libp2p/go-libp2p-peer"
+	//
+	// used by TestLargeProvidersSet: do not remove
+	// lds "github.com/ipfs/go-ds-leveldb"
 )
 
 func TestProviderManager(t *testing.T) {
@@ -200,12 +202,16 @@ func TestLargeProvidersSet(t *testing.T) {
 		}
 	}
 
-	for _, c := range cids {
-		_ = p.GetProviders(ctx, c)
+	for i := 0; i < 5; i++ {
+		start := time.Now()
+		for _, c := range cids {
+			_ = p.GetProviders(ctx, c)
+		}
+		elapsed := time.Since(start)
+		fmt.Printf("query %f ms\n", elapsed.Seconds()*1000)
 	}
-
 }
-//*/
+*/
 
 func TestUponCacheMissProvidersAreReadFromDatastore(t *testing.T) {
 	old := lruCacheSize


### PR DESCRIPTION
Before this will even compile https://github.com/ipfs/go-datastore/pull/54 needs to go in and deps updated.

To get the performance improvements  https://github.com/ipfs/go-ds-leveldb/pull/1 needs to go in and deps updated.
