### PR TITLE
[WIP] DHT query rate limiter improvements

### DIFF
--- a/dht_net.go
+++ b/dht_net.go
@@ -15,7 +15,8 @@ import (
 	peer "github.com/libp2p/go-libp2p-peer"
 )
 
-var dhtReadMessageTimeout = time.Minute
+// If a peer takes more than 5 seconds to respond, we should simply move on.
+var dhtReadMessageTimeout = 10 * time.Second
 var ErrReadTimeout = fmt.Errorf("timed out reading response")
 
 type bufferedWriteCloser interface {


### PR DESCRIPTION
This is a start of an attempt to reduce the dials started by the DHT. However,
we need to do some real profiling with different constants and tweaks. 

TODO:

* [ ] Play with dial timeouts.
* [ ] Play with request timeouts more.
* [ ] Play with request/dial concurrency.
* [ ] Try *aborting* dials to peers when we have better peers to try.

...

cc @raulk

Note: Read this patch by patch.