### PR TITLE
Rename IpfsDHT to Node

### DIFF
--- a/dht.go
+++ b/dht.go
@@ -37,6 +37,8 @@ var log = logging.Logger("dht")
 // collect members of the routing table.
 const NumBootstrapQueries = 5
 
+type IpfsDHT = Node
+
 // Node is an implementation of Kademlia with S/Kademlia modifications.
 // It is used to implement the base IpfsRouting module.
 type Node struct {

--- a/dht_bootstrap.go
+++ b/dht_bootstrap.go
@@ -45,7 +45,7 @@ var DefaultBootstrapConfig = BootstrapConfig{
 // These parameters are configurable.
 //
 // As opposed to BootstrapWithConfig, Bootstrap satisfies the routing interface
-func (dht *IpfsDHT) Bootstrap(ctx context.Context) error {
+func (dht *Node) Bootstrap(ctx context.Context) error {
 	proc, err := dht.BootstrapWithConfig(DefaultBootstrapConfig)
 	if err != nil {
 		return err
@@ -70,7 +70,7 @@ func (dht *IpfsDHT) Bootstrap(ctx context.Context) error {
 // These parameters are configurable.
 //
 // BootstrapWithConfig returns a process, so the user can stop it.
-func (dht *IpfsDHT) BootstrapWithConfig(cfg BootstrapConfig) (goprocess.Process, error) {
+func (dht *Node) BootstrapWithConfig(cfg BootstrapConfig) (goprocess.Process, error) {
 	if cfg.Queries <= 0 {
 		return nil, fmt.Errorf("invalid number of queries: %d", cfg.Queries)
 	}
@@ -96,7 +96,7 @@ func (dht *IpfsDHT) BootstrapWithConfig(cfg BootstrapConfig) (goprocess.Process,
 // These parameters are configurable.
 //
 // SignalBootstrap returns a process, so the user can stop it.
-func (dht *IpfsDHT) BootstrapOnSignal(cfg BootstrapConfig, signal <-chan time.Time) (goprocess.Process, error) {
+func (dht *Node) BootstrapOnSignal(cfg BootstrapConfig, signal <-chan time.Time) (goprocess.Process, error) {
 	if cfg.Queries <= 0 {
 		return nil, fmt.Errorf("invalid number of queries: %d", cfg.Queries)
 	}
@@ -110,7 +110,7 @@ func (dht *IpfsDHT) BootstrapOnSignal(cfg BootstrapConfig, signal <-chan time.Ti
 	return proc, nil
 }
 
-func (dht *IpfsDHT) bootstrapWorker(cfg BootstrapConfig) func(worker goprocess.Process) {
+func (dht *Node) bootstrapWorker(cfg BootstrapConfig) func(worker goprocess.Process) {
 	return func(worker goprocess.Process) {
 		// it would be useful to be able to send out signals of when we bootstrap, too...
 		// maybe this is a good case for whole module event pub/sub?
@@ -124,7 +124,7 @@ func (dht *IpfsDHT) bootstrapWorker(cfg BootstrapConfig) func(worker goprocess.P
 }
 
 // runBootstrap builds up list of peers by requesting random peer IDs
-func (dht *IpfsDHT) runBootstrap(ctx context.Context, cfg BootstrapConfig) error {
+func (dht *Node) runBootstrap(ctx context.Context, cfg BootstrapConfig) error {
 	bslog := func(msg string) {
 		log.Debugf("DHT %s dhtRunBootstrap %s -- routing table size: %d", dht.self, msg, dht.routingTable.Size())
 	}

--- a/dht_net.go
+++ b/dht_net.go
@@ -44,11 +44,11 @@ func (w *bufferedDelimitedWriter) Flush() error {
 }
 
 // handleNewStream implements the inet.StreamHandler
-func (dht *IpfsDHT) handleNewStream(s inet.Stream) {
+func (dht *Node) handleNewStream(s inet.Stream) {
 	go dht.handleNewMessage(s)
 }
 
-func (dht *IpfsDHT) handleNewMessage(s inet.Stream) {
+func (dht *Node) handleNewMessage(s inet.Stream) {
 	ctx := dht.Context()
 	cr := ctxio.NewReader(ctx, s) // ok to use. we defer close stream in this func
 	cw := ctxio.NewWriter(ctx, s) // ok to use. we defer close stream in this func
@@ -110,7 +110,7 @@ func (dht *IpfsDHT) handleNewMessage(s inet.Stream) {
 
 // sendRequest sends out a request, but also makes sure to
 // measure the RTT for latency measurements.
-func (dht *IpfsDHT) sendRequest(ctx context.Context, p peer.ID, pmes *pb.Message) (*pb.Message, error) {
+func (dht *Node) sendRequest(ctx context.Context, p peer.ID, pmes *pb.Message) (*pb.Message, error) {
 
 	ms, err := dht.messageSenderForPeer(p)
 	if err != nil {
@@ -133,7 +133,7 @@ func (dht *IpfsDHT) sendRequest(ctx context.Context, p peer.ID, pmes *pb.Message
 }
 
 // sendMessage sends out a message
-func (dht *IpfsDHT) sendMessage(ctx context.Context, p peer.ID, pmes *pb.Message) error {
+func (dht *Node) sendMessage(ctx context.Context, p peer.ID, pmes *pb.Message) error {
 	ms, err := dht.messageSenderForPeer(p)
 	if err != nil {
 		return err
@@ -146,7 +146,7 @@ func (dht *IpfsDHT) sendMessage(ctx context.Context, p peer.ID, pmes *pb.Message
 	return nil
 }
 
-func (dht *IpfsDHT) updateFromMessage(ctx context.Context, p peer.ID, mes *pb.Message) error {
+func (dht *Node) updateFromMessage(ctx context.Context, p peer.ID, mes *pb.Message) error {
 	// Make sure that this node is actually a DHT server, not just a client.
 	protos, err := dht.peerstore.SupportsProtocols(p, dht.protocolStrs()...)
 	if err == nil && len(protos) > 0 {
@@ -155,7 +155,7 @@ func (dht *IpfsDHT) updateFromMessage(ctx context.Context, p peer.ID, mes *pb.Me
 	return nil
 }
 
-func (dht *IpfsDHT) messageSenderForPeer(p peer.ID) (*messageSender, error) {
+func (dht *Node) messageSenderForPeer(p peer.ID) (*messageSender, error) {
 	dht.smlk.Lock()
 	ms, ok := dht.strmap[p]
 	if ok {
@@ -193,7 +193,7 @@ type messageSender struct {
 	w   bufferedWriteCloser
 	lk  sync.Mutex
 	p   peer.ID
-	dht *IpfsDHT
+	dht *Node
 
 	invalid   bool
 	singleMes int

--- a/dht_test.go
+++ b/dht_test.go
@@ -71,7 +71,7 @@ func (testValidator) Validate(_ string, b []byte) error {
 	return nil
 }
 
-func setupDHT(ctx context.Context, t *testing.T, client bool) *IpfsDHT {
+func setupDHT(ctx context.Context, t *testing.T, client bool) *Node {
 	d, err := New(
 		ctx,
 		bhost.New(swarmt.GenSwarm(t, ctx, swarmt.OptDisableReuseport)),
@@ -85,9 +85,9 @@ func setupDHT(ctx context.Context, t *testing.T, client bool) *IpfsDHT {
 	return d
 }
 
-func setupDHTS(ctx context.Context, n int, t *testing.T) ([]ma.Multiaddr, []peer.ID, []*IpfsDHT) {
+func setupDHTS(ctx context.Context, n int, t *testing.T) ([]ma.Multiaddr, []peer.ID, []*Node) {
 	addrs := make([]ma.Multiaddr, n)
-	dhts := make([]*IpfsDHT, n)
+	dhts := make([]*Node, n)
 	peers := make([]peer.ID, n)
 
 	sanityAddrsMap := make(map[string]struct{})
@@ -113,7 +113,7 @@ func setupDHTS(ctx context.Context, n int, t *testing.T) ([]ma.Multiaddr, []peer
 	return addrs, peers, dhts
 }
 
-func connectNoSync(t *testing.T, ctx context.Context, a, b *IpfsDHT) {
+func connectNoSync(t *testing.T, ctx context.Context, a, b *Node) {
 	t.Helper()
 
 	idB := b.self
@@ -129,7 +129,7 @@ func connectNoSync(t *testing.T, ctx context.Context, a, b *IpfsDHT) {
 	}
 }
 
-func wait(t *testing.T, ctx context.Context, a, b *IpfsDHT) {
+func wait(t *testing.T, ctx context.Context, a, b *Node) {
 	t.Helper()
 
 	// loop until connection notification has been received.
@@ -143,14 +143,14 @@ func wait(t *testing.T, ctx context.Context, a, b *IpfsDHT) {
 	}
 }
 
-func connect(t *testing.T, ctx context.Context, a, b *IpfsDHT) {
+func connect(t *testing.T, ctx context.Context, a, b *Node) {
 	t.Helper()
 	connectNoSync(t, ctx, a, b)
 	wait(t, ctx, a, b)
 	wait(t, ctx, b, a)
 }
 
-func bootstrap(t *testing.T, ctx context.Context, dhts []*IpfsDHT) {
+func bootstrap(t *testing.T, ctx context.Context, dhts []*Node) {
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -177,7 +177,7 @@ func TestValueGetSet(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	var dhts [5]*IpfsDHT
+	var dhts [5]*Node
 
 	for i := range dhts {
 		dhts[i] = setupDHT(ctx, t, false)
@@ -561,7 +561,7 @@ func TestLocalProvides(t *testing.T) {
 }
 
 // if minPeers or avgPeers is 0, dont test for it.
-func waitForWellFormedTables(t *testing.T, dhts []*IpfsDHT, minPeers, avgPeers int, timeout time.Duration) bool {
+func waitForWellFormedTables(t *testing.T, dhts []*Node, minPeers, avgPeers int, timeout time.Duration) bool {
 	// test "well-formed-ness" (>= minPeers peers in every routing table)
 
 	checkTables := func() bool {
@@ -597,7 +597,7 @@ func waitForWellFormedTables(t *testing.T, dhts []*IpfsDHT, minPeers, avgPeers i
 	}
 }
 
-func printRoutingTables(dhts []*IpfsDHT) {
+func printRoutingTables(dhts []*Node) {
 	// the routing tables should be full now. let's inspect them.
 	fmt.Printf("checking routing table of %d\n", len(dhts))
 	for _, dht := range dhts {
@@ -794,7 +794,7 @@ func TestProvidesMany(t *testing.T) {
 	defer cancel()
 
 	var wg sync.WaitGroup
-	getProvider := func(dht *IpfsDHT, k cid.Cid) {
+	getProvider := func(dht *Node, k cid.Cid) {
 		defer wg.Done()
 
 		expected := providers[k.KeyString()]

--- a/handlers.go
+++ b/handlers.go
@@ -25,7 +25,7 @@ var CloserPeerCount = KValue
 // dhthandler specifies the signature of functions that handle DHT messages.
 type dhtHandler func(context.Context, peer.ID, *pb.Message) (*pb.Message, error)
 
-func (dht *IpfsDHT) handlerForMsgType(t pb.Message_MessageType) dhtHandler {
+func (dht *Node) handlerForMsgType(t pb.Message_MessageType) dhtHandler {
 	switch t {
 	case pb.Message_GET_VALUE:
 		return dht.handleGetValue
@@ -44,7 +44,7 @@ func (dht *IpfsDHT) handlerForMsgType(t pb.Message_MessageType) dhtHandler {
 	}
 }
 
-func (dht *IpfsDHT) handleGetValue(ctx context.Context, p peer.ID, pmes *pb.Message) (_ *pb.Message, err error) {
+func (dht *Node) handleGetValue(ctx context.Context, p peer.ID, pmes *pb.Message) (_ *pb.Message, err error) {
 	ctx = log.Start(ctx, "handleGetValue")
 	log.SetTag(ctx, "peer", p)
 	defer func() { log.FinishWithErr(ctx, err) }()
@@ -86,7 +86,7 @@ func (dht *IpfsDHT) handleGetValue(ctx context.Context, p peer.ID, pmes *pb.Mess
 	return resp, nil
 }
 
-func (dht *IpfsDHT) checkLocalDatastore(k []byte) (*recpb.Record, error) {
+func (dht *Node) checkLocalDatastore(k []byte) (*recpb.Record, error) {
 	log.Debugf("%s handleGetValue looking into ds", dht.self)
 	dskey := convertToDsKey(k)
 	buf, err := dht.datastore.Get(dskey)
@@ -145,7 +145,7 @@ func cleanRecord(rec *recpb.Record) {
 }
 
 // Store a value in this peer local storage
-func (dht *IpfsDHT) handlePutValue(ctx context.Context, p peer.ID, pmes *pb.Message) (_ *pb.Message, err error) {
+func (dht *Node) handlePutValue(ctx context.Context, p peer.ID, pmes *pb.Message) (_ *pb.Message, err error) {
 	ctx = log.Start(ctx, "handlePutValue")
 	log.SetTag(ctx, "peer", p)
 	defer func() { log.FinishWithErr(ctx, err) }()
@@ -206,7 +206,7 @@ func (dht *IpfsDHT) handlePutValue(ctx context.Context, p peer.ID, pmes *pb.Mess
 
 // returns nil, nil when either nothing is found or the value found doesn't properly validate.
 // returns nil, some_error when there's a *datastore* error (i.e., something goes very wrong)
-func (dht *IpfsDHT) getRecordFromDatastore(dskey ds.Key) (*recpb.Record, error) {
+func (dht *Node) getRecordFromDatastore(dskey ds.Key) (*recpb.Record, error) {
 	buf, err := dht.datastore.Get(dskey)
 	if err == ds.ErrNotFound {
 		return nil, nil
@@ -234,12 +234,12 @@ func (dht *IpfsDHT) getRecordFromDatastore(dskey ds.Key) (*recpb.Record, error) 
 	return rec, nil
 }
 
-func (dht *IpfsDHT) handlePing(_ context.Context, p peer.ID, pmes *pb.Message) (*pb.Message, error) {
+func (dht *Node) handlePing(_ context.Context, p peer.ID, pmes *pb.Message) (*pb.Message, error) {
 	log.Debugf("%s Responding to ping from %s!\n", dht.self, p)
 	return pmes, nil
 }
 
-func (dht *IpfsDHT) handleFindPeer(ctx context.Context, p peer.ID, pmes *pb.Message) (_ *pb.Message, _err error) {
+func (dht *Node) handleFindPeer(ctx context.Context, p peer.ID, pmes *pb.Message) (_ *pb.Message, _err error) {
 	ctx = log.Start(ctx, "handleFindPeer")
 	defer func() { log.FinishWithErr(ctx, _err) }()
 	log.SetTag(ctx, "peer", p)
@@ -290,7 +290,7 @@ func (dht *IpfsDHT) handleFindPeer(ctx context.Context, p peer.ID, pmes *pb.Mess
 	return resp, nil
 }
 
-func (dht *IpfsDHT) handleGetProviders(ctx context.Context, p peer.ID, pmes *pb.Message) (_ *pb.Message, _err error) {
+func (dht *Node) handleGetProviders(ctx context.Context, p peer.ID, pmes *pb.Message) (_ *pb.Message, _err error) {
 	ctx = log.Start(ctx, "handleGetProviders")
 	defer func() { log.FinishWithErr(ctx, _err) }()
 	log.SetTag(ctx, "peer", p)
@@ -338,7 +338,7 @@ func (dht *IpfsDHT) handleGetProviders(ctx context.Context, p peer.ID, pmes *pb.
 	return resp, nil
 }
 
-func (dht *IpfsDHT) handleAddProvider(ctx context.Context, p peer.ID, pmes *pb.Message) (_ *pb.Message, _err error) {
+func (dht *Node) handleAddProvider(ctx context.Context, p peer.ID, pmes *pb.Message) (_ *pb.Message, _err error) {
 	ctx = log.Start(ctx, "handleAddProvider")
 	defer func() { log.FinishWithErr(ctx, _err) }()
 	log.SetTag(ctx, "peer", p)

--- a/lookup.go
+++ b/lookup.go
@@ -53,7 +53,7 @@ func loggableKey(k string) logging.LoggableMap {
 
 // Kademlia 'node lookup' operation. Returns a channel of the K closest peers
 // to the given key
-func (dht *IpfsDHT) GetClosestPeers(ctx context.Context, key string) (<-chan peer.ID, error) {
+func (dht *Node) GetClosestPeers(ctx context.Context, key string) (<-chan peer.ID, error) {
 	e := log.EventBegin(ctx, "getClosestPeers", loggableKey(key))
 	tablepeers := dht.routingTable.NearestPeers(kb.ConvertKey(key), AlphaValue)
 	if len(tablepeers) == 0 {

--- a/notif.go
+++ b/notif.go
@@ -7,10 +7,10 @@ import (
 )
 
 // netNotifiee defines methods to be used with the IpfsDHT
-type netNotifiee IpfsDHT
+type netNotifiee Node
 
-func (nn *netNotifiee) DHT() *IpfsDHT {
-	return (*IpfsDHT)(nn)
+func (nn *netNotifiee) DHT() *Node {
+	return (*Node)(nn)
 }
 
 func (nn *netNotifiee) Connected(n inet.Network, v inet.Conn) {

--- a/notify_test.go
+++ b/notify_test.go
@@ -74,7 +74,7 @@ func TestNotifieeFuzz(t *testing.T) {
 	connect(t, ctx, d1, d2)
 }
 
-func checkRoutingTable(a, b *IpfsDHT) bool {
+func checkRoutingTable(a, b *Node) bool {
 	// loop until connection notification has been received.
 	// under high load, this may not happen as immediately as we would like.
 	return a.routingTable.Find(b.self) != "" && b.routingTable.Find(a.self) != ""

--- a/query.go
+++ b/query.go
@@ -21,7 +21,7 @@ import (
 var maxQueryConcurrency = AlphaValue
 
 type dhtQuery struct {
-	dht         *IpfsDHT
+	dht         *Node
 	key         string    // the key we're querying for
 	qfunc       queryFunc // the function to execute per peer
 	concurrency int       // the concurrency parameter
@@ -39,7 +39,7 @@ type dhtQueryResult struct {
 }
 
 // constructs query
-func (dht *IpfsDHT) newQuery(k string, f queryFunc) *dhtQuery {
+func (dht *Node) newQuery(k string, f queryFunc) *dhtQuery {
 	return &dhtQuery{
 		key:         k,
 		dht:         dht,

--- a/records.go
+++ b/records.go
@@ -23,7 +23,7 @@ type pubkrs struct {
 	err  error
 }
 
-func (dht *IpfsDHT) GetPublicKey(ctx context.Context, p peer.ID) (ci.PubKey, error) {
+func (dht *Node) GetPublicKey(ctx context.Context, p peer.ID) (ci.PubKey, error) {
 	log.Debugf("getPublicKey for: %s", p)
 
 	// Check locally. Will also try to extract the public key from the peer
@@ -74,7 +74,7 @@ func (dht *IpfsDHT) GetPublicKey(ctx context.Context, p peer.ID) (ci.PubKey, err
 	return nil, err
 }
 
-func (dht *IpfsDHT) getPublicKeyFromDHT(ctx context.Context, p peer.ID) (ci.PubKey, error) {
+func (dht *Node) getPublicKeyFromDHT(ctx context.Context, p peer.ID) (ci.PubKey, error) {
 	// Only retrieve one value, because the public key is immutable
 	// so there's no need to retrieve multiple versions
 	pkkey := routing.KeyForPublicKey(p)
@@ -95,7 +95,7 @@ func (dht *IpfsDHT) getPublicKeyFromDHT(ctx context.Context, p peer.ID) (ci.PubK
 	return pubk, nil
 }
 
-func (dht *IpfsDHT) getPublicKeyFromNode(ctx context.Context, p peer.ID) (ci.PubKey, error) {
+func (dht *Node) getPublicKeyFromNode(ctx context.Context, p peer.ID) (ci.PubKey, error) {
 	// check locally, just in case...
 	pk := dht.peerstore.PubKey(p)
 	if pk != nil {


### PR DESCRIPTION
Renames `IpfsDHT` to `Node` per https://github.com/libp2p/go-libp2p-kad-dht/pull/191#issuecomment-452921311, and adds an alias for compatibility. It doesn't rename the receivers (which are all `dht`, and probably be `node`), or the constructors (`NewDHT` and friends). Those are easy enough to do subsequently if the PR is accepted. Tested against `go-libp2p-daemon`, which is the main `libp2p` consumer of this package at present.