### PR TITLE
Adaptive queue for staging dials

### DIFF
--- a/dial_queue.go
+++ b/dial_queue.go
@@ -160,7 +160,7 @@ func (dq *dialQueue) Consume() (<-chan peer.ID, error) {
 	select {
 	case dq.waitingCh <- waitingCh{ch, time.Now()}:
 	default:
-		return nil, errors.New("detected more consuming goroutines than declared upfront")
+		panic("detected more consuming goroutines than declared upfront")
 	}
 	return ch, nil
 }

--- a/dial_queue.go
+++ b/dial_queue.go
@@ -1,0 +1,249 @@
+package dht
+
+import (
+	"context"
+	"errors"
+	"math"
+	"sync"
+	"time"
+
+	"github.com/libp2p/go-libp2p-peer"
+	"github.com/libp2p/go-libp2p-peerstore/queue"
+)
+
+var DialQueueMinParallelism = 6
+var DialQueueMaxParallelism = 20
+var DialQueueMaxIdle = 5 * time.Second
+var DialQueueScalingMutePeriod = 1 * time.Second
+
+var ErrContextClosed = errors.New("context closed")
+
+type dialQueue struct {
+	ctx    context.Context
+	dialFn func(context.Context, peer.ID) error
+
+	lk            sync.Mutex
+	nWorkers      int
+	scalingFactor float64
+
+	in  *queue.ChanQueue
+	out *queue.ChanQueue
+
+	waitingCh chan chan<- peer.ID
+	dieCh     chan struct{}
+	growCh    chan struct{}
+	shrinkCh  chan struct{}
+}
+
+// newDialQueue returns an adaptive dial queue that spawns a dynamically sized set of goroutines to preemptively
+// stage dials for later handoff to the DHT protocol for RPC.
+//
+// Why? Dialing is expensive. It's orders of magnitude slower than running an RPC on an already-established
+// connection, as it requires establishing a TCP connection, multistream handshake, crypto handshake, mux handshake,
+// and protocol negotiation.
+//
+// We start with DialQueueMinParallelism number of workers, and scale up and down based on demand and supply of
+// dialled peers.
+//
+// The following events trigger scaling:
+//  - there are no successful dials to return immediately when requested (i.e. consumer stalls) => scale up.
+//  - there are no consumers to hand off a successful dial to when requested (i.e. producer stalls) => scale down.
+//
+// We ought to watch out for dialler throttling (e.g. FD limit exceeded), to avoid adding fuel to the fire. Since
+// we have no deterministic way to detect this, for now we are hard-limiting concurrency by a max factor.
+func newDialQueue(ctx context.Context, target string, in *queue.ChanQueue, dialFn func(context.Context, peer.ID) error, nConsumers int) *dialQueue {
+	sq := &dialQueue{
+		ctx:           ctx,
+		dialFn:        dialFn,
+		nWorkers:      DialQueueMinParallelism,
+		scalingFactor: 1.5,
+
+		in:  in,
+		out: queue.NewChanQueue(ctx, queue.NewXORDistancePQ(target)),
+
+		growCh:    make(chan struct{}, nConsumers),
+		shrinkCh:  make(chan struct{}, 1),
+		waitingCh: make(chan chan<- peer.ID, nConsumers),
+		dieCh:     make(chan struct{}, DialQueueMaxParallelism),
+	}
+	for i := 0; i < DialQueueMinParallelism; i++ {
+		go sq.worker()
+	}
+	go sq.control()
+	return sq
+}
+
+func (dq *dialQueue) control() {
+	var (
+		t              time.Time // for logging purposes
+		p              peer.ID
+		dialled        = dq.out.DeqChan
+		resp           chan<- peer.ID
+		waiting        chan chan<- peer.ID
+		lastScalingEvt = time.Now()
+	)
+	for {
+		// First process any backlog of dial jobs and waiters -- making progress is the priority.
+		// This block is copied below; couldn't find a more concise way of doing this.
+		select {
+		case <-dq.ctx.Done():
+			return
+		case p = <-dialled:
+			t = time.Now()
+			dialled, waiting = nil, dq.waitingCh
+			continue // onto the top.
+		case resp = <-waiting:
+			// got a channel that's waiting for a peer.
+			log.Debugf("delivering dialled peer to DHT; took %dms.", time.Now().Sub(t)/time.Millisecond)
+			resp <- p
+			close(resp)
+			dialled, waiting = dq.out.DeqChan, nil // stop consuming waiting jobs until we've cleared a peer.
+			continue                               // onto the top.
+		default:
+			// there's nothing to process, so proceed onto the main select block.
+		}
+
+		select {
+		case <-dq.ctx.Done():
+			return
+		case p = <-dialled:
+			t = time.Now()
+			dialled, waiting = nil, dq.waitingCh
+		case resp = <-waiting:
+			// got a channel that's waiting for a peer.
+			log.Debugf("delivering dialled peer to DHT; took %dms.", time.Now().Sub(t)/time.Millisecond)
+			resp <- p
+			close(resp)
+			dialled, waiting = dq.out.DeqChan, nil // stop consuming waiting jobs until we've cleared a peer.
+		case <-dq.growCh:
+			if time.Now().Sub(lastScalingEvt) < DialQueueScalingMutePeriod {
+				continue
+			}
+			dq.grow()
+			lastScalingEvt = time.Now()
+		case <-dq.shrinkCh:
+			if time.Now().Sub(lastScalingEvt) < DialQueueScalingMutePeriod {
+				continue
+			}
+			dq.shrink()
+			lastScalingEvt = time.Now()
+		}
+	}
+}
+
+func (dq *dialQueue) Consume() (<-chan peer.ID, error) {
+	ch := make(chan peer.ID, 1)
+
+	// short circuit and return a dialled peer if it's immediately available.
+	select {
+	case <-dq.ctx.Done():
+		return nil, ErrContextClosed
+	case p := <-dq.out.DeqChan:
+		ch <- p
+		close(ch)
+		return ch, nil
+	default:
+	}
+
+	// we have no finished dials to return, trigger a scale up.
+	select {
+	case dq.growCh <- struct{}{}:
+	default:
+	}
+
+	// park the channel until a dialled peer becomes available.
+	select {
+	case dq.waitingCh <- ch:
+	default:
+		return nil, errors.New("detected more consuming goroutines than declared upfront")
+	}
+	return ch, nil
+}
+
+func (dq *dialQueue) grow() {
+	dq.lk.Lock()
+	defer dq.lk.Unlock()
+	if dq.nWorkers == DialQueueMaxParallelism {
+		return
+	}
+	target := int(math.Floor(float64(dq.nWorkers) * dq.scalingFactor))
+	if target > DialQueueMaxParallelism {
+		target = DialQueueMinParallelism
+	}
+	for ; dq.nWorkers < target; dq.nWorkers++ {
+		go dq.worker()
+	}
+}
+
+func (dq *dialQueue) shrink() {
+	dq.lk.Lock()
+	defer dq.lk.Unlock()
+	if dq.nWorkers == DialQueueMinParallelism {
+		return
+	}
+	target := int(math.Floor(float64(dq.nWorkers) / dq.scalingFactor))
+	if target < DialQueueMinParallelism {
+		target = DialQueueMinParallelism
+	}
+	// send as many die signals as workers we have to prune.
+	for ; dq.nWorkers > target; dq.nWorkers-- {
+		select {
+		case dq.dieCh <- struct{}{}:
+		default:
+			log.Debugf("too many die signals queued up.")
+		}
+	}
+}
+
+func (dq *dialQueue) worker() {
+	// This idle timer tracks if the environment is slow. If we're waiting to long to acquire a peer to dial,
+	// it means that the DHT query is progressing slow and we should shrink the worker pool.
+	idleTimer := time.NewTimer(0)
+
+	for {
+		// trap exit signals first.
+		select {
+		case <-dq.ctx.Done():
+			return
+		case <-dq.dieCh:
+			return
+		default:
+		}
+
+		if !idleTimer.Stop() {
+			select {
+			case <-idleTimer.C:
+			default:
+			}
+		}
+		idleTimer.Reset(DialQueueMaxIdle)
+
+		select {
+		case <-dq.dieCh:
+			return
+		case <-dq.ctx.Done():
+			return
+		case <-idleTimer.C:
+			// no new dial requests during our idle period; time to scale down.
+		case p := <-dq.in.DeqChan:
+			if err := dq.dialFn(dq.ctx, p); err != nil {
+				log.Debugf("discarding dialled peer because of error: %v", err)
+				continue
+			}
+			waiting := len(dq.waitingCh)
+			dq.out.EnqChan <- p
+			if waiting > 0 {
+				// we have somebody to deliver this value to, so no need to shrink.
+				continue
+			}
+		}
+
+		// scaling down; control only arrives here if the idle timer fires, or if there are no goroutines
+		// waiting for the value we just produced.
+		select {
+		case dq.shrinkCh <- struct{}{}:
+		default:
+		}
+
+	}
+}

