### PR TITLE
Get rid of annoying "bootstrap: not found" warning

### DIFF
--- a/dht_bootstrap.go
+++ b/dht_bootstrap.go
@@ -136,6 +136,15 @@ func (dht *IpfsDHT) randomWalk(ctx context.Context) error {
 	}
 }
 
+// Traverse the DHT toward the self ID
+func (dht *IpfsDHT) selfWalk(ctx context.Context) error {
+	_, err := dht.walk(ctx, dht.self)
+	if err == routing.ErrNotFound {
+		return nil
+	}
+	return err
+}
+
 // runBootstrap builds up list of peers by requesting random peer IDs
 func (dht *IpfsDHT) runBootstrap(ctx context.Context, cfg BootstrapConfig) error {
 	doQuery := func(n int, target string, f func(context.Context) error) error {
@@ -163,10 +172,7 @@ func (dht *IpfsDHT) runBootstrap(ctx context.Context, cfg BootstrapConfig) error
 	}
 
 	// Find self to distribute peer info to our neighbors.
-	return doQuery(cfg.Queries, fmt.Sprintf("self: %s", dht.self), func(ctx context.Context) error {
-		_, err := dht.walk(ctx, dht.self)
-		return err
-	})
+	return doQuery(cfg.Queries, fmt.Sprintf("self: %s", dht.self), dht.selfWalk)
 }
 
 func (dht *IpfsDHT) BootstrapRandom(ctx context.Context) error {
@@ -174,6 +180,5 @@ func (dht *IpfsDHT) BootstrapRandom(ctx context.Context) error {
 }
 
 func (dht *IpfsDHT) BootstrapSelf(ctx context.Context) error {
-	_, err := dht.walk(ctx, dht.self)
-	return err
+	return dht.selfWalk(ctx)
 }


### PR DESCRIPTION
It's impossible to find the self ID in the DHT because of this statement https://github.com/libp2p/go-libp2p-kad-dht/blob/ac6772539b80d687c8ed711024b104aaa881c1d6/handlers.go#L257
So maybe we should ignore the "not found" error in this case, like we do it for the random walk.