### PR TITLE
update peer-id public key extraction (and more!)

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-4.0.1: QmWY24HyokZFtW5bx36EwJ7rBPiwKmNdWNtWbwfDCgnHtp
+4.0.2: QmT9TxakNKCHg3uBcLnNzBSBhhACvqH8tRzJvYZjUevrvE

--- a/package.json
+++ b/package.json
@@ -166,6 +166,6 @@
   "license": "MIT",
   "name": "go-libp2p-kad-dht",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "4.0.1"
+  "version": "4.0.2"
 }
 

--- a/package.json
+++ b/package.json
@@ -8,21 +8,21 @@
   },
   "gxDependencies": [
     {
-      "hash": "QmRb5jh8z2E8hMGN2tkvs1yHynUanqnZ3UeKwgN1i9P1F8",
+      "hash": "QmTG23dvpBCBjqQwyDxV8CQT6jmS4PSftNr1VqHhE3MLy7",
       "name": "go-log",
-      "version": "1.4.0"
+      "version": "1.4.1"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmaPbCnUMBohSGo3KnxEa2bHqyJVVeEEcwtqJAYxerieBo",
+      "hash": "Qme1knMqwt1hKZbc1BmQFmnm9f36nyQGwXxPGVpVJ9rMK5",
       "name": "go-libp2p-crypto",
-      "version": "1.5.0"
+      "version": "1.6.2"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmZoWKhxUmZ2seW4BzX6fJkNR8hh9PsGModr7q171yq2SS",
+      "hash": "QmcJukH2sAFjY3HdBKq35WDzWoL3UUu2gt9wdfqZTUyM74",
       "name": "go-libp2p-peer",
-      "version": "2.2.3"
+      "version": "2.3.2"
     },
     {
       "hash": "QmSF8fPo3jgVBAy8fpdjjYqgG87dkJgUprRBHRd2tmfgpP",
@@ -33,12 +33,6 @@
       "hash": "QmZ4Qi3GaRbjcx28Sme5eMH7RQjGkt8wHxt2a65oLaeFEV",
       "name": "gogo-protobuf",
       "version": "0.0.0"
-    },
-    {
-      "author": "cheggaaa",
-      "hash": "QmeWjRodbcZFKe5tMN7poEx3izym6osrLSnTLf9UjJZBbs",
-      "name": "pb",
-      "version": "1.0.3"
     },
     {
       "author": "jbenet",
@@ -60,9 +54,9 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmXauCuJzmzapetmC6W4TuDJLL1yFFrVzSHoWv8YdbmnxH",
+      "hash": "QmdeiKhUy1TVGBaKxt7y1QmBDLBdisSrLJ1x58Eoj4PXUh",
       "name": "go-libp2p-peerstore",
-      "version": "1.4.15"
+      "version": "1.4.17"
     },
     {
       "author": "whyrusleeping",
@@ -72,27 +66,27 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmVvkK7s5imCiq3JVbL3pGfnhcCnf3LrFJPF4GE2sAoGZf",
+      "hash": "QmUJzxQQ2kzwQubsMqBTr1NGDpLfh7pGA2E1oaJULcKDPq",
       "name": "go-testutil",
-      "version": "1.1.15"
+      "version": "1.2.1"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmcBSi3Zxa6ytDQxig2iMv4VMfiKKy7v4tibi1Sq6Z5u2x",
+      "hash": "QmZ9V14gpwKsTUG7y5mHZDnHSF4Fa4rKsXNx7jSTEQ4JWs",
       "name": "go-libp2p-record",
-      "version": "4.0.0"
+      "version": "4.0.1"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmTH6VLu3WXfbH3nuLdmscgPWuiPZv3GMJ2YCdzBS5z91T",
+      "hash": "QmVn1WR5woqFfydU7aUpjKeF514oAd1RvvBCcbuUiP8bm7",
       "name": "go-libp2p-kbucket",
-      "version": "2.1.17"
+      "version": "2.1.18"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmTiWLZ6Fo5j4KcTVutZJ5KWRRJrbxzmxA4td8NfEdrPh7",
+      "hash": "QmZix3EdeAdc4wnRksRXWEQ6kbqiFAP16h3Sq9JnEiP71N",
       "name": "go-libp2p-routing",
-      "version": "2.2.21"
+      "version": "2.2.22"
     },
     {
       "author": "whyrusleeping",
@@ -108,27 +102,27 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "Qmf9JgVLz46pxPXwG2eWSJpkqVCcjD4rp7zCRi2KP6GTNB",
+      "hash": "QmPDZJxtWGfcwLPazJxD4h3v3aDs43V7UNAVs3Jz1Wo7o4",
       "name": "go-libp2p-loggables",
-      "version": "1.1.13"
+      "version": "1.1.14"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmNmJZL7FQySMtE2BQuLMuZg2EB2CLEunJJUSVSc9YnnbV",
+      "hash": "QmfZTdmunzKzAGJrSvXXQbQ5kLLUiEMX5vdwux7iXkdk7D",
       "name": "go-libp2p-host",
-      "version": "2.1.5"
+      "version": "2.1.7"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmNh1kGFFdsPu79KNSaL4NUKUPb4Eiz4KHdMtFY6664RDp",
+      "hash": "QmWsV6kzPaYGBDVyuUfWBvyQygEc9Qrv9vzo8vZ7X4mdLN",
       "name": "go-libp2p",
-      "version": "5.0.14"
+      "version": "5.0.17"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmXfkENeeBvh3zYA51MaSdGUdBjhQ99cP5WQe8zgr6wchG",
+      "hash": "QmXoz9o2PT3tEzf7hicegwex5UgVP54n3k82K7jrWFyN86",
       "name": "go-libp2p-net",
-      "version": "2.0.5"
+      "version": "2.0.7"
     },
     {
       "author": "whyrusleeping",
@@ -144,9 +138,9 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmYVR3C8DWPHdHxvLtNFYfjsXgaRAdh6hPMNH3KiwCgu4o",
+      "hash": "Qmb6BsZf6Y3kxffXMNTubGPF1w1bkHtpvhfYbmnwP3NQyw",
       "name": "go-libp2p-netutil",
-      "version": "0.3.9"
+      "version": "0.3.11"
     },
     {
       "author": "multiformats",

--- a/records.go
+++ b/records.go
@@ -26,14 +26,8 @@ type pubkrs struct {
 func (dht *IpfsDHT) GetPublicKey(ctx context.Context, p peer.ID) (ci.PubKey, error) {
 	log.Debugf("getPublicKey for: %s", p)
 
-	// try extracting from identity.
-	pk := p.ExtractPublicKey()
-	if pk != nil {
-		return pk, nil
-	}
-
 	// check locally.
-	pk = dht.peerstore.PubKey(p)
+	pk := dht.peerstore.PubKey(p)
 	if pk != nil {
 		return pk, nil
 	}

--- a/records.go
+++ b/records.go
@@ -26,7 +26,8 @@ type pubkrs struct {
 func (dht *IpfsDHT) GetPublicKey(ctx context.Context, p peer.ID) (ci.PubKey, error) {
 	log.Debugf("getPublicKey for: %s", p)
 
-	// check locally.
+	// Check locally. Will also try to extract the public key from the peer
+	// ID itself if possible (if inlined).
 	pk := dht.peerstore.PubKey(p)
 	if pk != nil {
 		return pk, nil

--- a/records_test.go
+++ b/records_test.go
@@ -16,25 +16,26 @@ import (
 
 // Check that GetPublicKey() correctly extracts a public key
 func TestPubkeyExtract(t *testing.T) {
+	ctx := context.Background()
+	dht := setupDHT(ctx, t, false)
+	defer dht.Close()
+
 	_, pk, err := ci.GenerateEd25519Key(rand.Reader)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	pid, err := peer.IDFromEd25519PublicKey(pk)
+	pid, err := peer.IDFromPublicKey(pk)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// no need to actually construct one
-	d := new(IpfsDHT)
-
-	pk_out, err := d.GetPublicKey(context.Background(), pid)
+	pkOut, err := dht.GetPublicKey(context.Background(), pid)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if !pk_out.Equals(pk) {
+	if !pkOut.Equals(pk) {
 		t.Fatal("got incorrect public key out")
 	}
 }


### PR DESCRIPTION
1. Rely on the peerstore to extract the public key instead of doing so internally (centralize).
2. Update the tests for the changes in go-libp2p-peer.
3. Update a bunch of deps (including go-libp2p-crypto, go-log, etc.)
4. Remove unnecessary progress bar dependency.