### PR TITLE
Udpate go-peer API to match latest release.

### DIFF
--- a/records.go
+++ b/records.go
@@ -27,7 +27,7 @@ func (dht *IpfsDHT) GetPublicKey(ctx context.Context, p peer.ID) (ci.PubKey, err
 	log.Debugf("getPublicKey for: %s", p)
 
 	// try extracting from identity.
-	pk := p.ExtractPublicKey()
+	pk, _ := p.ExtractPublicKey()
 	if pk != nil {
 		return pk, nil
 	}

--- a/records_test.go
+++ b/records_test.go
@@ -21,7 +21,7 @@ func TestPubkeyExtract(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	pid, err := peer.IDFromEd25519PublicKey(pk)
+	pid, err := peer.IDFromPublicKey(pk)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
The API for ExtractPublicKey changed in
https://github.com/libp2p/go-libp2p-peer/commit/de78f161bd98f29bcbce2aeefbc292fe9083689f