### PR TITLE
Remove outdated package documentation

### DIFF
--- a/dht.go
+++ b/dht.go
@@ -1,5 +1,3 @@
-// Package dht implements a distributed hash table that satisfies the ipfs routing
-// interface. This DHT is modeled after kademlia with S/Kademlia modifications.
 package dht
 
 import (

--- a/dht_bootstrap.go
+++ b/dht_bootstrap.go
@@ -1,5 +1,3 @@
-// Package dht implements a distributed hash table that satisfies the ipfs routing
-// interface. This DHT is modeled after Kademlia with S/Kademlia modifications.
 package dht
 
 import (

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,3 @@
+// Package dht implements a distributed hash table that satisfies the ipfs routing
+// interface. This DHT is modeled after kademlia with S/Kademlia modifications.
+package dht

--- a/query.go
+++ b/query.go
@@ -1,8 +1,3 @@
-// package query implement a query manager to drive concurrent workers
-// to query the DHT. A query is setup with a target key, a queryFunc tasked
-// to communicate with a peer, and a set of initial peers. As the query
-// progress, queryFunc can return closer peers that will be used to navigate
-// closer to the target key in the DHT until an answer is reached.
 package dht
 
 import (


### PR DESCRIPTION
Both dht.go and `dht_bootstrap.go` duplicate the package documentation.
The whole block had been moved to doc.go

Also `query.go` provides documentation for query package but now it
belongs to `dht` package, so it's been removed.

The following image highlights the duplicated and outdated documentation blocks:

![screenshot_4](https://user-images.githubusercontent.com/1288313/48631490-ee8bd680-e9be-11e8-9c21-364ebc1fbbbf.png)