--- a/dial_queue.go
+++ b/dial_queue.go
@@ -10,9 +10,14 @@ import (
 )
 
 var (
-	DialQueueMinParallelism    = 6
-	DialQueueMaxParallelism    = 20
-	DialQueueMaxIdle           = 5 * time.Second
+	// DialQueueMinParallelism is the minimum number of worker dial goroutines that will be alive at any time.
+	DialQueueMinParallelism = 6
+	// DialQueueMaxParallelism is the maximum number of worker dial goroutines that can be alive at any time.
+	DialQueueMaxParallelism = 20
+	// DialQueueMaxIdle is the period that a worker dial goroutine waits before signalling a worker pool downscaling.
+	DialQueueMaxIdle = 5 * time.Second
+	// DialQueueScalingMutePeriod is the amount of time to ignore further worker pool scaling events, after one is
+	// processed. Its role is to reduce jitter.
 	DialQueueScalingMutePeriod = 1 * time.Second
 )
 

--- a/dial_queue.go
+++ b/dial_queue.go
@@ -91,6 +91,13 @@ func (dq *dialQueue) control() {
 		// This block is copied below; couldn't find a more concise way of doing this.
 		select {
 		case <-dq.ctx.Done():
+			// close channels.
+			if resp.ch != nil {
+				close(resp.ch)
+			}
+			for w := range waiting {
+				close(w.ch)
+			}
 			return
 		case p = <-dialled:
 			dialled, waiting = nil, dq.waitingCh

--- a/dial_queue_test.go
+++ b/dial_queue_test.go
@@ -1,0 +1,220 @@
+package dht
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/libp2p/go-libp2p-peer"
+	"github.com/libp2p/go-libp2p-peerstore/queue"
+)
+
+func init() {
+	DialQueueScalingMutePeriod = 0
+	DialQueueMaxIdle = 1 * time.Second
+}
+
+func TestDialQueueErrorsWithTooManyConsumers(t *testing.T) {
+	in := queue.NewChanQueue(context.Background(), queue.NewXORDistancePQ("test"))
+	hang := make(chan struct{})
+	dialFn := func(ctx context.Context, p peer.ID) error {
+		<-hang
+		return nil
+	}
+	dq := newDialQueue(context.Background(), "test", in, dialFn, 3)
+
+	for i := 0; i < 3; i++ {
+		if _, err := dq.Consume(); err != nil {
+			t.Errorf("expected nil err, got: %v", err)
+		}
+	}
+	if _, err := dq.Consume(); err == nil {
+		t.Error("expected err but got nil")
+	}
+}
+
+func TestDialQueueGrowsOnSlowDials(t *testing.T) {
+	in := queue.NewChanQueue(context.Background(), queue.NewXORDistancePQ("test"))
+	hang := make(chan struct{})
+
+	var wg sync.WaitGroup
+	wg.Add(19) // we expect 19 workers
+	dialFn := func(ctx context.Context, p peer.ID) error {
+		wg.Done()
+		<-hang
+		return nil
+	}
+
+	// Enqueue 20 jobs.
+	for i := 0; i < 20; i++ {
+		in.EnqChan <- peer.ID(i)
+	}
+
+	// remove the mute period to grow faster.
+	dq := newDialQueue(context.Background(), "test", in, dialFn, 4)
+
+	for i := 0; i < 4; i++ {
+		_, _ = dq.Consume()
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	doneCh := make(chan struct{})
+
+	// wait in a goroutine in case the test fails and we block.
+	go func() {
+		defer close(doneCh)
+		wg.Wait()
+	}()
+
+	select {
+	case <-doneCh:
+	case <-time.After(2 * time.Second):
+		t.Error("expected 19 concurrent dials, got less")
+	}
+}
+
+func TestDialQueueShrinksWithNoConsumers(t *testing.T) {
+	in := queue.NewChanQueue(context.Background(), queue.NewXORDistancePQ("test"))
+	hang := make(chan struct{})
+
+	var wg sync.WaitGroup
+	wg.Add(13)
+	dialFn := func(ctx context.Context, p peer.ID) error {
+		wg.Done()
+		<-hang
+		return nil
+	}
+
+	dq := newDialQueue(context.Background(), "test", in, dialFn, 3)
+
+	// Enqueue 13 jobs, one per worker we'll grow to.
+	for i := 0; i < 13; i++ {
+		in.EnqChan <- peer.ID(i)
+	}
+
+	// acquire 3 consumers, everytime we acquire a consumer, we will grow the pool because no dial job is completed
+	// and immediately returnable.
+	for i := 0; i < 3; i++ {
+		_, _ = dq.Consume()
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	waitForWg(t, &wg, 2*time.Second)
+
+	// Release a few dialFn, but not all of them because downscaling happens when workers detect there are no
+	// consumers to consume their values. So the other three will be these witnesses.
+	for i := 0; i < 10; i++ {
+		hang <- struct{}{}
+	}
+
+	// allow enough time for signalling and dispatching values to outstanding consumers.
+	time.Sleep(500 * time.Millisecond)
+
+	// unblock the other three.
+	hang <- struct{}{}
+	hang <- struct{}{}
+	hang <- struct{}{}
+
+	// we should now only have 6 workers, because all the shrink events will have been honoured.
+	wg.Add(6)
+
+	// enqueue more jobs
+	for i := 0; i < 20; i++ {
+		in.EnqChan <- peer.ID(i)
+	}
+
+	// let's check we have 6 workers hanging.
+	waitForWg(t, &wg, 2*time.Second)
+}
+
+// Inactivity = workers are idle because the DHT query is progressing slow and is producing too few peers to dial.
+func TestDialQueueShrinksWithInactivity(t *testing.T) {
+	in := queue.NewChanQueue(context.Background(), queue.NewXORDistancePQ("test"))
+	hang := make(chan struct{})
+
+	var wg sync.WaitGroup
+	wg.Add(13)
+	dialFn := func(ctx context.Context, p peer.ID) error {
+		wg.Done()
+		<-hang
+		return nil
+	}
+
+	// Enqueue 13 jobs.
+	for i := 0; i < 13; i++ {
+		in.EnqChan <- peer.ID(i)
+	}
+
+	dq := newDialQueue(context.Background(), "test", in, dialFn, 3)
+
+	// keep up to speed with backlog by releasing the dial function every time we acquire a channel.
+	for i := 0; i < 13; i++ {
+		ch, _ := dq.Consume()
+		hang <- struct{}{}
+		<-ch
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	// wait for MaxIdlePeriod.
+	time.Sleep(1500 * time.Millisecond)
+
+	// we should now only have 6 workers, because all the shrink events will have been honoured.
+	wg.Add(6)
+
+	// enqueue more jobs
+	for i := 0; i < 10; i++ {
+		in.EnqChan <- peer.ID(i)
+	}
+
+	// let's check we have 6 workers hanging.
+	waitForWg(t, &wg, 2*time.Second)
+}
+
+func TestDialQueueMutePeriodHonored(t *testing.T) {
+	DialQueueScalingMutePeriod = 2 * time.Second
+
+	in := queue.NewChanQueue(context.Background(), queue.NewXORDistancePQ("test"))
+	hang := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(6)
+	dialFn := func(ctx context.Context, p peer.ID) error {
+		wg.Done()
+		<-hang
+		return nil
+	}
+
+	// Enqueue a bunch of jobs.
+	for i := 0; i < 20; i++ {
+		in.EnqChan <- peer.ID(i)
+	}
+
+	dq := newDialQueue(context.Background(), "test", in, dialFn, 3)
+
+	// pick up three consumers.
+	for i := 0; i < 3; i++ {
+		_, _ = dq.Consume()
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	time.Sleep(500 * time.Millisecond)
+
+	// we'll only have 6 workers because the grow signals have been ignored.
+	waitForWg(t, &wg, 2*time.Second)
+}
+
+func waitForWg(t *testing.T, wg *sync.WaitGroup, wait time.Duration) {
+	t.Helper()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		wg.Wait()
+	}()
+
+	select {
+	case <-time.After(wait):
+		t.Error("timeout while waiting for WaitGroup")
+	case <-done:
+	}
+}

--- a/dial_queue_test.go
+++ b/dial_queue_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/libp2p/go-libp2p-peer"
-	"github.com/libp2p/go-libp2p-peerstore/queue"
+	peer "github.com/libp2p/go-libp2p-peer"
+	queue "github.com/libp2p/go-libp2p-peerstore/queue"
 )
 
 func init() {

--- a/query.go
+++ b/query.go
@@ -103,7 +103,7 @@ func newQueryRunner(q *dhtQuery) *dhtQueryRunner {
 		peersToQuery:   peersToQuery,
 		proc:           proc,
 	}
-	r.peersDialed = newDialQueue(ctx, q.key, peersToQuery, r.dialPeer, AlphaValue)
+	r.peersDialed = newDialQueue(ctx, q.key, peersToQuery, r.dialPeer)
 	return r
 }
 

--- a/query.go
+++ b/query.go
@@ -206,9 +206,9 @@ func (r *dhtQueryRunner) spawnWorkers(proc process.Process) {
 		case <-r.rateLimit:
 			ch := r.peersDialed.Consume()
 			select {
-			case p, _ := <-ch:
-				if p == "" {
-					// peer is nil; this signals context cancellation.
+			case p, ok := <-ch:
+				if !ok {
+					// this signals context cancellation.
 					return
 				}
 				// do it as a child func to make sure Run exits


### PR DESCRIPTION
Currently the DHT is performing dials outside of the Alpha concurrency limit. We are dialling all nodes that peers return in `CloserPeers` without limit. As a result, we end up flooding the swarm with dial jobs, which trips over the file descriptor limits, and brings dialling to a halt under some circumstances. Our current approach is also algorithmically incorrect, and leads to suboptimal query patterns.

This patch introduces an adaptive dial queue that spawns a dynamically sized set of goroutines to preemptively stage dials for later handoff to the DHT protocol for RPC. It identifies backpressure on both ends (dial consumers and dial producers), and takes compensating action by adjusting the worker pool.

We start with `DialQueueMinParallelism` number of workers (6), and scale up and down based on demand and supply of dialled peers.

The following events trigger scaling:
- we scale up when we can't immediately return a successful dial to a new consumer.
- we scale down when we've been idle for a while waiting for new dial attempts.
- we scale down when we complete a dial and realise nobody was waiting for it.

Dialler throttling (e.g. FD limit exceeded) is a concern, as we can easily spin up more workers to compensate, and end up adding fuel to the fire. Since we have no deterministic way to detect this for now, we hard-limit concurrency to `DialQueueMaxParallelism` (20).

Testing this patch in a production mirror reduced dial backlog considerably, and showed the adaptiveness in action:

```
Jan 29 00:42:02 localhost ipfs[6248]: 2019-01-29 00:42:02.873850 DEBUG dht dial_queue.go:177: grew dial worker pool: 6 => 9
Jan 29 00:42:03 localhost ipfs[6248]: 2019-01-29 00:42:03.003489 DEBUG dht dial_queue.go:177: grew dial worker pool: 6 => 9
Jan 29 00:42:03 localhost ipfs[6248]: 2019-01-29 00:42:03.083072 DEBUG dht dial_queue.go:177: grew dial worker pool: 9 => 13
Jan 29 00:42:03 localhost ipfs[6248]: 2019-01-29 00:42:03.186067 DEBUG dht dial_queue.go:177: grew dial worker pool: 6 => 9
Jan 29 00:42:03 localhost ipfs[6248]: 2019-01-29 00:42:03.246148 DEBUG dht dial_queue.go:199: shrunk dial worker pool: 9 => 6
Jan 29 00:42:03 localhost ipfs[6248]: 2019-01-29 00:42:03.246174 DEBUG dht dial_queue.go:177: grew dial worker pool: 13 => 19
Jan 29 00:42:03 localhost ipfs[6248]: 2019-01-29 00:42:03.328308 DEBUG dht dial_queue.go:177: grew dial worker pool: 6 => 9
Jan 29 00:42:03 localhost ipfs[6248]: 2019-01-29 00:42:03.451401 DEBUG dht dial_queue.go:177: grew dial worker pool: 6 => 9
Jan 29 00:42:03 localhost ipfs[6248]: 2019-01-29 00:42:03.462604 DEBUG dht dial_queue.go:177: grew dial worker pool: 9 => 13
Jan 29 00:42:03 localhost ipfs[6248]: 2019-01-29 00:42:03.463808 DEBUG dht dial_queue.go:177: grew dial worker pool: 9 => 13
Jan 29 00:42:03 localhost ipfs[6248]: 2019-01-29 00:42:03.464417 DEBUG dht dial_queue.go:177: grew dial worker pool: 9 => 13
Jan 29 00:42:03 localhost ipfs[6248]: 2019-01-29 00:42:03.465973 DEBUG dht dial_queue.go:177: grew dial worker pool: 9 => 13
Jan 29 00:42:03 localhost ipfs[6248]: 2019-01-29 00:42:03.470865 DEBUG dht dial_queue.go:199: shrunk dial worker pool: 18 => 12
Jan 29 00:42:03 localhost ipfs[6248]: 2019-01-29 00:42:03.697266 DEBUG dht dial_queue.go:177: grew dial worker pool: 6 => 9
Jan 29 00:42:03 localhost ipfs[6248]: 2019-01-29 00:42:03.697847 DEBUG dht dial_queue.go:177: grew dial worker pool: 6 => 9
Jan 29 00:42:03 localhost ipfs[6248]: 2019-01-29 00:42:03.838040 DEBUG dht dial_queue.go:177: grew dial worker pool: 9 => 13
``` 