### PR TITLE
dht query improvements

### DIFF
--- a/lookup.go
+++ b/lookup.go
@@ -98,8 +98,8 @@ func (dht *IpfsDHT) GetClosestPeers(ctx context.Context, key string) (<-chan pee
 			log.Debugf("closestPeers query run error: %s", err)
 		}
 
-		if res != nil && res.finalSet != nil {
-			sorted := kb.SortClosestPeers(res.finalSet.Peers(), kb.ConvertKey(key))
+		if res != nil && res.queriedSet != nil {
+			sorted := kb.SortClosestPeers(res.queriedSet.Peers(), kb.ConvertKey(key))
 			if len(sorted) > KValue {
 				sorted = sorted[:KValue]
 			}

--- a/query.go
+++ b/query.go
@@ -39,7 +39,8 @@ type dhtQueryResult struct {
 	closerPeers   []*pstore.PeerInfo // *
 	success       bool
 
-	finalSet *pset.PeerSet
+	finalSet   *pset.PeerSet
+	queriedSet *pset.PeerSet
 }
 
 // constructs query
@@ -77,6 +78,7 @@ func (q *dhtQuery) Run(ctx context.Context, peers []peer.ID) (*dhtQueryResult, e
 type dhtQueryRunner struct {
 	query          *dhtQuery        // query to run
 	peersSeen      *pset.PeerSet    // all peers queried. prevent querying same peer 2x
+	peersQueried   *pset.PeerSet    // peers successfully connected to and queried
 	peersToQuery   *queue.ChanQueue // peers remaining to be queried
 	peersRemaining todoctr.Counter  // peersToQuery + currently processing
 
@@ -100,6 +102,7 @@ func newQueryRunner(q *dhtQuery) *dhtQueryRunner {
 		peersToQuery:   queue.NewChanQueue(ctx, queue.NewXORDistancePQ(string(q.key))),
 		peersRemaining: todoctr.NewSyncCounter(),
 		peersSeen:      pset.New(),
+		peersQueried:   pset.New(),
 		rateLimit:      make(chan struct{}, q.concurrency),
 		proc:           proc,
 	}
@@ -164,7 +167,8 @@ func (r *dhtQueryRunner) Run(ctx context.Context, peers []peer.ID) (*dhtQueryRes
 	}
 
 	return &dhtQueryResult{
-		finalSet: r.peersSeen,
+		finalSet:   r.peersSeen,
+		queriedSet: r.peersQueried,
 	}, err
 }
 
@@ -273,6 +277,8 @@ func (r *dhtQueryRunner) queryPeer(proc process.Process, p peer.ID) {
 
 	// finally, run the query against this peer
 	res, err := r.query.qfunc(ctx, p)
+
+	r.peersQueried.Add(p)
 
 	if err != nil {
 		log.Debugf("ERROR worker for: %v %v", p, err)

--- a/query.go
+++ b/query.go
@@ -14,6 +14,7 @@ import (
 	todoctr "github.com/ipfs/go-todocounter"
 	process "github.com/jbenet/goprocess"
 	ctxproc "github.com/jbenet/goprocess/context"
+	inet "github.com/libp2p/go-libp2p-net"
 	peer "github.com/libp2p/go-libp2p-peer"
 	pset "github.com/libp2p/go-libp2p-peer/peerset"
 	pstore "github.com/libp2p/go-libp2p-peerstore"
@@ -236,7 +237,9 @@ func (r *dhtQueryRunner) queryPeer(proc process.Process, p peer.ID) {
 
 	// make sure we're connected to the peer.
 	// FIXME abstract away into the network layer
-	if conns := r.query.dht.host.Network().ConnsToPeer(p); len(conns) == 0 {
+	// Note: Failure to connect in this block will cause the function to
+	// short circuit.
+	if r.query.dht.host.Network().Connectedness(p) == inet.NotConnected {
 		log.Debug("not connected. dialing.")
 
 		notif.PublishQueryEvent(r.runCtx, &notif.QueryEvent{


### PR DESCRIPTION
This is a bit of a WIP, but these two changes should be pretty good on their own.

The first is relatively minor, and just uses a more optimal method for checking if we have a connection to a peer.

The second one changes `GetClosestPeers` to only return the peers from its query that it was actually able to connect to. This is *strictly* better than the current code, as currently we return a set of peers that we are either already connected to (and the query knows this) or we have already failed to dial them (and the query knows this). Where the end result is we basically fail to put records to the peers that the query has already failed to connect to. So theres really no point in returning these peers to the caller, as we *just* tried and failed to connect to them.