### PR TITLE
[DO NOT MERGE] enhanced logging for dht

### DIFF
--- a/dht.go
+++ b/dht.go
@@ -103,6 +103,20 @@ func New(ctx context.Context, h host.Host, options ...opts.Option) (*IpfsDHT, er
 			h.SetStreamHandler(p, dht.handleNewStream)
 		}
 	}
+
+	// print the routing table every minute.
+	go func() {
+		tick := time.Tick(1 * time.Minute)
+		for {
+			select {
+			case <-tick:
+				dht.routingTable.Print()
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
 	return dht, nil
 }
 

--- a/dht_net.go
+++ b/dht_net.go
@@ -117,8 +117,8 @@ func (dht *IpfsDHT) handleNewMessage(s network.Stream) bool {
 		pid, _ := peer.IDFromBytes(req.Key)
 
 		// note: MessageType implements Stringer.
-		logger.Debugf("[inbound rpc] handling incoming message; from_peer=%s, type=%s, cid_key=%s, peer_key=%s, raw_key=%x, closer=%v, providers=%v",
-			mPeer, req.GetType(), c, pid, req.Key, pb.PBPeersToPeerInfos(req.GetCloserPeers()), pb.PBPeersToPeerInfos(req.ProviderPeers))
+		logger.Debugf("[inbound rpc] handling incoming message; from_peer=%s, type=%s, cid_key=%s, peer_key=%s, raw_key=%x, closer=%d, providers=%d",
+			mPeer, req.GetType(), c, pid, req.Key, len(req.GetCloserPeers()), len(req.ProviderPeers))
 
 		handler := dht.handlerForMsgType(req.GetType())
 		if handler == nil {
@@ -140,8 +140,8 @@ func (dht *IpfsDHT) handleNewMessage(s network.Stream) bool {
 			continue
 		}
 
-		logger.Debugf("[inbound rpc] writing response message; to_peer=%s, type=%s, cid_key=%s, peer_key=%s, raw_key=%x, closer=%v, providers=%v",
-			mPeer, resp.GetType(), c, pid, req.Key, pb.PBPeersToPeerInfos(resp.GetCloserPeers()), pb.PBPeersToPeerInfos(resp.ProviderPeers))
+		logger.Debugf("[inbound rpc] writing response message; to_peer=%s, type=%s, cid_key=%s, peer_key=%s, raw_key=%x, closer=%d, providers=%d",
+			mPeer, resp.GetType(), c, pid, req.Key, len(resp.GetCloserPeers()), len(resp.ProviderPeers))
 
 		// send out response msg
 		err = writeMsg(s, resp)
@@ -155,8 +155,8 @@ func (dht *IpfsDHT) handleNewMessage(s network.Stream) bool {
 		latencyMillis := float64(elapsedTime) / float64(time.Millisecond)
 
 		// note: MessageType implements Stringer.
-		logger.Debugf("[inbound rpc] wrote response message; to_peer=%s, type=%s, cid_key=%s, peer_key=%s, raw_key=%x, closer=%v, providers=%v, elapsed_ms=%f",
-			mPeer, resp.GetType(), c, pid, req.Key, pb.PBPeersToPeerInfos(resp.GetCloserPeers()), pb.PBPeersToPeerInfos(resp.ProviderPeers), latencyMillis)
+		logger.Debugf("[inbound rpc] wrote response message; to_peer=%s, type=%s, cid_key=%s, peer_key=%s, raw_key=%x, closer=%d, providers=%d, elapsed_ms=%f",
+			mPeer, resp.GetType(), c, pid, req.Key, len(resp.GetCloserPeers()), len(resp.ProviderPeers), latencyMillis)
 
 		stats.Record(ctx, metrics.InboundRequestLatency.M(latencyMillis))
 	}
@@ -332,8 +332,8 @@ func (ms *messageSender) SendMessage(ctx context.Context, pmes *pb.Message) erro
 		}
 
 		// note: MessageType implements Stringer.
-		logger.Debugf("[outbound rpc] writing fire-and-forget outbound message; to_peer=%s, type=%s, cid_key=%s, peer_key=%s, raw_key=%x, closer=%v, providers=%v",
-			ms.p, pmes.GetType(), c, pid, pmes.Key, pb.PBPeersToPeerInfos(pmes.GetCloserPeers()), pb.PBPeersToPeerInfos(pmes.ProviderPeers))
+		logger.Debugf("[outbound rpc] writing fire-and-forget outbound message; to_peer=%s, type=%s, cid_key=%s, peer_key=%s, raw_key=%x, closer=%d, providers=%d",
+			ms.p, pmes.GetType(), c, pid, pmes.Key, len(pmes.GetCloserPeers()), len(pmes.ProviderPeers))
 
 		startTime := time.Now()
 		if err := ms.writeMsg(pmes); err != nil {
@@ -344,12 +344,12 @@ func (ms *messageSender) SendMessage(ctx context.Context, pmes *pb.Message) erro
 			latencyMillis := float64(elapsedTime) / float64(time.Millisecond)
 
 			if retry {
-				logger.Infof("[outbound rpc] error while writing fire-and-forget, bailing; err=%s, to_peer=%s, type=%s, cid_key=%s, peer_key=%s, raw_key=%x, closer=%v, providers=%v, elapsed_ms=%f",
-					err, ms.p, pmes.GetType(), c, pid, pmes.Key, pb.PBPeersToPeerInfos(pmes.GetCloserPeers()), pb.PBPeersToPeerInfos(pmes.ProviderPeers), latencyMillis)
+				logger.Infof("[outbound rpc] error while writing fire-and-forget, bailing; err=%s, to_peer=%s, type=%s, cid_key=%s, peer_key=%s, raw_key=%x, closer=%d, providers=%d, elapsed_ms=%f",
+					err, ms.p, pmes.GetType(), c, pid, pmes.Key, len(pmes.GetCloserPeers()), len(pmes.ProviderPeers), latencyMillis)
 				return err
 			}
-			logger.Infof("[outbound rpc] error while writing fire-and-forget, trying again; err=%s, to_peer=%s, type=%s, cid_key=%s, peer_key=%s, raw_key=%x, closer=%v, providers=%v, elapsed_ms=%f",
-				err, ms.p, pmes.GetType(), c, pid, pmes.Key, pb.PBPeersToPeerInfos(pmes.GetCloserPeers()), pb.PBPeersToPeerInfos(pmes.ProviderPeers), latencyMillis)
+			logger.Infof("[outbound rpc] error while writing fire-and-forget, trying again; err=%s, to_peer=%s, type=%s, cid_key=%s, peer_key=%s, raw_key=%x, closer=%d, providers=%d, elapsed_ms=%f",
+				err, ms.p, pmes.GetType(), c, pid, pmes.Key, len(pmes.GetCloserPeers()), len(pmes.ProviderPeers), latencyMillis)
 
 			retry = true
 			continue
@@ -359,8 +359,8 @@ func (ms *messageSender) SendMessage(ctx context.Context, pmes *pb.Message) erro
 		latencyMillis := float64(elapsedTime) / float64(time.Millisecond)
 
 		// note: MessageType implements Stringer.
-		logger.Debugf("[outbound rpc] wrote fire-and-forget outbound message; to_peer=%s, type=%s, cid_key=%s, peer_key=%s, raw_key=%x, closer=%v, providers=%v, elapsed_ms=%f",
-			ms.p, pmes.GetType(), c, pid, pmes.Key, pb.PBPeersToPeerInfos(pmes.GetCloserPeers()), pb.PBPeersToPeerInfos(pmes.ProviderPeers), latencyMillis)
+		logger.Debugf("[outbound rpc] wrote fire-and-forget outbound message; to_peer=%s, type=%s, cid_key=%s, peer_key=%s, raw_key=%x, closer=%d, providers=%d, elapsed_ms=%f",
+			ms.p, pmes.GetType(), c, pid, pmes.Key, len(pmes.GetCloserPeers()), len(pmes.ProviderPeers), latencyMillis)
 
 		logger.Event(ctx, "dhtSentMessage", ms.dht.self, ms.p, pmes)
 
@@ -390,8 +390,8 @@ func (ms *messageSender) SendRequest(ctx context.Context, pmes *pb.Message) (*pb
 
 		startTime := time.Now()
 		// note: MessageType implements Stringer.
-		logger.Debugf("[outbound rpc] writing request outbound message; to_peer=%s, type=%s, cid_key=%s, peer_key=%s, raw_key=%x, closer=%v, providers=%v",
-			ms.p, pmes.GetType(), c, pid, pmes.Key, pb.PBPeersToPeerInfos(pmes.GetCloserPeers()), pb.PBPeersToPeerInfos(pmes.ProviderPeers))
+		logger.Debugf("[outbound rpc] writing request outbound message; to_peer=%s, type=%s, cid_key=%s, peer_key=%s, raw_key=%x, closer=%d, providers=%d",
+			ms.p, pmes.GetType(), c, pid, pmes.Key, len(pmes.GetCloserPeers()), len(pmes.ProviderPeers))
 
 		if err := ms.writeMsg(pmes); err != nil {
 			ms.s.Reset()
@@ -409,8 +409,8 @@ func (ms *messageSender) SendRequest(ctx context.Context, pmes *pb.Message) (*pb
 		elapsedTime := time.Since(startTime)
 		latencyMillis := float64(elapsedTime) / float64(time.Millisecond)
 		// note: MessageType implements Stringer.
-		logger.Debugf("[outbound rpc] wrote request outbound message; to_peer=%s, type=%s, cid_key=%s, peer_key=%s, raw_key=%x, closer=%v, providers=%v, elapsed_ms=%f",
-			ms.p, pmes.GetType(), c, pid, pmes.Key, pb.PBPeersToPeerInfos(pmes.GetCloserPeers()), pb.PBPeersToPeerInfos(pmes.ProviderPeers), latencyMillis)
+		logger.Debugf("[outbound rpc] wrote request outbound message; to_peer=%s, type=%s, cid_key=%s, peer_key=%s, raw_key=%x, closer=%d, providers=%d, elapsed_ms=%f",
+			ms.p, pmes.GetType(), c, pid, pmes.Key, len(pmes.GetCloserPeers()), len(pmes.ProviderPeers), latencyMillis)
 
 		startTime = time.Now()
 
@@ -434,8 +434,8 @@ func (ms *messageSender) SendRequest(ctx context.Context, pmes *pb.Message) (*pb
 		c, _ = cid.Cast(mes.Key)
 		pid, _ = peer.IDFromBytes(pmes.Key)
 		// note: MessageType implements Stringer.
-		logger.Debugf("[outbound rpc] read response message; from_peer=%s, type=%s, cid_key=%s, peer_key=%s, raw_key=%x, closer=%v, providers=%v, elapsed_ms=%f",
-			ms.p, mes.GetType(), c, pid, mes.Key, pb.PBPeersToPeerInfos(mes.GetCloserPeers()), pb.PBPeersToPeerInfos(mes.ProviderPeers), latencyMillis)
+		logger.Debugf("[outbound rpc] read response message; from_peer=%s, type=%s, cid_key=%s, peer_key=%s, raw_key=%x, closer=%d, providers=%d, elapsed_ms=%f",
+			ms.p, mes.GetType(), c, pid, mes.Key, len(mes.GetCloserPeers()), len(mes.ProviderPeers), latencyMillis)
 
 		logger.Event(ctx, "dhtSentMessage", ms.dht.self, ms.p, pmes)
 

--- a/dht_net.go
+++ b/dht_net.go
@@ -340,11 +340,17 @@ func (ms *messageSender) SendMessage(ctx context.Context, pmes *pb.Message) erro
 			ms.s.Reset()
 			ms.s = nil
 
+			elapsedTime := time.Since(startTime)
+			latencyMillis := float64(elapsedTime) / float64(time.Millisecond)
+
 			if retry {
-				logger.Info("error writing message, bailing: ", err)
+				logger.Infof("[outbound rpc] error while writing fire-and-forget, bailing; err=%s, to_peer=%s, type=%s, cid_key=%s, peer_key=%s, raw_key=%x, closer=%v, providers=%v, elapsed_ms=%f",
+					err, ms.p, pmes.GetType(), c, pid, pmes.Key, pb.PBPeersToPeerInfos(pmes.GetCloserPeers()), pb.PBPeersToPeerInfos(pmes.ProviderPeers), latencyMillis)
 				return err
 			}
-			logger.Info("error writing message, trying again: ", err)
+			logger.Infof("[outbound rpc] error while writing fire-and-forget, trying again; err=%s, to_peer=%s, type=%s, cid_key=%s, peer_key=%s, raw_key=%x, closer=%v, providers=%v, elapsed_ms=%f",
+				err, ms.p, pmes.GetType(), c, pid, pmes.Key, pb.PBPeersToPeerInfos(pmes.GetCloserPeers()), pb.PBPeersToPeerInfos(pmes.ProviderPeers), latencyMillis)
+
 			retry = true
 			continue
 		}

--- a/query.go
+++ b/query.go
@@ -307,7 +307,7 @@ func (r *dhtQueryRunner) queryPeer(proc process.Process, p peer.ID) {
 			// add their addresses to the dialer's peerstore
 			r.query.dht.peerstore.AddAddrs(next.ID, next.Addrs, pstore.TempAddrTTL)
 			r.addPeerToQuery(next.ID)
-			logger.Debugf("PEERS CLOSER -- worker for: %v added %v (%v)", p, next.ID, next.Addrs)
+			// logger.Debugf("PEERS CLOSER -- worker for: %v added %v (%v)", p, next.ID, next.Addrs)
 		}
 	} else {
 		logger.Debugf("QUERY worker for: %v - not found, and no closer peers.", p)

--- a/routing.go
+++ b/routing.go
@@ -542,7 +542,7 @@ func (dht *IpfsDHT) findProvidersAsyncRoutine(ctx context.Context, key cid.Cid, 
 		// Give closer peers back to the query to be queried
 		closer := pmes.GetCloserPeers()
 		clpeers := pb.PBPeersToPeerInfos(closer)
-		logger.Debugf("got closer peers: %d %s", len(clpeers), clpeers)
+		// logger.Debugf("got closer peers: %d %s", len(clpeers), clpeers)
 
 		routing.PublishQueryEvent(parent, &routing.QueryEvent{
 			Type:      routing.PeerResponse,


### PR DESCRIPTION
Just a branch to track the logging enhancements for debugging efforts.

- [x] Common:
    - [x] RPC sent for request to peer X (log RPC type)
    - [x] RPC response received for request X (with time elapsed, and payload)
    - [x] RPC received from peer X (log RPC type).
    - [x] RPC responded to peer X (log RPC type).
    - [x] Periodically: dump the routing table.
- [ ] Providers:
    - [ ] Provider record lookup starts.
    - [ ] Provider record lookup ends (with time elapsed).
    - [ ] Inside provider record lookup:
        - [ ] Query sent to peer (log peer).
        - [ ] Query response received from peer (log peer, with time elapsed).
        - [ ] Closer peers reported in response.
    - [ ] Provider record publishing starts.
    - [ ] Provider record publishing ends (with time elapsed).
        - [ ] Inside provider record publishing:
            - [ ] GetCloserPeers initiated.
            - [ ] GetCloserPeers finished (print which peers are closer and are candidates for provider record).
            - [ ] During GetCloserPeers:
                - [ ] FIND_PEER query sent to peer.
                - [ ] FIND_PEER query response received from peer (with time elapsed and closer peers).
            - [ ] PUT_PROVIDER sent to peer (log peer). [this is a fire-and-forget message, so no response]
- [ ] Peer routing:
    - [ ] FindPeer initiated.
    - [ ] FindPeer finished (with time elapsed and results).
    - [ ] During FindPeer:
        - [ ] FIND_PEER query sent to peer.
        - [ ] FIND_PEER query response received from peer (with time elapsed and closer peers).
