### PR TITLE
tests: skip key inlining test

### DIFF
--- a/records_test.go
+++ b/records_test.go
@@ -15,6 +15,7 @@ import (
 
 // Check that GetPublicKey() correctly extracts a public key
 func TestPubkeyExtract(t *testing.T) {
+	t.Skip("public key extraction for ed25519 keys has been disabled. See https://github.com/libp2p/specs/issues/111")
 	ctx := context.Background()
 	dht := setupDHT(ctx, t, false)
 	defer dht.Close()


### PR DESCRIPTION
This has temporarily been disabled due to the changes/issues described in:

https://github.com/libp2p/specs/issues/111