### PR TITLE
fix a potential DHT query hang

### DIFF
--- a/query.go
+++ b/query.go
@@ -209,6 +209,8 @@ func (r *dhtQueryRunner) spawnWorkers(proc process.Process) {
 			select {
 			case p, more := <-r.peersToQuery.DeqChan:
 				if !more {
+					// Put this back so we can finish any outstanding queries.
+					r.rateLimit <- struct{}{}
 					return // channel closed.
 				}
 


### PR DESCRIPTION
Without this, one of the workers may hang when trying to re-grab the rate-limit after dialing. I believe this may be what's causing some of our DHT requests to stall (evidence: massive goroutine buildup on the gateways).