### PR TITLE
Fix Bootstrap sub-queries

### DIFF
--- a/dht_bootstrap.go
+++ b/dht_bootstrap.go
@@ -146,7 +146,7 @@ func (dht *IpfsDHT) runBootstrap(ctx context.Context, cfg BootstrapConfig) error
 	defer logger.EventBegin(ctx, "dhtRunBootstrap").Done()
 
 	doQuery := func(n int, target string, f func(context.Context) error) error {
-		logger.Debugf("Bootstrapping query (%d/%d) to %s", n, cfg.Queries, target)
+		logger.Infof("Bootstrapping query (%d/%d) to %s", n, cfg.Queries, target)
 		ctx, cancel := context.WithTimeout(ctx, cfg.Timeout)
 		defer cancel()
 		return f(ctx)

--- a/dht_bootstrap.go
+++ b/dht_bootstrap.go
@@ -147,9 +147,13 @@ func (dht *IpfsDHT) runBootstrap(ctx context.Context, cfg BootstrapConfig) error
 
 	doQuery := func(n int, target string, f func(context.Context) error) error {
 		logger.Infof("Bootstrapping query (%d/%d) to %s", n, cfg.Queries, target)
-		ctx, cancel := context.WithTimeout(ctx, cfg.Timeout)
+		queryCtx, cancel := context.WithTimeout(ctx, cfg.Timeout)
 		defer cancel()
-		return f(ctx)
+		err := f(queryCtx)
+		if err == context.DeadlineExceeded && queryCtx.Err() == context.DeadlineExceeded && ctx.Err() == nil {
+			return nil
+		}
+		return err
 	}
 
 	// Do all but one of the bootstrap queries as random walks.

--- a/query.go
+++ b/query.go
@@ -168,7 +168,7 @@ func (r *dhtQueryRunner) Run(ctx context.Context, peers []peer.ID) (*dhtQueryRes
 	case <-r.proc.Closed():
 		r.RLock()
 		defer r.RUnlock()
-		err = context.DeadlineExceeded
+		err = r.runCtx.Err()
 	}
 
 	if r.result != nil && r.result.success {


### PR DESCRIPTION
This fixes bootstrap "sub-queries" when the sub-query timeout is triggered with `DeadlineExceeded`. Currently the sub-query timeout is not handled correctly, and query timeouts are not propagated correctly.