### PR TITLE
Fix CircleCI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,10 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/golang:1.11
+        environment:
+          GO111MODULE: "on"
+    steps:
+      - checkout
+      - run: go test -v -race -bench . ./...

--- a/notify_test.go
+++ b/notify_test.go
@@ -59,7 +59,7 @@ func TestNotifieeFuzz(t *testing.T) {
 	d1 := setupDHT(ctx, t, false)
 	d2 := setupDHT(ctx, t, false)
 
-	for i := 0; i < 100; i++ {
+	for i := 0; i < 10; i++ {
 		connectNoSync(t, ctx, d1, d2)
 		for _, conn := range d1.host.Network().ConnsToPeer(d2.self) {
 			conn.Close()


### PR DESCRIPTION
Adds the CircleCI config to test go.mod support. Includes benchmark and race detector tests. Can be merged prior to #236, and will supplement it. Reworked from #230, now that go.mod is added in #236 instead.