### PR TITLE
Make dial queue parameters configurable

### DIFF
--- a/dial_queue_test.go
+++ b/dial_queue_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestDialQueueGrowsOnSlowDials(t *testing.T) {
-
 	in := queue.NewChanQueue(context.Background(), queue.NewXORDistancePQ("test"))
 	hang := make(chan struct{})
 
@@ -29,7 +28,19 @@ func TestDialQueueGrowsOnSlowDials(t *testing.T) {
 	}
 
 	// remove the mute period to grow faster.
-	dq := newDialQueue(context.Background(), "test", in, dialFn, 10*time.Minute, 0)
+	config := dqDefaultConfig()
+	config.maxIdle = 10 * time.Minute
+	config.mutePeriod = 0
+	dq, err := newDialQueue(&dqParams{
+		ctx:    context.Background(),
+		target: "test",
+		in:     in,
+		dialFn: dialFn,
+		config: config,
+	})
+	if err != nil {
+		t.Error("unexpected error when constructing the dial queue", err)
+	}
 
 	for i := 0; i < 4; i++ {
 		_ = dq.Consume()
@@ -37,7 +48,7 @@ func TestDialQueueGrowsOnSlowDials(t *testing.T) {
 	}
 
 	for i := 0; i < 20; i++ {
-		if atomic.LoadInt32(&cnt) > int32(DialQueueMinParallelism) {
+		if atomic.LoadInt32(&cnt) > int32(DefaultDialQueueMinParallelism) {
 			return
 		}
 		time.Sleep(100 * time.Millisecond)
@@ -61,7 +72,19 @@ func TestDialQueueShrinksWithNoConsumers(t *testing.T) {
 		return nil
 	}
 
-	dq := newDialQueue(context.Background(), "test", in, dialFn, 10*time.Minute, 0)
+	config := dqDefaultConfig()
+	config.maxIdle = 10 * time.Minute
+	config.mutePeriod = 0
+	dq, err := newDialQueue(&dqParams{
+		ctx:    context.Background(),
+		target: "test",
+		in:     in,
+		dialFn: dialFn,
+		config: config,
+	})
+	if err != nil {
+		t.Error("unexpected error when constructing the dial queue", err)
+	}
 
 	// acquire 3 consumers, everytime we acquire a consumer, we will grow the pool because no dial job is completed
 	// and immediately returnable.
@@ -121,7 +144,19 @@ func TestDialQueueShrinksWithWhenIdle(t *testing.T) {
 		in.EnqChan <- peer.ID(i)
 	}
 
-	dq := newDialQueue(context.Background(), "test", in, dialFn, time.Second, 0)
+	config := dqDefaultConfig()
+	config.maxIdle = 1 * time.Second
+	config.mutePeriod = 0
+	dq, err := newDialQueue(&dqParams{
+		ctx:    context.Background(),
+		target: "test",
+		in:     in,
+		dialFn: dialFn,
+		config: config,
+	})
+	if err != nil {
+		t.Error("unexpected error when constructing the dial queue", err)
+	}
 
 	// keep up to speed with backlog by releasing the dial function every time we acquire a channel.
 	for i := 0; i < 13; i++ {
@@ -162,7 +197,18 @@ func TestDialQueueMutePeriodHonored(t *testing.T) {
 		in.EnqChan <- peer.ID(i)
 	}
 
-	dq := newDialQueue(context.Background(), "test", in, dialFn, DialQueueMaxIdle, 2*time.Second)
+	config := dqDefaultConfig()
+	config.mutePeriod = 2 * time.Second
+	dq, err := newDialQueue(&dqParams{
+		ctx:    context.Background(),
+		target: "test",
+		in:     in,
+		dialFn: dialFn,
+		config: config,
+	})
+	if err != nil {
+		t.Error("unexpected error when constructing the dial queue", err)
+	}
 
 	// pick up three consumers.
 	for i := 0; i < 3; i++ {

--- a/query.go
+++ b/query.go
@@ -103,7 +103,17 @@ func newQueryRunner(q *dhtQuery) *dhtQueryRunner {
 		peersToQuery:   peersToQuery,
 		proc:           proc,
 	}
-	r.peersDialed = newDialQueue(ctx, q.key, peersToQuery, r.dialPeer, DialQueueMaxIdle, DialQueueScalingMutePeriod)
+	dq, err := newDialQueue(&dqParams{
+		ctx:    ctx,
+		target: q.key,
+		in:     peersToQuery,
+		dialFn: r.dialPeer,
+		config: dqDefaultConfig(),
+	})
+	if err != nil {
+		panic(err)
+	}
+	r.peersDialed = dq
 	return r
 }
 


### PR DESCRIPTION
Also wrapped the args to the `newDialQueue()` constructor in a struct, to avoid an obscene arity. Gives us more flexibility in the future. Inspired by the style of [aws-sdk-go](https://godoc.org/github.com/aws/aws-sdk-go).

For now these types and functions remain private.

_Follow-up to https://github.com/libp2p/go-libp2p-kad-dht/issues/239#issuecomment-459250772._