### PR TITLE
gx: update go-datastore

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-3.0.7: QmWRBYr99v8sjrpbyNWMuGkQekn7b9ELoLSCe8Ny7Nxain
+3.0.8: QmTo76F1MnDZ6uZrdk8ufMpUcstiij8DYkbhy2DwEsfJ1s

--- a/package.json
+++ b/package.json
@@ -48,9 +48,9 @@
     },
     {
       "author": "jbenet",
-      "hash": "QmVSase1JP7cq9QkPT46oNwdp9pT6kBkG3oqS14y3QcZjG",
+      "hash": "QmdHG8MAuARdGHxx4rPQASLcvhz24fzjSQq7AJRAQEorq5",
       "name": "go-datastore",
-      "version": "1.2.2"
+      "version": "1.4.0"
     },
     {
       "author": "hashicorp",
@@ -72,9 +72,9 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "Qmbi2cDAzNb9ofcdmXqhejBzuQwxCKV8xZu3gnWzJDFPQn",
+      "hash": "QmXVJax39Hpq2KHYsJZobhVSyKNNwWp3pXLjmdoqYheDHA",
       "name": "autobatch",
-      "version": "0.2.6"
+      "version": "0.2.7"
     },
     {
       "author": "whyrusleeping",
@@ -178,6 +178,6 @@
   "license": "MIT",
   "name": "go-libp2p-kad-dht",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "3.0.7"
+  "version": "3.0.8"
 }
 


### PR DESCRIPTION
Depends on:

- https://github.com/whyrusleeping/failstore/pull/5
- https://github.com/whyrusleeping/retry-datastore/pull/4
- https://github.com/ipfs/go-ds-flatfs/pull/24
- https://github.com/ipfs/go-ds-measure/pull/11
- https://github.com/ipfs/go-ds-leveldb/pull/8
- https://github.com/whyrusleeping/autobatch/pull/5


This PR with gx updates has been created using gx-workspace: https://github.com/ipfs/gx-workspace