### PR TITLE
Composite routing table

### DIFF
--- a/composite_rt.go
+++ b/composite_rt.go
@@ -1,0 +1,126 @@
+package dht
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/libp2p/go-libp2p-core/peerstore"
+	kbucket "github.com/libp2p/go-libp2p-kbucket"
+)
+
+type CompositeRT struct {
+	// protos maps protocols to slice indices.
+	protos map[string]int
+
+	lk sync.RWMutex
+	// tracks membership of peers in routing tables.
+	peers map[string]int
+
+	// once initialized, this slice will never be written to, so no lock is needed.
+	rts []*kbucket.RoutingTable
+}
+
+var _ RoutingTable = (*CompositeRT)(nil)
+
+type CompositeRTConfig struct {
+	Protocol   string
+	BucketSize int
+}
+
+// TODO: collapse all these params into a struct.
+func NewCompositeRT(localID peer.ID, latency time.Duration, metrics peerstore.Metrics,
+	peerAdded func(peer.ID), peerRemoved func(peer.ID), config ...CompositeRTConfig) *CompositeRT {
+	var (
+		rts    = make([]*kbucket.RoutingTable, 0, len(config))
+		protos = make(map[string]int, len(config))
+	)
+
+	for i, c := range config {
+		rt := kbucket.NewRoutingTable(c.BucketSize, kbucket.ConvertPeerID(localID), latency, metrics)
+		rt.PeerAdded = peerAdded
+		rt.PeerRemoved = peerRemoved
+
+		rts = append(rts, rt)
+		protos[c.Protocol] = i
+	}
+
+	ret := &CompositeRT{
+		peers:  make(map[string]int),
+		rts:    rts,
+		protos: protos,
+	}
+	return ret
+}
+
+func (c *CompositeRT) getRoutingTable(p string) *kbucket.RoutingTable {
+	c.lk.RLock()
+	defer c.lk.RUnlock()
+
+	if idx, ok := c.peers[p]; ok {
+		return c.rts[idx]
+	}
+
+	panic("tried to get routing table for untracked peer")
+}
+
+func (c *CompositeRT) Track(id peer.ID, proto string) {
+	c.lk.Lock()
+	defer c.lk.Unlock()
+
+	if idx, ok := c.protos[proto]; ok {
+		c.peers[string(id)] = idx
+		c.peers[string(kbucket.ConvertPeerID(id))] = idx
+	} else {
+		panic("unrecognized protocol id")
+	}
+}
+
+func (c *CompositeRT) Update(p peer.ID) (evicted peer.ID, err error) {
+	return c.getRoutingTable(string(p)).Update(p)
+}
+
+func (c *CompositeRT) Remove(p peer.ID) {
+	c.lk.Lock()
+	delete(c.peers, string(p))
+	delete(c.peers, string(kbucket.ConvertPeerID(p)))
+	c.lk.Unlock()
+
+	c.getRoutingTable(string(p)).Remove(p)
+}
+
+func (c *CompositeRT) Find(p peer.ID) peer.ID {
+	return c.getRoutingTable(string(p)).Find(p)
+}
+
+func (c *CompositeRT) NearestPeer(id kbucket.ID) peer.ID {
+	return c.getRoutingTable(string(id)).NearestPeer(id)
+}
+
+func (c *CompositeRT) NearestPeers(id kbucket.ID, count int) []peer.ID {
+	return c.getRoutingTable(string(id)).NearestPeers(id, count)
+}
+
+func (c *CompositeRT) ListPeers() []peer.ID {
+	ret := make([]peer.ID, 0, c.Size())
+	for _, rt := range c.rts {
+		ret = append(ret, rt.ListPeers()...)
+	}
+	return ret
+}
+
+func (c *CompositeRT) Size() (size int) {
+	for _, rt := range c.rts {
+		size += rt.Size()
+	}
+	return size
+}
+
+func (c *CompositeRT) Print() {
+	fmt.Println("Printing a composite routing table")
+	for proto, idx := range c.protos {
+		fmt.Printf("--- Routing table for protocol %s ---\n", proto)
+		c.rts[idx].Print()
+	}
+}

--- a/composite_rt.go
+++ b/composite_rt.go
@@ -99,6 +99,8 @@ func (c *CompositeRT) NearestPeer(id kbucket.ID) peer.ID {
 }
 
 func (c *CompositeRT) NearestPeers(id kbucket.ID, count int) []peer.ID {
+	// TODO: this implementation is a placeholder; we really need to collect data from all routing tables to avoid
+	//  segregating networks.
 	return c.getRoutingTable(string(id)).NearestPeers(id, count)
 }
 

--- a/dht.go
+++ b/dht.go
@@ -77,6 +77,8 @@ type IpfsDHT struct {
 
 	mode   DHTMode
 	modeLk sync.Mutex
+
+	restrictRoutingToLatestVersion bool
 }
 
 // Assert that IPFS assumptions about interfaces aren't broken. These aren't a
