### PR TITLE
Make DHT Protocols Configurable

### DIFF
--- a/dht.go
+++ b/dht.go
@@ -392,8 +392,8 @@ func (dht *IpfsDHT) Close() error {
 
 func (dht *IpfsDHT) protocolStrs() []string {
 	pstrs := make([]string, len(dht.protocols))
-	for _, proto := range dht.protocols {
-		pstrs = append(pstrs, string(proto))
+	for idx, proto := range dht.protocols {
+		pstrs[idx] = string(proto)
 	}
 
 	return pstrs

--- a/dht_net.go
+++ b/dht_net.go
@@ -190,7 +190,7 @@ func (ms *messageSender) prep() error {
 		return nil
 	}
 
-	nstr, err := ms.dht.host.NewStream(ms.dht.ctx, ms.p, ProtocolDHT, ProtocolDHTOld)
+	nstr, err := ms.dht.host.NewStream(ms.dht.ctx, ms.p, ms.dht.protocols...)
 	if err != nil {
 		return err
 	}

--- a/dht_test.go
+++ b/dht_test.go
@@ -13,7 +13,6 @@ import (
 
 	opts "github.com/libp2p/go-libp2p-kad-dht/opts"
 	pb "github.com/libp2p/go-libp2p-kad-dht/pb"
-	"github.com/libp2p/go-libp2p-protocol"
 
 	cid "github.com/ipfs/go-cid"
 	u "github.com/ipfs/go-ipfs-util"
@@ -1082,7 +1081,7 @@ func TestGetSetPluggedProtocol(t *testing.T) {
 	defer cancel()
 
 	os := []opts.Option{
-		opts.Protocols([]protocol.ID{"/esh/dht"}),
+		opts.Protocols("/esh/dht"),
 		opts.Client(false),
 		opts.NamespacedValidator("v", blankValidator{}),
 	}

--- a/ext_test.go
+++ b/ext_test.go
@@ -36,7 +36,7 @@ func TestGetFailures(t *testing.T) {
 	d.Update(ctx, hosts[1].ID())
 
 	// Reply with failures to every message
-	hosts[1].SetStreamHandler(ProtocolDHT, func(s inet.Stream) {
+	hosts[1].SetStreamHandler(d.protocols[0], func(s inet.Stream) {
 		s.Close()
 	})
 
@@ -58,7 +58,7 @@ func TestGetFailures(t *testing.T) {
 	t.Log("Timeout test passed.")
 
 	// Reply with failures to every message
-	hosts[1].SetStreamHandler(ProtocolDHT, func(s inet.Stream) {
+	hosts[1].SetStreamHandler(d.protocols[0], func(s inet.Stream) {
 		defer s.Close()
 
 		pbr := ggio.NewDelimitedReader(s, inet.MessageSizeMax)
@@ -110,7 +110,7 @@ func TestGetFailures(t *testing.T) {
 			Record: rec,
 		}
 
-		s, err := hosts[1].NewStream(context.Background(), hosts[0].ID(), ProtocolDHT)
+		s, err := hosts[1].NewStream(context.Background(), hosts[0].ID(), d.protocols[0])
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -160,7 +160,7 @@ func TestNotFound(t *testing.T) {
 	// Reply with random peers to every message
 	for _, host := range hosts {
 		host := host // shadow loop var
-		host.SetStreamHandler(ProtocolDHT, func(s inet.Stream) {
+		host.SetStreamHandler(d.protocols[0], func(s inet.Stream) {
 			defer s.Close()
 
 			pbr := ggio.NewDelimitedReader(s, inet.MessageSizeMax)
@@ -239,7 +239,7 @@ func TestLessThanKResponses(t *testing.T) {
 	// Reply with random peers to every message
 	for _, host := range hosts {
 		host := host // shadow loop var
-		host.SetStreamHandler(ProtocolDHT, func(s inet.Stream) {
+		host.SetStreamHandler(d.protocols[0], func(s inet.Stream) {
 			defer s.Close()
 
 			pbr := ggio.NewDelimitedReader(s, inet.MessageSizeMax)
@@ -305,7 +305,7 @@ func TestMultipleQueries(t *testing.T) {
 
 	// It would be nice to be able to just get a value and succeed but then
 	// we'd need to deal with selectors and validators...
-	hosts[1].SetStreamHandler(ProtocolDHT, func(s inet.Stream) {
+	hosts[1].SetStreamHandler(d.protocols[0], func(s inet.Stream) {
 		defer s.Close()
 
 		pbr := ggio.NewDelimitedReader(s, inet.MessageSizeMax)

--- a/notif.go
+++ b/notif.go
@@ -9,8 +9,6 @@ import (
 // netNotifiee defines methods to be used with the IpfsDHT
 type netNotifiee IpfsDHT
 
-var dhtProtocols = []string{string(ProtocolDHT), string(ProtocolDHTOld)}
-
 func (nn *netNotifiee) DHT() *IpfsDHT {
 	return (*IpfsDHT)(nn)
 }
@@ -24,7 +22,7 @@ func (nn *netNotifiee) Connected(n inet.Network, v inet.Conn) {
 	}
 
 	p := v.RemotePeer()
-	protos, err := dht.peerstore.SupportsProtocols(p, dhtProtocols...)
+	protos, err := dht.peerstore.SupportsProtocols(p, dht.protocolStrs()...)
 	if err == nil && len(protos) != 0 {
 		// We lock here for consistency with the lock in testConnection.
 		// This probably isn't necessary because (dis)connect
@@ -57,7 +55,7 @@ func (nn *netNotifiee) testConnection(v inet.Conn) {
 	}
 	defer s.Close()
 
-	selected, err := mstream.SelectOneOf(dhtProtocols, s)
+	selected, err := mstream.SelectOneOf(dht.protocolStrs(), s)
 	if err != nil {
 		// Doesn't support the protocol
 		return

--- a/opts/options.go
+++ b/opts/options.go
@@ -5,14 +5,20 @@ import (
 
 	ds "github.com/ipfs/go-datastore"
 	dssync "github.com/ipfs/go-datastore/sync"
+	"github.com/libp2p/go-libp2p-protocol"
 	record "github.com/libp2p/go-libp2p-record"
 )
+
+var ProtocolDHT protocol.ID = "/ipfs/kad/1.0.0"
+var ProtocolDHTOld protocol.ID = "/ipfs/dht"
+var DefaultProtocols = []protocol.ID{ProtocolDHT, ProtocolDHTOld}
 
 // Options is a structure containing all the options that can be used when constructing a DHT.
 type Options struct {
 	Datastore ds.Batching
 	Validator record.Validator
 	Client    bool
+	Protocols []protocol.ID
 }
 
 // Apply applies the given options to this Option
@@ -35,6 +41,7 @@ var Defaults = func(o *Options) error {
 		"pk": record.PublicKeyValidator{},
 	}
 	o.Datastore = dssync.MutexWrap(ds.NewMapDatastore())
+	o.Protocols = DefaultProtocols
 	return nil
 }
 
@@ -82,6 +89,16 @@ func NamespacedValidator(ns string, v record.Validator) Option {
 			return fmt.Errorf("can only add namespaced validators to a NamespacedValidator")
 		}
 		nsval[ns] = v
+		return nil
+	}
+}
+
+// Protocols sets the protocols for the DHT
+//
+// Defaults to dht.DefaultProtocols
+func Protocols(protocols []protocol.ID) Option {
+	return func(o *Options) error {
+		o.Protocols = protocols
 		return nil
 	}
 }

--- a/opts/options.go
+++ b/opts/options.go
@@ -96,7 +96,7 @@ func NamespacedValidator(ns string, v record.Validator) Option {
 // Protocols sets the protocols for the DHT
 //
 // Defaults to dht.DefaultProtocols
-func Protocols(protocols []protocol.ID) Option {
+func Protocols(protocols ...protocol.ID) Option {
 	return func(o *Options) error {
 		o.Protocols = protocols
 		return nil


### PR DESCRIPTION
This changeset makes it possible for the DHT to use non-IPFS protocols.

Comments in #152 motivated creating a branch off of `feat/routing-refactor` instead of `master`.