### PR TITLE
Just pass the record object to validation functions

### DIFF
--- a/dht_test.go
+++ b/dht_test.go
@@ -20,7 +20,6 @@ import (
 	peer "github.com/libp2p/go-libp2p-peer"
 	pstore "github.com/libp2p/go-libp2p-peerstore"
 	record "github.com/libp2p/go-libp2p-record"
-	recpb "github.com/libp2p/go-libp2p-record/pb"
 	bhost "github.com/libp2p/go-libp2p/p2p/host/basic"
 	ci "github.com/libp2p/go-testutil/ci"
 	travisci "github.com/libp2p/go-testutil/ci/travis"
@@ -51,7 +50,7 @@ func setupDHT(ctx context.Context, t *testing.T, client bool) *IpfsDHT {
 	}
 
 	d.Validator["v"] = &record.ValidChecker{
-		Func: func(*recpb.Record) error {
+		Func: func(*record.ValidationRecord) error {
 			return nil
 		},
 		Sign: false,
@@ -151,7 +150,7 @@ func TestValueGetSet(t *testing.T) {
 	defer dhtB.host.Close()
 
 	vf := &record.ValidChecker{
-		Func: func(*recpb.Record) error { return nil },
+		Func: func(*record.ValidationRecord) error { return nil },
 		Sign: false,
 	}
 	nulsel := func(_ string, bs [][]byte) (int, error) { return 0, nil }

--- a/dht_test.go
+++ b/dht_test.go
@@ -20,6 +20,7 @@ import (
 	peer "github.com/libp2p/go-libp2p-peer"
 	pstore "github.com/libp2p/go-libp2p-peerstore"
 	record "github.com/libp2p/go-libp2p-record"
+	recpb "github.com/libp2p/go-libp2p-record/pb"
 	bhost "github.com/libp2p/go-libp2p/p2p/host/basic"
 	ci "github.com/libp2p/go-testutil/ci"
 	travisci "github.com/libp2p/go-testutil/ci/travis"
@@ -50,7 +51,7 @@ func setupDHT(ctx context.Context, t *testing.T, client bool) *IpfsDHT {
 	}
 
 	d.Validator["v"] = &record.ValidChecker{
-		Func: func(string, []byte) error {
+		Func: func(*recpb.Record) error {
 			return nil
 		},
 		Sign: false,
@@ -150,7 +151,7 @@ func TestValueGetSet(t *testing.T) {
 	defer dhtB.host.Close()
 
 	vf := &record.ValidChecker{
-		Func: func(string, []byte) error { return nil },
+		Func: func(*recpb.Record) error { return nil },
 		Sign: false,
 	}
 	nulsel := func(_ string, bs [][]byte) (int, error) { return 0, nil }

--- a/package.json
+++ b/package.json
@@ -84,9 +84,9 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmWGtsyPYEoiqTtWLpeUA2jpW4YSZgarKDD2zivYAFz7sR",
+      "hash": "QmajyQvG3Her6XmwoTHSVUyuEAc9v6AEj2GW3dx4Wyxd5K",
       "name": "go-libp2p-record",
-      "version": "2.1.6"
+      "version": "3.0.0"
     },
     {
       "author": "whyrusleeping",


### PR DESCRIPTION
Update go-libp2p-kad-dht to use new validation function format in https://github.com/libp2p/go-libp2p-record/pull/9