### PR TITLE
Export BootstrapOnce so peers can bootstrap whenever they want

### DIFF
--- a/dht_bootstrap.go
+++ b/dht_bootstrap.go
@@ -91,6 +91,15 @@ func (dht *IpfsDHT) Bootstrap(ctx context.Context) error {
 	return nil
 }
 
+// synchronous bootstrap.
+func (dht *IpfsDHT) BootstrapOnce(ctx context.Context) error {
+	if err := dht.selfWalk(ctx); err != nil {
+		return errors.Wrap(err, "failed bootstrap while searching for self")
+	} else {
+		return dht.bootstrapBuckets(ctx)
+	}
+}
+
 // bootstrapBuckets scans the routing table, and does a random walk on k-buckets that haven't been queried since the given bucket period
 func (dht *IpfsDHT) bootstrapBuckets(ctx context.Context) error {
 	doQuery := func(bucketId int, target string, f func(context.Context) error) error {
@@ -164,13 +173,4 @@ func (dht *IpfsDHT) selfWalk(ctx context.Context) error {
 		return nil
 	}
 	return err
-}
-
-// synchronous bootstrap.
-func (dht *IpfsDHT) bootstrapOnce(ctx context.Context) error {
-	if err := dht.selfWalk(ctx); err != nil {
-		return errors.Wrap(err, "failed bootstrap while searching for self")
-	} else {
-		return dht.bootstrapBuckets(ctx)
-	}
 }

--- a/dht_test.go
+++ b/dht_test.go
@@ -200,7 +200,7 @@ func bootstrap(t *testing.T, ctx context.Context, dhts []*IpfsDHT) {
 	start := rand.Intn(len(dhts)) // randomize to decrease bias.
 	for i := range dhts {
 		dht := dhts[(start+i)%len(dhts)]
-		dht.bootstrapOnce(ctx)
+		dht.BootstrapOnce(ctx)
 	}
 }
 
@@ -783,7 +783,7 @@ func TestPeriodicBootstrap(t *testing.T) {
 
 	t.Logf("bootstrapping them so they find each other. %d", nDHTs)
 	for _, dht := range dhts {
-		go dht.bootstrapOnce(ctx)
+		go dht.BootstrapOnce(ctx)
 	}
 
 	// this is async, and we dont know when it's finished with one cycle, so keep checking


### PR DESCRIPTION
This is to export the bootstrapOnce functionality that was unexported in #384

@Stebalien  