### PR TITLE
docs: duplicate pkg documentation

### DIFF
--- a/dht_bootstrap.go
+++ b/dht_bootstrap.go
@@ -1,5 +1,3 @@
-// Package dht implements a distributed hash table that satisfies the ipfs routing
-// interface. This DHT is modeled after Kademlia with S/Kademlia modifications.
 package dht
 
 import (


### PR DESCRIPTION
Also contained in "dht.go" and prints twice in godoc.
https://godoc.org/github.com/libp2p/go-libp2p-kad-dht
![image](https://user-images.githubusercontent.com/13862850/50438271-386bb480-08bb-11e9-8db1-029866fc9160.png)
