### PR TITLE
Include Travis go mod tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,14 +11,25 @@ env:
 go:
     - 1.11.x
 
-install:
-  - make deps
+install: true
 
-script:
-  - bash <(curl -s https://raw.githubusercontent.com/ipfs/ci-helpers/master/travis-ci/run-standard-tests.sh)
+jobs:
+  include:
+    - stage: "build and test"
+      name: "gx"
+      script:
+        - make deps
+        - bash <(curl -s https://raw.githubusercontent.com/ipfs/ci-helpers/master/travis-ci/run-standard-tests.sh)
+
+    - name: "go mod"
+      script:
+        - export GO111MODULE=on
+        - make mod_deps
+        - bash <(curl -s https://raw.githubusercontent.com/ipfs/ci-helpers/master/travis-ci/run-standard-tests.sh)
 
 cache:
     directories:
+        - $GOPATH/pkg/mod
         - $GOPATH/src/gx
 
 notifications:

--- a/Makefile
+++ b/Makefile
@@ -10,3 +10,6 @@ deps: gx
 
 publish:
 	gx-go rewrite --undo
+
+mod_deps:
+	env GO111MODULE=on go mod download


### PR DESCRIPTION
Include the go mod tests on Travis, they're still relevant even without the major versioning.