### PR TITLE
Configurable DHT Protocols

### DIFF
--- a/dht.go
+++ b/dht.go
@@ -35,6 +35,7 @@ var log = logging.Logger("dht")
 
 var ProtocolDHT protocol.ID = "/ipfs/kad/1.0.0"
 var ProtocolDHTOld protocol.ID = "/ipfs/dht"
+var DefaultProtocols = []protocol.ID{ProtocolDHT, ProtocolDHTOld}
 
 // NumBootstrapQueries defines the number of random dht queries to do to
 // collect members of the routing table.
@@ -83,7 +84,7 @@ func NewDHT(ctx context.Context, h host.Host, dstore ds.Batching, protocols []pr
 
 // NewDefaultDHT delegates to NewDHT, providing IPFS DHT protocols
 func NewDefaultDHT(ctx context.Context, h host.Host, dstore ds.Batching) *IpfsDHT {
-	return NewDHT(ctx, h, dstore, []protocol.ID{ProtocolDHT, ProtocolDHTOld})
+	return NewDHT(ctx, h, dstore, DefaultProtocols)
 }
 
 // NewDHTClient creates a new DHT object with the given peer as the 'local'
@@ -111,7 +112,7 @@ func NewDHTClient(ctx context.Context, h host.Host, dstore ds.Batching, protocol
 
 // NewDefaultDHTClient delegates to NewDHTClient, providing IPFS DHT protocols
 func NewDefaultDHTClient(ctx context.Context, h host.Host, dstore ds.Batching) *IpfsDHT {
-	return NewDHTClient(ctx, h, dstore, []protocol.ID{ProtocolDHT, ProtocolDHTOld})
+	return NewDHTClient(ctx, h, dstore, DefaultProtocols)
 }
 
 func makeDHT(ctx context.Context, h host.Host, dstore ds.Batching, protocols []protocol.ID) *IpfsDHT {

--- a/dht_net.go
+++ b/dht_net.go
@@ -190,7 +190,7 @@ func (ms *messageSender) prep() error {
 		return nil
 	}
 
-	nstr, err := ms.dht.host.NewStream(ms.dht.ctx, ms.p, ProtocolDHT, ProtocolDHTOld)
+	nstr, err := ms.dht.host.NewStream(ms.dht.ctx, ms.p, ms.dht.protocols...)
 	if err != nil {
 		return err
 	}

--- a/dht_test.go
+++ b/dht_test.go
@@ -47,9 +47,9 @@ func setupDHT(ctx context.Context, t *testing.T, client bool) *IpfsDHT {
 	dss := dssync.MutexWrap(ds.NewMapDatastore())
 	var d *IpfsDHT
 	if client {
-		d = NewDHTClient(ctx, h, dss)
+		d = NewDefaultDHTClient(ctx, h, dss)
 	} else {
-		d = NewDHT(ctx, h, dss)
+		d = NewDefaultDHT(ctx, h, dss)
 	}
 
 	d.Validator["v"] = func(*record.ValidationRecord) error { return nil }

--- a/ext_test.go
+++ b/ext_test.go
@@ -32,7 +32,7 @@ func TestGetFailures(t *testing.T) {
 	hosts := mn.Hosts()
 
 	tsds := dssync.MutexWrap(ds.NewMapDatastore())
-	d := NewDHT(ctx, hosts[0], tsds)
+	d := NewDefaultDHT(ctx, hosts[0], tsds)
 	d.Update(ctx, hosts[1].ID())
 
 	// Reply with failures to every message
@@ -149,7 +149,7 @@ func TestNotFound(t *testing.T) {
 	}
 	hosts := mn.Hosts()
 	tsds := dssync.MutexWrap(ds.NewMapDatastore())
-	d := NewDHT(ctx, hosts[0], tsds)
+	d := NewDefaultDHT(ctx, hosts[0], tsds)
 
 	for _, p := range hosts {
 		d.Update(ctx, p.ID())
@@ -226,7 +226,7 @@ func TestLessThanKResponses(t *testing.T) {
 	hosts := mn.Hosts()
 
 	tsds := dssync.MutexWrap(ds.NewMapDatastore())
-	d := NewDHT(ctx, hosts[0], tsds)
+	d := NewDefaultDHT(ctx, hosts[0], tsds)
 
 	for i := 1; i < 5; i++ {
 		d.Update(ctx, hosts[i].ID())
@@ -293,7 +293,7 @@ func TestMultipleQueries(t *testing.T) {
 	}
 	hosts := mn.Hosts()
 	tsds := dssync.MutexWrap(ds.NewMapDatastore())
-	d := NewDHT(ctx, hosts[0], tsds)
+	d := NewDefaultDHT(ctx, hosts[0], tsds)
 
 	d.Update(ctx, hosts[1].ID())
 

--- a/notif.go
+++ b/notif.go
@@ -9,8 +9,6 @@ import (
 // netNotifiee defines methods to be used with the IpfsDHT
 type netNotifiee IpfsDHT
 
-var dhtProtocols = []string{string(ProtocolDHT), string(ProtocolDHTOld)}
-
 func (nn *netNotifiee) DHT() *IpfsDHT {
 	return (*IpfsDHT)(nn)
 }
@@ -24,7 +22,7 @@ func (nn *netNotifiee) Connected(n inet.Network, v inet.Conn) {
 	}
 
 	p := v.RemotePeer()
-	protos, err := dht.peerstore.SupportsProtocols(p, dhtProtocols...)
+	protos, err := dht.peerstore.SupportsProtocols(p, dht.protocolStrs()...)
 	if err == nil && len(protos) != 0 {
 		// We lock here for consistency with the lock in testConnection.
 		// This probably isn't necessary because (dis)connect
@@ -57,7 +55,7 @@ func (nn *netNotifiee) testConnection(v inet.Conn) {
 	}
 	defer s.Close()
 
-	selected, err := mstream.SelectOneOf(dhtProtocols, s)
+	selected, err := mstream.SelectOneOf(dht.protocolStrs(), s)
 	if err != nil {
 		// Doesn't support the protocol
 		return


### PR DESCRIPTION
This changeset makes it possible for the DHT to use non-IPFS protocols.

Note that this is a breaking API change; `NewDHT` has been given a new `protocols` parameter, as has `NewDHTClient`. The preexisting constructors have been renamed to `NewDefaultDHT` and `NewDefaultDHTClient`. If we want to avoid breaking changes, I can use different names for the new constructors (suggestions would be appreciated).