### PR TITLE
gx: update go-libp2p-routing

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-4.4.0: QmaXYSwxqJsX3EoGb1ZV2toZ9fXc8hWJPaBW1XAp1h2Tsp
+4.4.1: QmdB3eTAndZ1rqGTtUVwVmxdctb46C1hLfgdsbLHzJRDSr

--- a/package.json
+++ b/package.json
@@ -84,9 +84,9 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmdKS5YtmuSWKuLLgbHG176mS3VX3AKiyVmaaiAfvgcuch",
+      "hash": "QmaM261ArNTmKMybV4LKy68JTZrf5CkCbRGDxsZwYHgqDS",
       "name": "go-libp2p-routing",
-      "version": "2.5.0"
+      "version": "2.6.1"
     },
     {
       "author": "whyrusleeping",
@@ -166,6 +166,6 @@
   "license": "MIT",
   "name": "go-libp2p-kad-dht",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "4.4.0"
+  "version": "4.4.1"
 }
 


### PR DESCRIPTION
This PR with gx updates has been created using gx-workspace: https://github.com/ipfs/gx-workspace