### PR TITLE
Add find peer success addrs to peerstore

### DIFF
--- a/query.go
+++ b/query.go
@@ -297,6 +297,9 @@ func (r *dhtQueryRunner) queryPeer(proc process.Process, p peer.ID) {
 		r.Lock()
 		r.result = res
 		r.Unlock()
+		if res.peer != nil {
+			r.query.dht.peerstore.AddAddrs(res.peer.ID, res.peer.Addrs, pstore.TempAddrTTL)
+		}
 		go r.proc.Close() // signal to everyone that we're done.
 		// must be async, as we're one of the children, and Close blocks.
 


### PR DESCRIPTION
When a peer is found, add its addrs to the peerstore, just like the addresses for closer peers are added. In particular this is helpful for followup queries by the DHT user.

I'm not sure about the TTL, and the fact that addresses are deferred to the peerstore at all for the DHT, but it's an improvement nonetheless and came up messing around with the [DHT tool](https://github.com/anacrolix/go-libp2p-dht-tool).