### PR TITLE
Log before and after bootstrap sub-queries

### DIFF
--- a/dht_bootstrap.go
+++ b/dht_bootstrap.go
@@ -138,15 +138,13 @@ func (dht *IpfsDHT) randomWalk(ctx context.Context) error {
 
 // runBootstrap builds up list of peers by requesting random peer IDs
 func (dht *IpfsDHT) runBootstrap(ctx context.Context, cfg BootstrapConfig) error {
-	bslog := func(msg string) {
-		logger.Debugf("DHT %s dhtRunBootstrap %s -- routing table size: %d", dht.self, msg, dht.routingTable.Size())
-	}
-	bslog("start")
-	defer bslog("end")
-	defer logger.EventBegin(ctx, "dhtRunBootstrap").Done()
-
 	doQuery := func(n int, target string, f func(context.Context) error) error {
-		logger.Infof("Bootstrapping query (%d/%d) to %s", n, cfg.Queries, target)
+		logger.Infof("starting bootstrap query (%d/%d) to %s (routing table size was %d)",
+			n, cfg.Queries, target, dht.routingTable.Size())
+		defer func() {
+			logger.Infof("finished bootstrap query (%d/%d) to %s (routing table size is now %d)",
+				n, cfg.Queries, target, dht.routingTable.Size())
+		}()
 		queryCtx, cancel := context.WithTimeout(ctx, cfg.Timeout)
 		defer cancel()
 		err := f(queryCtx)


### PR DESCRIPTION
It's more helpful to know what's going on between the bootstrap sub-queries, I've found myself using this change for testing several PRs. In particular, this helps with testing improvements to the bootstrap default config, and determining the value of random vs. targeted bootstrap subqueries.