### PR TITLE
Fix logging of keys.

### DIFF
--- a/lookup.go
+++ b/lookup.go
@@ -30,7 +30,10 @@ func toPeerInfos(ps []peer.ID) []*pstore.PeerInfo {
 }
 
 func loggableKey(k string) logging.LoggableMap {
-	if cid, err := cid.Cast([]byte(k)); err == nil {
+	cid, err := cid.Cast([]byte(k))
+	if err != nil {
+		log.Errorf("loggableKey could not cast key: %v", err)
+	} else {
 		k = cid.String()
 	}
 	return logging.LoggableMap{

--- a/lookup.go
+++ b/lookup.go
@@ -3,6 +3,7 @@ package dht
 import (
 	"context"
 
+	cid "github.com/ipfs/go-cid"
 	logging "github.com/ipfs/go-log"
 	kb "github.com/libp2p/go-libp2p-kbucket"
 	peer "github.com/libp2p/go-libp2p-peer"
@@ -29,6 +30,9 @@ func toPeerInfos(ps []peer.ID) []*pstore.PeerInfo {
 }
 
 func loggableKey(k string) logging.LoggableMap {
+	if cid, err := cid.Cast([]byte(k)); err == nil {
+		k = cid.String()
+	}
 	return logging.LoggableMap{
 		"key": k,
 	}


### PR DESCRIPTION
Currently keys that get logged are casted from []byte. Which means that log output looks like this.
```
{"event":"getClosestPeersBegin","key":"\u0012 \ufffdᱡ\ufffd`\ufffdF]\ufffd\ufffdᠸCƶ\u0006E\ufffdrb\ufffd\ufffdO\ufffd\ufffdu\ufffd\ufffdj\u000b","system":"dht","time":"2017-07-27T11:12:08.51775836Z"}
```
after fix like this:
```
{"event":"getClosestPeersBegin","key":"QmQyyaB8znrakGydP3ynRsXre96Uw9wc6w6zuP61bbZuNj","system":"dht","time":"2017-07-27T11:16:30.693008112Z"}
```