### PR TITLE
add dial success/failure per query distribution

### DIFF
--- a/dial_queue.go
+++ b/dial_queue.go
@@ -44,8 +44,8 @@ type dialQueue struct {
 	shrinkCh  chan struct{}
 
 	// stats
-	successes   int64
-	failures    int64
+	successes int64
+	failures  int64
 }
 
 type dqParams struct {

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -43,10 +43,15 @@ var (
 	SentBytes               = stats.Int64("libp2p.io/dht/kad/sent_bytes", "Total sent bytes per RPC", stats.UnitBytes)
 	SuccessfulDialsPerQuery = stats.Int64("libp2p.io/dht/kad/successful_dials_per_query", "Distribution of the number of successful dials per query", stats.UnitDimensionless)
 	FailedDialsPerQuery     = stats.Int64("libp2p.io/dht/kad/failed_dials_per_query", "Distribution of the number of failed dials per query", stats.UnitDimensionless)
+	Queries                 = stats.Int64("libp2p.io/dht/kad/queries", "Total number of queries made", stats.UnitDimensionless)
 )
 
 // DefaultViews provides a default set of views to register.
 var DefaultViews = []*view.View{
+	&view.View{
+		Measure:     Queries,
+		Aggregation: view.Count(),
+	},
 	&view.View{
 		Measure:     SuccessfulDialsPerQuery,
 		Aggregation: defaultDistribution,

--- a/query.go
+++ b/query.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/libp2p/go-libp2p-kad-dht/metrics"
+	"go.opencensus.io/stats"
 
 	logging "github.com/ipfs/go-log"
 	todoctr "github.com/ipfs/go-todocounter"
@@ -125,6 +127,7 @@ func newQueryRunner(q *dhtQuery) *dhtQueryRunner {
 }
 
 func (r *dhtQueryRunner) Run(ctx context.Context, peers []peer.ID) (*dhtQueryResult, error) {
+	stats.Record(ctx, metrics.Queries.M(1))
 	r.log = logger
 	r.runCtx = ctx
 


### PR DESCRIPTION
The results channel design is so that we have an accurate measurement of how many dial failures/successes there are **per query**. We can extend the `result` enum to include other error types for finer-grained metrics at a later date. 

@whyrusleeping @raulk I am unsure as to whether the `defer` is ever triggered, but the understanding I gathered from @magik6k it is one `dialqueue` therefore one control go routine per query and so when that returns that query should have finished.

I can add the metrics to record just the number of dial failures/successes and those can be recorded during processing?