@@ -100,7 +102,7 @@ func New(ctx context.Context, h host.Host, options ...opts.Option) (*IpfsDHT, er
 	// register for network notifs.
 	dht.host.Network().Notify((*netNotifiee)(dht))
 
-	go dht.handleProtocolChanges(ctx, ch, cancel)
+	go dht.handleProtocolChanges(ctx)
 
 	dht.proc = goprocessctx.WithContextAndTeardown(ctx, func() error {
 		// remove ourselves from network notifs.
@@ -513,7 +515,7 @@ func (dht *IpfsDHT) handleProtocolChanges(ctx context.Context) {
 	ch := make(chan event.EvtPeerProtocolsUpdated, 8)
 	cancel, err := dht.host.EventBus().Subscribe(ch)
 	if err != nil {
-		return nil, err
+		panic(err)
 	}
 	defer cancel()
 
@@ -542,7 +544,7 @@ func (dht *IpfsDHT) handleProtocolChanges(ctx context.Context) {
 
 			if add && drop {
 				// TODO: discuss how to handle this case
-				log.Warning("peer adding and dropping dht protocols? odd")
+				logger.Warning("peer adding and dropping dht protocols? odd")
 			} else if add {
 				dht.RoutingTable().Update(e.Peer)
 			} else if drop {

--- a/dht.go
+++ b/dht.go
@@ -113,6 +113,7 @@ func New(ctx context.Context, h host.Host, options ...opts.Option) (*IpfsDHT, er
 	dht.proc.AddChild(dht.providers.Process())
 	dht.Validator = cfg.Validator
 	dht.mode = ModeClient
+	dht.restrictRoutingToLatestVersion = !cfg.ConnectToOldNodes
 
 	if !cfg.Client {
 		dht.mode = ModeServer

--- a/dht_net.go
+++ b/dht_net.go
@@ -82,7 +82,7 @@ func (dht *IpfsDHT) handleNewMessage(s network.Stream) bool {
 
 	for {
 		if dht.getMode() != ModeServer {
-			logger.Errorf("responding to dht message while not in server mode")
+			logger.Errorf("ignoring incoming dht message while not in server mode")
 			return false
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/ipfs/go-todocounter v0.0.1
 	github.com/jbenet/goprocess v0.1.3
 	github.com/libp2p/go-libp2p v0.1.0
-	github.com/libp2p/go-libp2p-core v0.0.1
+	github.com/libp2p/go-libp2p-core v0.0.4
 	github.com/libp2p/go-libp2p-kbucket v0.2.0
 	github.com/libp2p/go-libp2p-peerstore v0.1.0
 	github.com/libp2p/go-libp2p-record v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,11 @@ github.com/Kubuxu/go-os-helper v0.0.1/go.mod h1:N8B+I7vPCT80IcP58r50u4+gEEcsZETF
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
 github.com/btcsuite/btcd v0.0.0-20190213025234-306aecffea32 h1:qkOC5Gd33k54tobS36cXdAzJbeHaduLtnLQQwNoIi78=
 github.com/btcsuite/btcd v0.0.0-20190213025234-306aecffea32/go.mod h1:DrZx5ec/dmnfpw9KyYoQyYo7d0KEvTkk/5M/vbZjAr8=
+github.com/btcsuite/btcd v0.0.0-20190523000118-16327141da8c h1:aEbSeNALREWXk0G7UdNhR3ayBV7tZ4M2PNmnrCAph6Q=
+github.com/btcsuite/btcd v0.0.0-20190523000118-16327141da8c/go.mod h1:3J08xEfcugPacsc34/LKRU2yO7YmuT8yt28J8k2+rrI=
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f/go.mod h1:TdznJufoqS23FtqVCzL0ZqgP5MqXbb4fg/WgDys70nA=
 github.com/btcsuite/btcutil v0.0.0-20190207003914-4c204d697803/go.mod h1:+5NJ2+qvTyV9exUAL/rxXi3DcLg2Ts+ymUAY5y4NvMg=
+github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d/go.mod h1:+5NJ2+qvTyV9exUAL/rxXi3DcLg2Ts+ymUAY5y4NvMg=
 github.com/btcsuite/go-socks v0.0.0-20170105172521-4720035b7bfd/go.mod h1:HHNXQzUsZCxOoE+CPiyCTO6x34Zs86zZUiwtpXoGdtg=
 github.com/btcsuite/goleveldb v0.0.0-20160330041536-7834afc9e8cd/go.mod h1:F+uVaaLLH7j4eDXPRvw78tMflu7Ie2bzYOH4Y8rRKBY=
 github.com/btcsuite/snappy-go v0.0.0-20151229074030-0bdef8d06723/go.mod h1:8woku9dyThutzjeg+3xrA5iCpBRH8XEEg3lh6TiUghc=
@@ -114,6 +117,8 @@ github.com/libp2p/go-libp2p-blankhost v0.1.1/go.mod h1:pf2fvdLJPsC1FsVrNP3DUUvMz
 github.com/libp2p/go-libp2p-circuit v0.1.0/go.mod h1:Ahq4cY3V9VJcHcn1SBXjr78AbFkZeIRmfunbA7pmFh8=
 github.com/libp2p/go-libp2p-core v0.0.1 h1:HSTZtFIq/W5Ue43Zw+uWZyy2Vl5WtF0zDjKN8/DT/1I=
 github.com/libp2p/go-libp2p-core v0.0.1/go.mod h1:g/VxnTZ/1ygHxH3dKok7Vno1VfpvGcGip57wjTU4fco=
+github.com/libp2p/go-libp2p-core v0.0.4 h1:wNg7b2tKrZlSNibP+j7A1v8eatjf4+9+YRw0L3DUeFE=
+github.com/libp2p/go-libp2p-core v0.0.4/go.mod h1:jyuCQP356gzfCFtRKyvAbNkyeuxb7OlyhWZ3nls5d2I=
 github.com/libp2p/go-libp2p-crypto v0.1.0 h1:k9MFy+o2zGDNGsaoZl0MA3iZ75qXxr9OOoAZF+sD5OQ=
 github.com/libp2p/go-libp2p-crypto v0.1.0/go.mod h1:sPUokVISZiy+nNuTTH/TY+leRSxnFj/2GLjtOTW90hI=
 github.com/libp2p/go-libp2p-discovery v0.1.0/go.mod h1:4F/x+aldVHjHDHuX85x1zWoFTGElt8HnoDzwkFZm29g=
@@ -260,6 +265,8 @@ golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734 h1:p/H982KKEjUnLJkM3tt/Le
 golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190513172903-22d7a77e9e5f h1:R423Cnkcp5JABoeemiGEPlt9tHXFfw5kvc0yqlxRPWo=
 golang.org/x/crypto v0.0.0-20190513172903-22d7a77e9e5f/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20190618222545-ea8f1a30c443 h1:IcSOAf4PyMp3U3XbIEj1/xJ2BjNN2jWv7JoyOsMxXUU=
+golang.org/x/crypto v0.0.0-20190618222545-ea8f1a30c443/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=

--- a/notif.go
+++ b/notif.go
@@ -38,6 +38,8 @@ func (nn *netNotifiee) Connected(n network.Network, v network.Conn) {
 		dht.plk.Lock()
 		defer dht.plk.Unlock()
 		if dht.host.Network().Connectedness(p) == network.Connected {
+			// TODO: track the right protocol here.
+			// dht.routingTable.Track(p, protos[0])
 			dht.Update(dht.Context(), p)
 		}
 		return

--- a/opts/options.go
+++ b/opts/options.go
@@ -14,8 +14,9 @@ import (
 const ProtocolDHTOld protocol.ID = "/ipfs/dht"
 
 var (
-	ProtocolDHT      protocol.ID = "/ipfs/kad/1.0.0"
-	DefaultProtocols             = []protocol.ID{ProtocolDHT}
+	ProtocolDHT100   protocol.ID = "/ipfs/kad/1.0.0"
+	ProtocolDHT      protocol.ID = "/ipfs/kad/1.1.0"
+	DefaultProtocols             = []protocol.ID{ProtocolDHT, ProtocolDHT100}
 )
 
 // Options is a structure containing all the options that can be used when constructing a DHT.

--- a/opts/options.go
+++ b/opts/options.go
@@ -21,10 +21,11 @@ var (
 
 // Options is a structure containing all the options that can be used when constructing a DHT.
 type Options struct {
-	Datastore ds.Batching
-	Validator record.Validator
-	Client    bool
-	Protocols []protocol.ID
+	Datastore         ds.Batching
+	Validator         record.Validator
+	Client            bool
+	Protocols         []protocol.ID
+	ConnectToOldNodes bool
 }
 
 // Apply applies the given options to this Option
@@ -105,6 +106,13 @@ func NamespacedValidator(ns string, v record.Validator) Option {
 func Protocols(protocols ...protocol.ID) Option {
 	return func(o *Options) error {
 		o.Protocols = protocols
+		return nil
+	}
+}
+
+func ConnectToOldNodes() Option {
+	return func(o *Options) error {
+		o.ConnectToOldNodes = true
 		return nil
 	}
 }

--- a/table.go
+++ b/table.go
@@ -1,0 +1,17 @@
+package dht
+
+import (
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/libp2p/go-libp2p-kbucket"
+)
+
+type RoutingTable interface {
+	Update(p peer.ID) (evicted peer.ID, err error)
+	Remove(p peer.ID)
+	Find(id peer.ID) peer.ID
+	NearestPeer(id kbucket.ID) peer.ID
+	NearestPeers(id kbucket.ID, count int) []peer.ID
+	ListPeers() []peer.ID
+	Size() int
+	Print()
+}


### PR DESCRIPTION
As we make changes to the DHT and keep bumping the protocol ID, we need to bring some order into how peers stay connected and routable despite protocol differences. 

Binary switches are not flexible/supportive enough (e.g. ignoring peers with lower protocols), as they lead to disjoint/disconnected networks and cause disruption.

This is the start to a composite routing table which allows us to maintain one routing table per protocol, with different kbucket sizes. This way we can prefer the higher version (by assigning it bucketSize=20), but keep residual connectedness to peers with older protocols (by assigning bucketSize=3 to those DHT networks), thus preventing otherwise drastic disruptions and general WTF.