### PR TITLE
Improve log message in Addresses()

### DIFF
--- a/pb/message.go
+++ b/pb/message.go
@@ -111,7 +111,7 @@ func (m *Message_Peer) Addresses() []ma.Multiaddr {
 	for _, addr := range m.Addrs {
 		maddr, err := ma.NewMultiaddrBytes(addr)
 		if err != nil {
-			log.Warningf("error decoding Multiaddr for peer: %s", m.GetId())
+			log.Warningf("error decoding Multiaddr for peer %s: %s", peer.ID(m.GetId()).Pretty(), err)
 			continue
 		}
 


### PR DESCRIPTION
It'd previously only print binary gibberish, in the worst case it'd spill over into the next line.