### PR TITLE
Set KeysOnly field of query condition to true for Datastore.Query(), then it will query only keys.

### DIFF
--- a/providers/providers.go
+++ b/providers/providers.go
@@ -214,7 +214,7 @@ func (pm *ProviderManager) deleteProvSet(k *cid.Cid) error {
 
 func (pm *ProviderManager) getProvKeys() (func() (*cid.Cid, bool), error) {
 	res, err := pm.dstore.Query(dsq.Query{
-		KeysOnly: false,
+		KeysOnly: true,
 		Prefix:   providersKeyPrefix,
 	})
 	if err != nil {


### PR DESCRIPTION
License: MIT
Signed-off-by: Jason Chang <ridewindx@163.com>