### PR TITLE
Rename log to logger

### DIFF
--- a/dht.go
+++ b/dht.go
@@ -31,7 +31,7 @@ import (
 	base32 "github.com/whyrusleeping/base32"
 )
 
-var log = logging.Logger("dht")
+var logger = logging.Logger("dht")
 
 // NumBootstrapQueries defines the number of random dht queries to do to
 // collect members of the routing table.
@@ -157,12 +157,12 @@ func (dht *IpfsDHT) putValueToPeer(ctx context.Context, p peer.ID, rec *recpb.Re
 	pmes.Record = rec
 	rpmes, err := dht.sendRequest(ctx, p, pmes)
 	if err != nil {
-		log.Debugf("putValueToPeer: %v. (peer: %s, key: %s)", err, p.Pretty(), loggableKey(string(rec.Key)))
+		logger.Debugf("putValueToPeer: %v. (peer: %s, key: %s)", err, p.Pretty(), loggableKey(string(rec.Key)))
 		return err
 	}
 
 	if !bytes.Equal(rpmes.GetRecord().Value, pmes.GetRecord().Value) {
-		log.Warningf("putValueToPeer: value not put correctly. (%v != %v)", pmes, rpmes)
+		logger.Warningf("putValueToPeer: value not put correctly. (%v != %v)", pmes, rpmes)
 		return errors.New("value not put correctly")
 	}
 
@@ -187,12 +187,12 @@ func (dht *IpfsDHT) getValueOrPeers(ctx context.Context, p peer.ID, key string) 
 
 	if record := pmes.GetRecord(); record != nil {
 		// Success! We were given the value
-		log.Debug("getValueOrPeers: got value")
+		logger.Debug("getValueOrPeers: got value")
 
 		// make sure record is valid.
 		err = dht.Validator.Validate(string(record.GetKey()), record.GetValue())
 		if err != nil {
-			log.Info("Received invalid record! (discarded)")
+			logger.Info("Received invalid record! (discarded)")
 			// return a sentinal to signify an invalid record was received
 			err = errInvalidRecord
 			record = new(recpb.Record)
@@ -201,11 +201,11 @@ func (dht *IpfsDHT) getValueOrPeers(ctx context.Context, p peer.ID, key string) 
 	}
 
 	if len(peers) > 0 {
-		log.Debug("getValueOrPeers: peers")
+		logger.Debug("getValueOrPeers: peers")
 		return nil, peers, nil
 	}
 
-	log.Warning("getValueOrPeers: routing.ErrNotFound")
+	logger.Warning("getValueOrPeers: routing.ErrNotFound")
 	return nil, nil, routing.ErrNotFound
 }
 
@@ -216,7 +216,7 @@ func (dht *IpfsDHT) getValueSingle(ctx context.Context, p peer.ID, key string) (
 		"peer": p,
 	}
 
-	eip := log.EventBegin(ctx, "getValueSingle", meta)
+	eip := logger.EventBegin(ctx, "getValueSingle", meta)
 	defer eip.Done()
 
 	pmes := pb.NewMessage(pb.Message_GET_VALUE, []byte(key), 0)
@@ -225,7 +225,7 @@ func (dht *IpfsDHT) getValueSingle(ctx context.Context, p peer.ID, key string) (
 	case nil:
 		return resp, nil
 	case ErrReadTimeout:
-		log.Warningf("getValueSingle: read timeout %s %s", p.Pretty(), key)
+		logger.Warningf("getValueSingle: read timeout %s %s", p.Pretty(), key)
 		fallthrough
 	default:
 		eip.SetError(err)
@@ -235,16 +235,16 @@ func (dht *IpfsDHT) getValueSingle(ctx context.Context, p peer.ID, key string) (
 
 // getLocal attempts to retrieve the value from the datastore
 func (dht *IpfsDHT) getLocal(key string) (*recpb.Record, error) {
-	log.Debugf("getLocal %s", key)
+	logger.Debugf("getLocal %s", key)
 	rec, err := dht.getRecordFromDatastore(mkDsKey(key))
 	if err != nil {
-		log.Warningf("getLocal: %s", err)
+		logger.Warningf("getLocal: %s", err)
 		return nil, err
 	}
 
 	// Double check the key. Can't hurt.
 	if rec != nil && string(rec.GetKey()) != key {
-		log.Errorf("BUG getLocal: found a DHT record that didn't match it's key: %s != %s", rec.GetKey(), key)
+		logger.Errorf("BUG getLocal: found a DHT record that didn't match it's key: %s != %s", rec.GetKey(), key)
 		return nil, nil
 
 	}
@@ -256,7 +256,7 @@ func (dht *IpfsDHT) getLocal(key string) (*recpb.Record, error) {
 func (dht *IpfsDHT) getOwnPrivateKey() (ci.PrivKey, error) {
 	sk := dht.peerstore.PrivKey(dht.self)
 	if sk == nil {
-		log.Warningf("%s dht cannot get own private key!", dht.self)
+		logger.Warningf("%s dht cannot get own private key!", dht.self)
 		return nil, fmt.Errorf("cannot get private key to sign record!")
 	}
 	return sk, nil
@@ -264,10 +264,10 @@ func (dht *IpfsDHT) getOwnPrivateKey() (ci.PrivKey, error) {
 
 // putLocal stores the key value pair in the datastore
 func (dht *IpfsDHT) putLocal(key string, rec *recpb.Record) error {
-	log.Debugf("putLocal: %v %v", key, rec)
+	logger.Debugf("putLocal: %v %v", key, rec)
 	data, err := proto.Marshal(rec)
 	if err != nil {
-		log.Warningf("putLocal: %s", err)
+		logger.Warningf("putLocal: %s", err)
 		return err
 	}
 
@@ -277,7 +277,7 @@ func (dht *IpfsDHT) putLocal(key string, rec *recpb.Record) error {
 // Update signals the routingTable to Update its last-seen status
 // on the given peer.
 func (dht *IpfsDHT) Update(ctx context.Context, p peer.ID) {
-	log.Event(ctx, "updatePeer", p)
+	logger.Event(ctx, "updatePeer", p)
 	dht.routingTable.Update(p)
 }
 
@@ -293,7 +293,7 @@ func (dht *IpfsDHT) FindLocal(id peer.ID) pstore.PeerInfo {
 
 // findPeerSingle asks peer 'p' if they know where the peer with id 'id' is
 func (dht *IpfsDHT) findPeerSingle(ctx context.Context, p peer.ID, id peer.ID) (*pb.Message, error) {
-	eip := log.EventBegin(ctx, "findPeerSingle",
+	eip := logger.EventBegin(ctx, "findPeerSingle",
 		logging.LoggableMap{
 			"peer":   p,
 			"target": id,
@@ -306,7 +306,7 @@ func (dht *IpfsDHT) findPeerSingle(ctx context.Context, p peer.ID, id peer.ID) (
 	case nil:
 		return resp, nil
 	case ErrReadTimeout:
-		log.Warningf("read timeout: %s %s", p.Pretty(), id)
+		logger.Warningf("read timeout: %s %s", p.Pretty(), id)
 		fallthrough
 	default:
 		eip.SetError(err)
@@ -315,7 +315,7 @@ func (dht *IpfsDHT) findPeerSingle(ctx context.Context, p peer.ID, id peer.ID) (
 }
 
 func (dht *IpfsDHT) findProvidersSingle(ctx context.Context, p peer.ID, key cid.Cid) (*pb.Message, error) {
-	eip := log.EventBegin(ctx, "findProvidersSingle", p, key)
+	eip := logger.EventBegin(ctx, "findProvidersSingle", p, key)
 	defer eip.Done()
 
 	pmes := pb.NewMessage(pb.Message_GET_PROVIDERS, key.Bytes(), 0)
@@ -324,7 +324,7 @@ func (dht *IpfsDHT) findProvidersSingle(ctx context.Context, p peer.ID, key cid.
 	case nil:
 		return resp, nil
 	case ErrReadTimeout:
-		log.Warningf("read timeout: %s %s", p.Pretty(), key)
+		logger.Warningf("read timeout: %s %s", p.Pretty(), key)
 		fallthrough
 	default:
 		eip.SetError(err)
@@ -344,7 +344,7 @@ func (dht *IpfsDHT) betterPeersToQuery(pmes *pb.Message, p peer.ID, count int) [
 
 	// no node? nil
 	if closer == nil {
-		log.Warning("betterPeersToQuery: no closer peers to send:", p)
+		logger.Warning("betterPeersToQuery: no closer peers to send:", p)
 		return nil
 	}
 
@@ -353,7 +353,7 @@ func (dht *IpfsDHT) betterPeersToQuery(pmes *pb.Message, p peer.ID, count int) [
 
 		// == to self? thats bad
 		if clp == dht.self {
-			log.Error("BUG betterPeersToQuery: attempted to return self! this shouldn't happen...")
+			logger.Error("BUG betterPeersToQuery: attempted to return self! this shouldn't happen...")
 			return nil
 		}
 		// Dont send a peer back themselves

--- a/dht_bootstrap.go
+++ b/dht_bootstrap.go
@@ -82,7 +82,7 @@ func (dht *IpfsDHT) BootstrapWithConfig(ctx context.Context, cfg BootstrapConfig
 		for {
 			err := dht.runBootstrap(ctx, cfg)
 			if err != nil {
-				log.Warningf("error bootstrapping: %s", err)
+				logger.Warningf("error bootstrapping: %s", err)
 			}
 			select {
 			case <-time.After(cfg.Period):
@@ -128,7 +128,7 @@ func (dht *IpfsDHT) randomWalk(ctx context.Context) error {
 	case nil:
 		// We found a peer from a randomly generated ID. This should be very
 		// unlikely.
-		log.Warningf("random walk toward %s actually found peer: %s", id, p)
+		logger.Warningf("random walk toward %s actually found peer: %s", id, p)
 		return nil
 	default:
 		return err
@@ -138,14 +138,14 @@ func (dht *IpfsDHT) randomWalk(ctx context.Context) error {
 // runBootstrap builds up list of peers by requesting random peer IDs
 func (dht *IpfsDHT) runBootstrap(ctx context.Context, cfg BootstrapConfig) error {
 	bslog := func(msg string) {
-		log.Debugf("DHT %s dhtRunBootstrap %s -- routing table size: %d", dht.self, msg, dht.routingTable.Size())
+		logger.Debugf("DHT %s dhtRunBootstrap %s -- routing table size: %d", dht.self, msg, dht.routingTable.Size())
 	}
 	bslog("start")
 	defer bslog("end")
-	defer log.EventBegin(ctx, "dhtRunBootstrap").Done()
+	defer logger.EventBegin(ctx, "dhtRunBootstrap").Done()
 
 	doQuery := func(n int, target string, f func(context.Context) error) error {
-		log.Debugf("Bootstrapping query (%d/%d) to %s", n, cfg.Queries, target)
+		logger.Debugf("Bootstrapping query (%d/%d) to %s", n, cfg.Queries, target)
 		ctx, cancel := context.WithTimeout(ctx, cfg.Timeout)
 		defer cancel()
 		return f(ctx)

--- a/dht_net.go
+++ b/dht_net.go
@@ -66,7 +66,7 @@ func (dht *IpfsDHT) handleNewMessage(s inet.Stream) {
 		case nil:
 		default:
 			s.Reset()
-			log.Debugf("Error unmarshaling data: %s", err)
+			logger.Debugf("Error unmarshaling data: %s", err)
 			return
 		}
 
@@ -77,7 +77,7 @@ func (dht *IpfsDHT) handleNewMessage(s inet.Stream) {
 		handler := dht.handlerForMsgType(pmes.GetType())
 		if handler == nil {
 			s.Reset()
-			log.Debug("got back nil handler from handlerForMsgType")
+			logger.Debug("got back nil handler from handlerForMsgType")
 			return
 		}
 
@@ -85,13 +85,13 @@ func (dht *IpfsDHT) handleNewMessage(s inet.Stream) {
 		rpmes, err := handler(ctx, mPeer, pmes)
 		if err != nil {
 			s.Reset()
-			log.Debugf("handle message error: %s", err)
+			logger.Debugf("handle message error: %s", err)
 			return
 		}
 
 		// if nil response, return it before serializing
 		if rpmes == nil {
-			log.Debug("got back nil response from request")
+			logger.Debug("got back nil response from request")
 			continue
 		}
 
@@ -102,7 +102,7 @@ func (dht *IpfsDHT) handleNewMessage(s inet.Stream) {
 		}
 		if err != nil {
 			s.Reset()
-			log.Debugf("send response error: %s", err)
+			logger.Debugf("send response error: %s", err)
 			return
 		}
 	}
@@ -128,7 +128,7 @@ func (dht *IpfsDHT) sendRequest(ctx context.Context, p peer.ID, pmes *pb.Message
 	dht.updateFromMessage(ctx, p, rpmes)
 
 	dht.peerstore.RecordLatency(p, time.Since(start))
-	log.Event(ctx, "dhtReceivedMessage", dht.self, p, rpmes)
+	logger.Event(ctx, "dhtReceivedMessage", dht.self, p, rpmes)
 	return rpmes, nil
 }
 
@@ -142,7 +142,7 @@ func (dht *IpfsDHT) sendMessage(ctx context.Context, p peer.ID, pmes *pb.Message
 	if err := ms.SendMessage(ctx, pmes); err != nil {
 		return err
 	}
-	log.Event(ctx, "dhtSentMessage", dht.self, p, pmes)
+	logger.Event(ctx, "dhtSentMessage", dht.self, p, pmes)
 	return nil
 }
 
@@ -259,16 +259,16 @@ func (ms *messageSender) SendMessage(ctx context.Context, pmes *pb.Message) erro
 			ms.s = nil
 
 			if retry {
-				log.Info("error writing message, bailing: ", err)
+				logger.Info("error writing message, bailing: ", err)
 				return err
 			} else {
-				log.Info("error writing message, trying again: ", err)
+				logger.Info("error writing message, trying again: ", err)
 				retry = true
 				continue
 			}
 		}
 
-		log.Event(ctx, "dhtSentMessage", ms.dht.self, ms.p, pmes)
+		logger.Event(ctx, "dhtSentMessage", ms.dht.self, ms.p, pmes)
 
 		if ms.singleMes > streamReuseTries {
 			go inet.FullClose(ms.s)
@@ -295,10 +295,10 @@ func (ms *messageSender) SendRequest(ctx context.Context, pmes *pb.Message) (*pb
 			ms.s = nil
 
 			if retry {
-				log.Info("error writing message, bailing: ", err)
+				logger.Info("error writing message, bailing: ", err)
 				return nil, err
 			} else {
-				log.Info("error writing message, trying again: ", err)
+				logger.Info("error writing message, trying again: ", err)
 				retry = true
 				continue
 			}
@@ -310,16 +310,16 @@ func (ms *messageSender) SendRequest(ctx context.Context, pmes *pb.Message) (*pb
 			ms.s = nil
 
 			if retry {
-				log.Info("error reading message, bailing: ", err)
+				logger.Info("error reading message, bailing: ", err)
 				return nil, err
 			} else {
-				log.Info("error reading message, trying again: ", err)
+				logger.Info("error reading message, trying again: ", err)
 				retry = true
 				continue
 			}
 		}
 
-		log.Event(ctx, "dhtSentMessage", ms.dht.self, ms.p, pmes)
+		logger.Event(ctx, "dhtSentMessage", ms.dht.self, ms.p, pmes)
 
 		if ms.singleMes > streamReuseTries {
 			go inet.FullClose(ms.s)

--- a/dht_test.go
+++ b/dht_test.go
@@ -155,7 +155,7 @@ func bootstrap(t *testing.T, ctx context.Context, dhts []*IpfsDHT) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	log.Debugf("Bootstrapping DHTs...")
+	logger.Debugf("Bootstrapping DHTs...")
 
 	// tried async. sequential fares much better. compare:
 	// 100 async https://gist.github.com/jbenet/56d12f0578d5f34810b2
@@ -492,7 +492,7 @@ func TestProvides(t *testing.T) {
 	connect(t, ctx, dhts[1], dhts[3])
 
 	for _, k := range testCaseCids {
-		log.Debugf("announcing provider for %s", k)
+		logger.Debugf("announcing provider for %s", k)
 		if err := dhts[3].Provide(ctx, k, true); err != nil {
 			t.Fatal(err)
 		}
@@ -505,7 +505,7 @@ func TestProvides(t *testing.T) {
 	for _, c := range testCaseCids {
 		n = (n + 1) % 3
 
-		log.Debugf("getting providers for %s from %d", c, n)
+		logger.Debugf("getting providers for %s from %d", c, n)
 		ctxT, cancel := context.WithTimeout(ctx, time.Second)
 		defer cancel()
 		provchan := dhts[n].FindProvidersAsync(ctxT, c, 1)
@@ -542,7 +542,7 @@ func TestLocalProvides(t *testing.T) {
 	connect(t, ctx, dhts[1], dhts[3])
 
 	for _, k := range testCaseCids {
-		log.Debugf("announcing provider for %s", k)
+		logger.Debugf("announcing provider for %s", k)
 		if err := dhts[3].Provide(ctx, k, false); err != nil {
 			t.Fatal(err)
 		}
@@ -587,7 +587,7 @@ func waitForWellFormedTables(t *testing.T, dhts []*IpfsDHT, minPeers, avgPeers i
 	for {
 		select {
 		case <-timeoutA:
-			log.Debugf("did not reach well-formed routing tables by %s", timeout)
+			logger.Debugf("did not reach well-formed routing tables by %s", timeout)
 			return false // failed
 		case <-time.After(5 * time.Millisecond):
 			if checkTables() {
@@ -721,7 +721,6 @@ func TestPeriodicBootstrap(t *testing.T) {
 
 func TestProvidesMany(t *testing.T) {
 	t.Skip("this test doesn't work")
-	// t.Skip("skipping test to debug another")
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -801,7 +800,7 @@ func TestProvidesMany(t *testing.T) {
 	for _, c := range testCaseCids {
 		// everyone should be able to find it...
 		for _, dht := range dhts {
-			log.Debugf("getting providers for %s at %s", c, dht.self)
+			logger.Debugf("getting providers for %s at %s", c, dht.self)
 			wg.Add(1)
 			go getProvider(dht, c)
 		}
@@ -986,7 +985,7 @@ func TestFindPeersConnectedToPeer(t *testing.T) {
 
 	// testPeerListsMatch(t, shouldFind, found)
 
-	log.Warning("TestFindPeersConnectedToPeer is not quite correct")
+	logger.Warning("TestFindPeersConnectedToPeer is not quite correct")
 	if len(found) == 0 {
 		t.Fatal("didn't find any peers.")
 	}
@@ -1031,7 +1030,7 @@ func TestConnectCollision(t *testing.T) {
 	runTimes := 10
 
 	for rtime := 0; rtime < runTimes; rtime++ {
-		log.Info("Running Time: ", rtime)
+		logger.Info("Running Time: ", rtime)
 
 		ctx, cancel := context.WithCancel(context.Background())
 

--- a/dial_queue.go
+++ b/dial_queue.go
@@ -156,7 +156,7 @@ func (dq *dialQueue) control() {
 				return // we're done if the ChanQueue is closed, which happens when the context is closed.
 			}
 			w := waiting[0]
-			log.Debugf("delivering dialled peer to DHT; took %dms.", time.Since(w.ts)/time.Millisecond)
+			logger.Debugf("delivering dialled peer to DHT; took %dms.", time.Since(w.ts)/time.Millisecond)
 			w.ch <- p
 			close(w.ch)
 			waiting = waiting[1:]
@@ -180,7 +180,7 @@ func (dq *dialQueue) control() {
 				return // we're done if the ChanQueue is closed, which happens when the context is closed.
 			}
 			w := waiting[0]
-			log.Debugf("delivering dialled peer to DHT; took %dms.", time.Since(w.ts)/time.Millisecond)
+			logger.Debugf("delivering dialled peer to DHT; took %dms.", time.Since(w.ts)/time.Millisecond)
 			w.ch <- p
 			close(w.ch)
 			waiting = waiting[1:]
@@ -243,7 +243,7 @@ func (dq *dialQueue) grow() {
 		if prev == dq.nWorkers {
 			return
 		}
-		log.Debugf("grew dial worker pool: %d => %d", prev, dq.nWorkers)
+		logger.Debugf("grew dial worker pool: %d => %d", prev, dq.nWorkers)
 	}(dq.nWorkers)
 
 	if dq.nWorkers == dq.config.maxParallelism {
@@ -265,7 +265,7 @@ func (dq *dialQueue) shrink() {
 		if prev == dq.nWorkers {
 			return
 		}
-		log.Debugf("shrunk dial worker pool: %d => %d", prev, dq.nWorkers)
+		logger.Debugf("shrunk dial worker pool: %d => %d", prev, dq.nWorkers)
 	}(dq.nWorkers)
 
 	if dq.nWorkers == dq.config.minParallelism {
@@ -280,7 +280,7 @@ func (dq *dialQueue) shrink() {
 		select {
 		case dq.dieCh <- struct{}{}:
 		default:
-			log.Debugf("too many die signals queued up.")
+			logger.Debugf("too many die signals queued up.")
 		}
 	}
 }
@@ -316,10 +316,10 @@ func (dq *dialQueue) worker() {
 		case p := <-dq.in.DeqChan:
 			t := time.Now()
 			if err := dq.dialFn(dq.ctx, p); err != nil {
-				log.Debugf("discarding dialled peer because of error: %v", err)
+				logger.Debugf("discarding dialled peer because of error: %v", err)
 				continue
 			}
-			log.Debugf("dialling %v took %dms (as observed by the dht subsystem).", p, time.Since(t)/time.Millisecond)
+			logger.Debugf("dialling %v took %dms (as observed by the dht subsystem).", p, time.Since(t)/time.Millisecond)
 			waiting := len(dq.waitingCh)
 			dq.out.EnqChan <- p
 			if waiting > 0 {

--- a/ext_test.go
+++ b/ext_test.go
@@ -196,7 +196,7 @@ func TestNotFound(t *testing.T) {
 	ctx, cancel := context.WithTimeout(ctx, time.Second*20)
 	defer cancel()
 	v, err := d.GetValue(ctx, "hello")
-	log.Debugf("get value got %v", v)
+	logger.Debugf("get value got %v", v)
 	if err != nil {
 		if merr, ok := err.(u.MultiErr); ok && len(merr) > 0 {
 			err = merr[0]

--- a/handlers.go
+++ b/handlers.go
@@ -45,10 +45,10 @@ func (dht *IpfsDHT) handlerForMsgType(t pb.Message_MessageType) dhtHandler {
 }
 
 func (dht *IpfsDHT) handleGetValue(ctx context.Context, p peer.ID, pmes *pb.Message) (_ *pb.Message, err error) {
-	ctx = log.Start(ctx, "handleGetValue")
-	log.SetTag(ctx, "peer", p)
-	defer func() { log.FinishWithErr(ctx, err) }()
-	log.Debugf("%s handleGetValue for key: %s", dht.self, pmes.GetKey())
+	ctx = logger.Start(ctx, "handleGetValue")
+	logger.SetTag(ctx, "peer", p)
+	defer func() { logger.FinishWithErr(ctx, err) }()
+	logger.Debugf("%s handleGetValue for key: %s", dht.self, pmes.GetKey())
 
 	// setup response
 	resp := pb.NewMessage(pmes.GetType(), pmes.GetKey(), pmes.GetClusterLevel())
@@ -71,9 +71,9 @@ func (dht *IpfsDHT) handleGetValue(ctx context.Context, p peer.ID, pmes *pb.Mess
 	if len(closer) > 0 {
 		closerinfos := pstore.PeerInfos(dht.peerstore, closer)
 		for _, pi := range closerinfos {
-			log.Debugf("handleGetValue returning closer peer: '%s'", pi.ID)
+			logger.Debugf("handleGetValue returning closer peer: '%s'", pi.ID)
 			if len(pi.Addrs) < 1 {
-				log.Warningf(`no addresses on peer being sent!
+				logger.Warningf(`no addresses on peer being sent!
 					[local:%s]
 					[sending:%s]
 					[remote:%s]`, dht.self, pi.ID, p)
@@ -87,10 +87,10 @@ func (dht *IpfsDHT) handleGetValue(ctx context.Context, p peer.ID, pmes *pb.Mess
 }
 
 func (dht *IpfsDHT) checkLocalDatastore(k []byte) (*recpb.Record, error) {
-	log.Debugf("%s handleGetValue looking into ds", dht.self)
+	logger.Debugf("%s handleGetValue looking into ds", dht.self)
 	dskey := convertToDsKey(k)
 	buf, err := dht.datastore.Get(dskey)
-	log.Debugf("%s handleGetValue looking into ds GOT %v", dht.self, buf)
+	logger.Debugf("%s handleGetValue looking into ds GOT %v", dht.self, buf)
 
 	if err == ds.ErrNotFound {
 		return nil, nil
@@ -102,24 +102,24 @@ func (dht *IpfsDHT) checkLocalDatastore(k []byte) (*recpb.Record, error) {
 	}
 
 	// if we have the value, send it back
-	log.Debugf("%s handleGetValue success!", dht.self)
+	logger.Debugf("%s handleGetValue success!", dht.self)
 
 	rec := new(recpb.Record)
 	err = proto.Unmarshal(buf, rec)
 	if err != nil {
-		log.Debug("failed to unmarshal DHT record from datastore")
+		logger.Debug("failed to unmarshal DHT record from datastore")
 		return nil, err
 	}
 
 	var recordIsBad bool
 	recvtime, err := u.ParseRFC3339(rec.GetTimeReceived())
 	if err != nil {
-		log.Info("either no receive time set on record, or it was invalid: ", err)
+		logger.Info("either no receive time set on record, or it was invalid: ", err)
 		recordIsBad = true
 	}
 
 	if time.Now().Sub(recvtime) > MaxRecordAge {
-		log.Debug("old record found, tossing.")
+		logger.Debug("old record found, tossing.")
 		recordIsBad = true
 	}
 
@@ -130,7 +130,7 @@ func (dht *IpfsDHT) checkLocalDatastore(k []byte) (*recpb.Record, error) {
 	if recordIsBad {
 		err := dht.datastore.Delete(dskey)
 		if err != nil {
-			log.Error("Failed to delete bad record from datastore: ", err)
+			logger.Error("Failed to delete bad record from datastore: ", err)
 		}
 
 		return nil, nil // can treat this as not having the record at all
@@ -146,13 +146,13 @@ func cleanRecord(rec *recpb.Record) {
 
 // Store a value in this peer local storage
 func (dht *IpfsDHT) handlePutValue(ctx context.Context, p peer.ID, pmes *pb.Message) (_ *pb.Message, err error) {
-	ctx = log.Start(ctx, "handlePutValue")
-	log.SetTag(ctx, "peer", p)
-	defer func() { log.FinishWithErr(ctx, err) }()
+	ctx = logger.Start(ctx, "handlePutValue")
+	logger.SetTag(ctx, "peer", p)
+	defer func() { logger.FinishWithErr(ctx, err) }()
 
 	rec := pmes.GetRecord()
 	if rec == nil {
-		log.Infof("Got nil record from: %s", p.Pretty())
+		logger.Infof("Got nil record from: %s", p.Pretty())
 		return nil, errors.New("nil record")
 	}
 
@@ -164,7 +164,7 @@ func (dht *IpfsDHT) handlePutValue(ctx context.Context, p peer.ID, pmes *pb.Mess
 
 	// Make sure the record is valid (not expired, valid signature etc)
 	if err = dht.Validator.Validate(string(rec.GetKey()), rec.GetValue()); err != nil {
-		log.Warningf("Bad dht record in PUT from: %s. %s", p.Pretty(), err)
+		logger.Warningf("Bad dht record in PUT from: %s. %s", p.Pretty(), err)
 		return nil, err
 	}
 
@@ -182,11 +182,11 @@ func (dht *IpfsDHT) handlePutValue(ctx context.Context, p peer.ID, pmes *pb.Mess
 		recs := [][]byte{rec.GetValue(), existing.GetValue()}
 		i, err := dht.Validator.Select(string(rec.GetKey()), recs)
 		if err != nil {
-			log.Warningf("Bad dht record in PUT from %s: %s", p.Pretty(), err)
+			logger.Warningf("Bad dht record in PUT from %s: %s", p.Pretty(), err)
 			return nil, err
 		}
 		if i != 0 {
-			log.Infof("DHT record in PUT from %s is older than existing record. Ignoring", p.Pretty())
+			logger.Infof("DHT record in PUT from %s is older than existing record. Ignoring", p.Pretty())
 			return nil, errors.New("old record")
 		}
 	}
@@ -200,7 +200,7 @@ func (dht *IpfsDHT) handlePutValue(ctx context.Context, p peer.ID, pmes *pb.Mess
 	}
 
 	err = dht.datastore.Put(dskey, data)
-	log.Debugf("%s handlePutValue %v", dht.self, dskey)
+	logger.Debugf("%s handlePutValue %v", dht.self, dskey)
 	return pmes, err
 }
 
@@ -212,14 +212,14 @@ func (dht *IpfsDHT) getRecordFromDatastore(dskey ds.Key) (*recpb.Record, error) 
 		return nil, nil
 	}
 	if err != nil {
-		log.Errorf("Got error retrieving record with key %s from datastore: %s", dskey, err)
+		logger.Errorf("Got error retrieving record with key %s from datastore: %s", dskey, err)
 		return nil, err
 	}
 	rec := new(recpb.Record)
 	err = proto.Unmarshal(buf, rec)
 	if err != nil {
 		// Bad data in datastore, log it but don't return an error, we'll just overwrite it
-		log.Errorf("Bad record data stored in datastore with key %s: could not unmarshal record", dskey)
+		logger.Errorf("Bad record data stored in datastore with key %s: could not unmarshal record", dskey)
 		return nil, nil
 	}
 
@@ -227,7 +227,7 @@ func (dht *IpfsDHT) getRecordFromDatastore(dskey ds.Key) (*recpb.Record, error) 
 	if err != nil {
 		// Invalid record in datastore, probably expired but don't return an error,
 		// we'll just overwrite it
-		log.Debugf("Local record verify failed: %s (discarded)", err)
+		logger.Debugf("Local record verify failed: %s (discarded)", err)
 		return nil, nil
 	}
 
@@ -235,14 +235,14 @@ func (dht *IpfsDHT) getRecordFromDatastore(dskey ds.Key) (*recpb.Record, error) 
 }
 
 func (dht *IpfsDHT) handlePing(_ context.Context, p peer.ID, pmes *pb.Message) (*pb.Message, error) {
-	log.Debugf("%s Responding to ping from %s!\n", dht.self, p)
+	logger.Debugf("%s Responding to ping from %s!\n", dht.self, p)
 	return pmes, nil
 }
 
 func (dht *IpfsDHT) handleFindPeer(ctx context.Context, p peer.ID, pmes *pb.Message) (_ *pb.Message, _err error) {
-	ctx = log.Start(ctx, "handleFindPeer")
-	defer func() { log.FinishWithErr(ctx, _err) }()
-	log.SetTag(ctx, "peer", p)
+	ctx = logger.Start(ctx, "handleFindPeer")
+	defer func() { logger.FinishWithErr(ctx, _err) }()
+	logger.SetTag(ctx, "peer", p)
 	resp := pb.NewMessage(pmes.GetType(), nil, pmes.GetClusterLevel())
 	var closest []peer.ID
 
@@ -272,7 +272,7 @@ func (dht *IpfsDHT) handleFindPeer(ctx context.Context, p peer.ID, pmes *pb.Mess
 	}
 
 	if closest == nil {
-		log.Infof("%s handleFindPeer %s: could not find anything.", dht.self, p)
+		logger.Infof("%s handleFindPeer %s: could not find anything.", dht.self, p)
 		return resp, nil
 	}
 
@@ -282,7 +282,7 @@ func (dht *IpfsDHT) handleFindPeer(ctx context.Context, p peer.ID, pmes *pb.Mess
 	for _, pi := range closestinfos {
 		if len(pi.Addrs) > 0 {
 			withAddresses = append(withAddresses, pi)
-			log.Debugf("handleFindPeer: sending back '%s'", pi.ID)
+			logger.Debugf("handleFindPeer: sending back '%s'", pi.ID)
 		}
 	}
 
@@ -291,26 +291,26 @@ func (dht *IpfsDHT) handleFindPeer(ctx context.Context, p peer.ID, pmes *pb.Mess
 }
 
 func (dht *IpfsDHT) handleGetProviders(ctx context.Context, p peer.ID, pmes *pb.Message) (_ *pb.Message, _err error) {
-	ctx = log.Start(ctx, "handleGetProviders")
-	defer func() { log.FinishWithErr(ctx, _err) }()
-	log.SetTag(ctx, "peer", p)
+	ctx = logger.Start(ctx, "handleGetProviders")
+	defer func() { logger.FinishWithErr(ctx, _err) }()
+	logger.SetTag(ctx, "peer", p)
 
 	resp := pb.NewMessage(pmes.GetType(), pmes.GetKey(), pmes.GetClusterLevel())
 	c, err := cid.Cast([]byte(pmes.GetKey()))
 	if err != nil {
 		return nil, err
 	}
-	log.SetTag(ctx, "key", c)
+	logger.SetTag(ctx, "key", c)
 
 	// debug logging niceness.
 	reqDesc := fmt.Sprintf("%s handleGetProviders(%s, %s): ", dht.self, p, c)
-	log.Debugf("%s begin", reqDesc)
-	defer log.Debugf("%s end", reqDesc)
+	logger.Debugf("%s begin", reqDesc)
+	defer logger.Debugf("%s end", reqDesc)
 
 	// check if we have this value, to add ourselves as provider.
 	has, err := dht.datastore.Has(convertToDsKey(c.Bytes()))
 	if err != nil && err != ds.ErrNotFound {
-		log.Debugf("unexpected datastore error: %v\n", err)
+		logger.Debugf("unexpected datastore error: %v\n", err)
 		has = false
 	}
 
@@ -318,13 +318,13 @@ func (dht *IpfsDHT) handleGetProviders(ctx context.Context, p peer.ID, pmes *pb.
 	providers := dht.providers.GetProviders(ctx, c)
 	if has {
 		providers = append(providers, dht.self)
-		log.Debugf("%s have the value. added self as provider", reqDesc)
+		logger.Debugf("%s have the value. added self as provider", reqDesc)
 	}
 
 	if providers != nil && len(providers) > 0 {
 		infos := pstore.PeerInfos(dht.peerstore, providers)
 		resp.ProviderPeers = pb.PeerInfosToPBPeers(dht.host.Network(), infos)
-		log.Debugf("%s have %d providers: %s", reqDesc, len(providers), infos)
+		logger.Debugf("%s have %d providers: %s", reqDesc, len(providers), infos)
 	}
 
 	// Also send closer peers.
@@ -332,24 +332,24 @@ func (dht *IpfsDHT) handleGetProviders(ctx context.Context, p peer.ID, pmes *pb.
 	if closer != nil {
 		infos := pstore.PeerInfos(dht.peerstore, closer)
 		resp.CloserPeers = pb.PeerInfosToPBPeers(dht.host.Network(), infos)
-		log.Debugf("%s have %d closer peers: %s", reqDesc, len(closer), infos)
+		logger.Debugf("%s have %d closer peers: %s", reqDesc, len(closer), infos)
 	}
 
 	return resp, nil
 }
 
 func (dht *IpfsDHT) handleAddProvider(ctx context.Context, p peer.ID, pmes *pb.Message) (_ *pb.Message, _err error) {
-	ctx = log.Start(ctx, "handleAddProvider")
-	defer func() { log.FinishWithErr(ctx, _err) }()
-	log.SetTag(ctx, "peer", p)
+	ctx = logger.Start(ctx, "handleAddProvider")
+	defer func() { logger.FinishWithErr(ctx, _err) }()
+	logger.SetTag(ctx, "peer", p)
 
 	c, err := cid.Cast([]byte(pmes.GetKey()))
 	if err != nil {
 		return nil, err
 	}
-	log.SetTag(ctx, "key", c)
+	logger.SetTag(ctx, "key", c)
 
-	log.Debugf("%s adding %s as a provider for '%s'\n", dht.self, p, c)
+	logger.Debugf("%s adding %s as a provider for '%s'\n", dht.self, p, c)
 
 	// add provider should use the address given in the message
 	pinfos := pb.PBPeersToPeerInfos(pmes.GetProviderPeers())
@@ -357,16 +357,16 @@ func (dht *IpfsDHT) handleAddProvider(ctx context.Context, p peer.ID, pmes *pb.M
 		if pi.ID != p {
 			// we should ignore this provider record! not from originator.
 			// (we should sign them and check signature later...)
-			log.Debugf("handleAddProvider received provider %s from %s. Ignore.", pi.ID, p)
+			logger.Debugf("handleAddProvider received provider %s from %s. Ignore.", pi.ID, p)
 			continue
 		}
 
 		if len(pi.Addrs) < 1 {
-			log.Debugf("%s got no valid addresses for provider %s. Ignore.", dht.self, p)
+			logger.Debugf("%s got no valid addresses for provider %s. Ignore.", dht.self, p)
 			continue
 		}
 
-		log.Infof("received provider %s for %s (addrs: %s)", p, c, pi.Addrs)
+		logger.Infof("received provider %s for %s (addrs: %s)", p, c, pi.Addrs)
 		if pi.ID != dht.self { // don't add own addrs.
 			// add the received addresses to our peerstore.
 			dht.peerstore.AddAddrs(pi.ID, pi.Addrs, pstore.ProviderAddrTTL)

--- a/lookup.go
+++ b/lookup.go
@@ -41,7 +41,7 @@ func tryFormatLoggableKey(k string) (string, error) {
 func loggableKey(k string) logging.LoggableMap {
 	newKey, err := tryFormatLoggableKey(k)
 	if err != nil {
-		log.Debug(err)
+		logger.Debug(err)
 	} else {
 		k = newKey
 	}
@@ -54,7 +54,7 @@ func loggableKey(k string) logging.LoggableMap {
 // Kademlia 'node lookup' operation. Returns a channel of the K closest peers
 // to the given key
 func (dht *IpfsDHT) GetClosestPeers(ctx context.Context, key string) (<-chan peer.ID, error) {
-	e := log.EventBegin(ctx, "getClosestPeers", loggableKey(key))
+	e := logger.EventBegin(ctx, "getClosestPeers", loggableKey(key))
 	tablepeers := dht.routingTable.NearestPeers(kb.ConvertKey(key), AlphaValue)
 	if len(tablepeers) == 0 {
 		return nil, kb.ErrLookupFailure
@@ -74,7 +74,7 @@ func (dht *IpfsDHT) GetClosestPeers(ctx context.Context, key string) (<-chan pee
 
 		pmes, err := dht.findPeerSingle(ctx, p, peer.ID(key))
 		if err != nil {
-			log.Debugf("error getting closer peers: %s", err)
+			logger.Debugf("error getting closer peers: %s", err)
 			return nil, err
 		}
 		peers := pb.PBPeersToPeerInfos(pmes.GetCloserPeers())
@@ -95,7 +95,7 @@ func (dht *IpfsDHT) GetClosestPeers(ctx context.Context, key string) (<-chan pee
 		// run it!
 		res, err := query.Run(ctx, tablepeers)
 		if err != nil {
-			log.Debugf("closestPeers query run error: %s", err)
+			logger.Debugf("closestPeers query run error: %s", err)
 		}
 
 		if res != nil && res.queriedSet != nil {

--- a/records.go
+++ b/records.go
@@ -24,7 +24,7 @@ type pubkrs struct {
 }
 
 func (dht *IpfsDHT) GetPublicKey(ctx context.Context, p peer.ID) (ci.PubKey, error) {
-	log.Debugf("getPublicKey for: %s", p)
+	logger.Debugf("getPublicKey for: %s", p)
 
 	// Check locally. Will also try to extract the public key from the peer
 	// ID itself if possible (if inlined).
@@ -63,7 +63,7 @@ func (dht *IpfsDHT) GetPublicKey(ctx context.Context, p peer.ID) (ci.PubKey, err
 			// Found the public key
 			err := dht.peerstore.AddPubKey(p, r.pubk)
 			if err != nil {
-				log.Warningf("Failed to add public key to peerstore for %v", p)
+				logger.Warningf("Failed to add public key to peerstore for %v", p)
 			}
 			return r.pubk, nil
 		}
@@ -85,13 +85,13 @@ func (dht *IpfsDHT) getPublicKeyFromDHT(ctx context.Context, p peer.ID) (ci.PubK
 
 	pubk, err := ci.UnmarshalPublicKey(val)
 	if err != nil {
-		log.Errorf("Could not unmarshall public key retrieved from DHT for %v", p)
+		logger.Errorf("Could not unmarshall public key retrieved from DHT for %v", p)
 		return nil, err
 	}
 
 	// Note: No need to check that public key hash matches peer ID
 	// because this is done by GetValues()
-	log.Debugf("Got public key for %s from DHT", p)
+	logger.Debugf("Got public key for %s from DHT", p)
 	return pubk, nil
 }
 
@@ -117,20 +117,20 @@ func (dht *IpfsDHT) getPublicKeyFromNode(ctx context.Context, p peer.ID) (ci.Pub
 
 	pubk, err := ci.UnmarshalPublicKey(record.GetValue())
 	if err != nil {
-		log.Errorf("Could not unmarshall public key for %v", p)
+		logger.Errorf("Could not unmarshall public key for %v", p)
 		return nil, err
 	}
 
 	// Make sure the public key matches the peer ID
 	id, err := peer.IDFromPublicKey(pubk)
 	if err != nil {
-		log.Errorf("Could not extract peer id from public key for %v", p)
+		logger.Errorf("Could not extract peer id from public key for %v", p)
 		return nil, err
 	}
 	if id != p {
 		return nil, fmt.Errorf("public key %v does not match peer %v", id, p)
 	}
 
-	log.Debugf("Got public key from node %v itself", p)
+	logger.Debugf("Got public key from node %v itself", p)
 	return pubk, nil
 }

--- a/routing.go
+++ b/routing.go
@@ -36,7 +36,7 @@ var asyncQueryBuffer = 10
 // PutValue adds value corresponding to given Key.
 // This is the top level "Store" operation of the DHT
 func (dht *IpfsDHT) PutValue(ctx context.Context, key string, value []byte, opts ...ropts.Option) (err error) {
-	eip := log.EventBegin(ctx, "PutValue")
+	eip := logger.EventBegin(ctx, "PutValue")
 	defer func() {
 		eip.Append(loggableKey(key))
 		if err != nil {
@@ -44,7 +44,7 @@ func (dht *IpfsDHT) PutValue(ctx context.Context, key string, value []byte, opts
 		}
 		eip.Done()
 	}()
-	log.Debugf("PutValue %s", key)
+	logger.Debugf("PutValue %s", key)
 
 	// don't even allow local users to put bad values.
 	if err := dht.Validator.Validate(key, value); err != nil {
@@ -95,7 +95,7 @@ func (dht *IpfsDHT) PutValue(ctx context.Context, key string, value []byte, opts
 
 			err := dht.putValueToPeer(ctx, p, rec)
 			if err != nil {
-				log.Debugf("failed putting value to peer: %s", err)
+				logger.Debugf("failed putting value to peer: %s", err)
 			}
 		}(p)
 	}
@@ -111,7 +111,7 @@ type RecvdVal struct {
 
 // GetValue searches for the value corresponding to given Key.
 func (dht *IpfsDHT) GetValue(ctx context.Context, key string, opts ...ropts.Option) (_ []byte, err error) {
-	eip := log.EventBegin(ctx, "GetValue")
+	eip := logger.EventBegin(ctx, "GetValue")
 	defer func() {
 		eip.Append(loggableKey(key))
 		if err != nil {
@@ -144,7 +144,7 @@ func (dht *IpfsDHT) GetValue(ctx context.Context, key string, opts ...ropts.Opti
 	if best == nil {
 		return nil, routing.ErrNotFound
 	}
-	log.Debugf("GetValue %v %v", key, best)
+	logger.Debugf("GetValue %v %v", key, best)
 	return best, nil
 }
 
@@ -191,7 +191,7 @@ func (dht *IpfsDHT) SearchValue(ctx context.Context, key string, opts ...ropts.O
 						if v.From == dht.self {
 							err := dht.putLocal(key, fixupRec)
 							if err != nil {
-								log.Error("Error correcting local dht entry:", err)
+								logger.Error("Error correcting local dht entry:", err)
 							}
 							return
 						}
@@ -199,7 +199,7 @@ func (dht *IpfsDHT) SearchValue(ctx context.Context, key string, opts ...ropts.O
 						defer cancel()
 						err := dht.putValueToPeer(ctx, v.From, fixupRec)
 						if err != nil {
-							log.Debug("Error correcting DHT entry: ", err)
+							logger.Debug("Error correcting DHT entry: ", err)
 						}
 					}(v)
 				}
@@ -227,7 +227,7 @@ func (dht *IpfsDHT) SearchValue(ctx context.Context, key string, opts ...ropts.O
 					}
 					sel, err := dht.Validator.Select(key, [][]byte{best.Val, v.Val})
 					if err != nil {
-						log.Warning("Failed to select dht key: ", err)
+						logger.Warning("Failed to select dht key: ", err)
 						continue
 					}
 					if sel != 1 {
@@ -251,7 +251,7 @@ func (dht *IpfsDHT) SearchValue(ctx context.Context, key string, opts ...ropts.O
 
 // GetValues gets nvals values corresponding to the given key.
 func (dht *IpfsDHT) GetValues(ctx context.Context, key string, nvals int) (_ []RecvdVal, err error) {
-	eip := log.EventBegin(ctx, "GetValues")
+	eip := logger.EventBegin(ctx, "GetValues")
 
 	eip.Append(loggableKey(key))
 	defer eip.Done()
@@ -287,7 +287,7 @@ func (dht *IpfsDHT) getValues(ctx context.Context, key string, nvals int) (<-cha
 	if lrec != nil {
 		// TODO: this is tricky, we don't always want to trust our own value
 		// what if the authoritative source updated it?
-		log.Debug("have it locally")
+		logger.Debug("have it locally")
 		vals <- RecvdVal{
 			Val:  lrec.GetValue(),
 			From: dht.self,
@@ -304,9 +304,9 @@ func (dht *IpfsDHT) getValues(ctx context.Context, key string, nvals int) (<-cha
 
 	// get closest peers in the routing table
 	rtp := dht.routingTable.NearestPeers(kb.ConvertKey(key), AlphaValue)
-	log.Debugf("peers in rt: %d %s", len(rtp), rtp)
+	logger.Debugf("peers in rt: %d %s", len(rtp), rtp)
 	if len(rtp) == 0 {
-		log.Warning("No peers from routing table!")
+		logger.Warning("No peers from routing table!")
 		return done(kb.ErrLookupFailure)
 	}
 
@@ -396,7 +396,7 @@ func (dht *IpfsDHT) getValues(ctx context.Context, key string, nvals int) (<-cha
 
 // Provide makes this node announce that it can provide a value for the given key
 func (dht *IpfsDHT) Provide(ctx context.Context, key cid.Cid, brdcst bool) (err error) {
-	eip := log.EventBegin(ctx, "Provide", key, logging.LoggableMap{"broadcast": brdcst})
+	eip := logger.EventBegin(ctx, "Provide", key, logging.LoggableMap{"broadcast": brdcst})
 	defer func() {
 		if err != nil {
 			eip.SetError(err)
@@ -425,10 +425,10 @@ func (dht *IpfsDHT) Provide(ctx context.Context, key cid.Cid, brdcst bool) (err 
 		wg.Add(1)
 		go func(p peer.ID) {
 			defer wg.Done()
-			log.Debugf("putProvider(%s, %s)", key, p)
+			logger.Debugf("putProvider(%s, %s)", key, p)
 			err := dht.sendMessage(ctx, p, mes)
 			if err != nil {
-				log.Debug(err)
+				logger.Debug(err)
 			}
 		}(p)
 	}
@@ -465,14 +465,14 @@ func (dht *IpfsDHT) FindProviders(ctx context.Context, c cid.Cid) ([]pstore.Peer
 // Peers will be returned on the channel as soon as they are found, even before
 // the search query completes.
 func (dht *IpfsDHT) FindProvidersAsync(ctx context.Context, key cid.Cid, count int) <-chan pstore.PeerInfo {
-	log.Event(ctx, "findProviders", key)
+	logger.Event(ctx, "findProviders", key)
 	peerOut := make(chan pstore.PeerInfo, count)
 	go dht.findProvidersAsyncRoutine(ctx, key, count, peerOut)
 	return peerOut
 }
 
 func (dht *IpfsDHT) findProvidersAsyncRoutine(ctx context.Context, key cid.Cid, count int, peerOut chan pstore.PeerInfo) {
-	defer log.EventBegin(ctx, "findProvidersAsync", key).Done()
+	defer logger.EventBegin(ctx, "findProvidersAsync", key).Done()
 	defer close(peerOut)
 
 	ps := pset.NewLimited(count)
@@ -507,27 +507,27 @@ func (dht *IpfsDHT) findProvidersAsyncRoutine(ctx context.Context, key cid.Cid, 
 			return nil, err
 		}
 
-		log.Debugf("%d provider entries", len(pmes.GetProviderPeers()))
+		logger.Debugf("%d provider entries", len(pmes.GetProviderPeers()))
 		provs := pb.PBPeersToPeerInfos(pmes.GetProviderPeers())
-		log.Debugf("%d provider entries decoded", len(provs))
+		logger.Debugf("%d provider entries decoded", len(provs))
 
 		// Add unique providers from request, up to 'count'
 		for _, prov := range provs {
 			if prov.ID != dht.self {
 				dht.peerstore.AddAddrs(prov.ID, prov.Addrs, pstore.TempAddrTTL)
 			}
-			log.Debugf("got provider: %s", prov)
+			logger.Debugf("got provider: %s", prov)
 			if ps.TryAdd(prov.ID) {
-				log.Debugf("using provider: %s", prov)
+				logger.Debugf("using provider: %s", prov)
 				select {
 				case peerOut <- *prov:
 				case <-ctx.Done():
-					log.Debug("context timed out sending more providers")
+					logger.Debug("context timed out sending more providers")
 					return nil, ctx.Err()
 				}
 			}
 			if ps.Size() >= count {
-				log.Debugf("got enough providers (%d/%d)", ps.Size(), count)
+				logger.Debugf("got enough providers (%d/%d)", ps.Size(), count)
 				return &dhtQueryResult{success: true}, nil
 			}
 		}
@@ -535,7 +535,7 @@ func (dht *IpfsDHT) findProvidersAsyncRoutine(ctx context.Context, key cid.Cid, 
 		// Give closer peers back to the query to be queried
 		closer := pmes.GetCloserPeers()
 		clpeers := pb.PBPeersToPeerInfos(closer)
-		log.Debugf("got closer peers: %d %s", len(clpeers), clpeers)
+		logger.Debugf("got closer peers: %d %s", len(clpeers), clpeers)
 
 		notif.PublishQueryEvent(parent, &notif.QueryEvent{
 			Type:      notif.PeerResponse,
@@ -548,13 +548,13 @@ func (dht *IpfsDHT) findProvidersAsyncRoutine(ctx context.Context, key cid.Cid, 
 	peers := dht.routingTable.NearestPeers(kb.ConvertKey(key.KeyString()), AlphaValue)
 	_, err := query.Run(ctx, peers)
 	if err != nil {
-		log.Debugf("Query error: %s", err)
+		logger.Debugf("Query error: %s", err)
 		// Special handling for issue: https://github.com/ipfs/go-ipfs/issues/3032
 		if fmt.Sprint(err) == "<nil>" {
-			log.Error("reproduced bug 3032:")
-			log.Errorf("Errors type information: %#v", err)
-			log.Errorf("go version: %s", runtime.Version())
-			log.Error("please report this information to: https://github.com/ipfs/go-ipfs/issues/3032")
+			logger.Error("reproduced bug 3032:")
+			logger.Errorf("Errors type information: %#v", err)
+			logger.Errorf("go version: %s", runtime.Version())
+			logger.Error("please report this information to: https://github.com/ipfs/go-ipfs/issues/3032")
 
 			// replace problematic error with something that won't crash the daemon
 			err = fmt.Errorf("<nil>")
@@ -568,7 +568,7 @@ func (dht *IpfsDHT) findProvidersAsyncRoutine(ctx context.Context, key cid.Cid, 
 
 // FindPeer searches for a peer with given ID.
 func (dht *IpfsDHT) FindPeer(ctx context.Context, id peer.ID) (_ pstore.PeerInfo, err error) {
-	eip := log.EventBegin(ctx, "FindPeer", id)
+	eip := logger.EventBegin(ctx, "FindPeer", id)
 	defer func() {
 		if err != nil {
 			eip.SetError(err)
@@ -589,7 +589,7 @@ func (dht *IpfsDHT) FindPeer(ctx context.Context, id peer.ID) (_ pstore.PeerInfo
 	// Sanity...
 	for _, p := range peers {
 		if p == id {
-			log.Debug("found target peer in list of closest peers...")
+			logger.Debug("found target peer in list of closest peers...")
 			return dht.peerstore.PeerInfo(p), nil
 		}
 	}
@@ -635,7 +635,7 @@ func (dht *IpfsDHT) FindPeer(ctx context.Context, id peer.ID) (_ pstore.PeerInfo
 		return pstore.PeerInfo{}, err
 	}
 
-	log.Debugf("FindPeer %v %v", id, result.success)
+	logger.Debugf("FindPeer %v %v", id, result.success)
 	if result.peer.ID == "" {
 		return pstore.PeerInfo{}, routing.ErrNotFound
 	}
@@ -700,7 +700,7 @@ func (dht *IpfsDHT) FindPeersConnectedToPeer(ctx context.Context, id peer.ID) (<
 	// this does no error checking
 	go func() {
 		if _, err := query.Run(ctx, peers); err != nil {
-			log.Debug(err)
+			logger.Debug(err)
 		}
 
 		// close the peerchan channel when done.


### PR DESCRIPTION
Rename the IPFS dht logger instance from `log` to anything other than `log`. It makes it very difficult to do quick instrumentations of the code for debugging using the standard library `log` package.