### PR TITLE
Feat/message size

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/libp2p/go-libp2p-routing v0.1.0
 	github.com/libp2p/go-libp2p-swarm v0.1.0
 	github.com/libp2p/go-libp2p-testing v0.0.3
+	github.com/libp2p/go-msgio v0.0.2
 	github.com/mr-tron/base58 v1.1.2
 	github.com/multiformats/go-multiaddr v0.0.4
 	github.com/multiformats/go-multiaddr-dns v0.0.2


### PR DESCRIPTION
Closes #346.

I thought about retrofitting the writer pool at first. Looking into the implementation of the `ggio` delimited writer, I found that the comment [here](https://github.com/libp2p/go-libp2p-kad-dht/blob/f0593aa9f9c137483fd0c0457aa8cd59ff344120/dht_net.go#L29) was actually incorrect, and that the entire message is written to a byte buffer before being written to the underlying `Writer`. Should we discharge the pool entirely? Or is it worth simplifying the implementation to use a buffer pool and a shared `msgio` varint writer?