### PR TITLE
dial queue: fix possible goroutine leak

### DIFF
--- a/dial_queue.go
+++ b/dial_queue.go
@@ -110,7 +110,7 @@ type waitingCh struct {
 // end up adding fuel to the fire. Since we have no deterministic way to detect this for now, we hard-limit concurrency
 // to config.maxParallelism.
 func newDialQueue(params *dqParams) (*dialQueue, error) {
-	sq := &dialQueue{
+	dq := &dialQueue{
 		dqParams:  params,
 		nWorkers:  params.config.minParallelism,
 		out:       queue.NewChanQueue(params.ctx, queue.NewXORDistancePQ(params.target)),
@@ -121,10 +121,10 @@ func newDialQueue(params *dqParams) (*dialQueue, error) {
 	}
 
 	for i := 0; i < int(params.config.minParallelism); i++ {
-		go sq.worker()
+		go dq.worker()
 	}
-	go sq.control()
-	return sq, nil
+	go dq.control()
+	return dq, nil
 }
 
 func (dq *dialQueue) control() {


### PR DESCRIPTION
On context cancellation, the `ChanQueue` stops its loop but keeps the `EnqChan` channel open. Under the right conditions, this could cause a worker goroutine to leak by blocking forever when sending to `EnqChan`, as nobody would be receiving any longer.

This race is fixed by attaching a separate context to the `ChanQueue` whose cancellation we control. Only after all workers have yielded (fenced by a `WaitGroup`), do we close the `ChanQueue`.

---

EDIT: force pushed a simpler solution as suggested by @Stebalien: https://github.com/libp2p/go-libp2p-kad-dht/pull/262#pullrequestreview-205009617