### PR TITLE
feat(bootstrap): take autobootstrap to completion

### DIFF
--- a/dht.go
+++ b/dht.go
@@ -70,7 +70,7 @@ type IpfsDHT struct {
 	bootstrapCfg opts.BootstrapConfig
 
 	triggerAutoBootstrap bool
-	triggerBootstrap     chan *bootstrapReq
+	triggerBootstrap     chan struct{}
 	latestSelfWalk       time.Time // the last time we looked-up our own peerID in the network
 }
 
@@ -163,7 +163,7 @@ func makeDHT(ctx context.Context, h host.Host, dstore ds.Batching, protocols []p
 		routingTable:     rt,
 		protocols:        protocols,
 		bucketSize:       bucketSize,
-		triggerBootstrap: make(chan *bootstrapReq),
+		triggerBootstrap: make(chan struct{}),
 	}
 
 	dht.ctx = dht.newContextWithLocalTags(ctx)

--- a/dht.go
+++ b/dht.go
@@ -109,6 +109,7 @@ func New(ctx context.Context, h host.Host, options ...opts.Option) (*IpfsDHT, er
 			h.SetStreamHandler(p, dht.handleNewStream)
 		}
 	}
+	dht.startBootstrapping()
 	return dht, nil
 }
 

--- a/dht.go
+++ b/dht.go
@@ -71,6 +71,7 @@ type IpfsDHT struct {
 
 	triggerAutoBootstrap bool
 	triggerBootstrap     chan *bootstrapReq
+	latestSelfWalk       time.Time // the last time we looked-up our own peerID in the network
 }
 
 // Assert that IPFS assumptions about interfaces aren't broken. These aren't a
@@ -174,7 +175,7 @@ func makeDHT(ctx context.Context, h host.Host, dstore ds.Batching, protocols []p
 // come up with an alternative solution.
 // issue is being tracked at https://github.com/libp2p/go-libp2p-kad-dht/issues/387
 /*func (dht *IpfsDHT) rtRecovery(proc goprocess.Process) {
-	writeResp := func(errorChan chan error, errChan error) {
+	writeResp := func(errorChan chan error, err error) {
 		select {
 		case <-proc.Closing():
 		case errorChan <- errChan:

--- a/dht_bootstrap.go
+++ b/dht_bootstrap.go
@@ -66,6 +66,9 @@ func (dht *IpfsDHT) startBootstrapping() error {
 			if err := dht.doBootstrap(ctx, true); err != nil {
 				logger.Warningf("bootstrap error: %s", err)
 			}
+		} else {
+			// disable the "auto-bootstrap" ticker so that no more ticks are sent to his channel
+			scanInterval.Stop()
 		}
 
 		for {
@@ -96,9 +99,8 @@ func (dht *IpfsDHT) doBootstrap(ctx context.Context, walkSelf bool) error {
 	if walkSelf {
 		if err := dht.selfWalk(ctx); err != nil {
 			return fmt.Errorf("self walk: error: %s", err)
-		} else {
-			dht.latestSelfWalk = time.Now()
 		}
+		dht.latestSelfWalk = time.Now()
 	}
 
 	if err := dht.bootstrapBuckets(ctx); err != nil {

--- a/dht_bootstrap.go
+++ b/dht_bootstrap.go
@@ -7,6 +7,8 @@ import (
 	"sync"
 	"time"
 
+	process "github.com/jbenet/goprocess"
+	processctx "github.com/jbenet/goprocess/context"
 	"github.com/libp2p/go-libp2p-core/routing"
 	"github.com/multiformats/go-multiaddr"
 	_ "github.com/multiformats/go-multiaddr-dns"
@@ -41,52 +43,47 @@ func init() {
 	}
 }
 
-// BootstrapConfig runs cfg.Queries bootstrap queries every cfg.BucketPeriod.
-func (dht *IpfsDHT) Bootstrap(ctx context.Context) error {
-	triggerBootstrapFnc := func() {
-		logger.Infof("triggerBootstrapFnc: RT only has %d peers which is less than the min threshold of %d, triggering self & bucket bootstrap",
-			dht.routingTable.Size(), minRTBootstrapThreshold)
-
-		if err := dht.selfWalk(ctx); err != nil {
-			logger.Warningf("triggerBootstrapFnc: self walk: error: %s", err)
-		}
-
-		if err := dht.bootstrapBuckets(ctx); err != nil {
-			logger.Warningf("triggerBootstrapFnc: bootstrap buckets: error bootstrapping: %s", err)
-		}
-	}
-
-	// we should query for self periodically so we can discover closer peers
-	go func() {
-		for {
-			err := dht.selfWalk(ctx)
-			if err != nil {
-				logger.Warningf("self walk: error: %s", err)
-			}
-			select {
-			case <-time.After(dht.bootstrapCfg.SelfQueryInterval):
-			case <-ctx.Done():
-				return
-			}
-		}
-	}()
-
+// Bootstrap  i
+func (dht *IpfsDHT) startBootstrapping() error {
 	// scan the RT table periodically & do a random walk on k-buckets that haven't been queried since the given bucket period
-	go func() {
+	dht.proc.Go(func(proc process.Process) {
+		ctx := processctx.OnClosingContext(proc)
+		scanInterval := time.NewTicker(dht.bootstrapCfg.RoutingTableScanInterval)
+		defer scanInterval.Stop()
+
+		var (
+			lastSelfWalk time.Time
+			walkSelf     = true
+		)
+
 		for {
+			if walkSelf {
+				walkSelf = false
+				err := dht.selfWalk(ctx)
+				if err != nil {
+					logger.Warningf("self walk: error: %s", err)
+				} else {
+					lastSelfWalk = time.Now()
+				}
+			}
+
 			err := dht.bootstrapBuckets(ctx)
 			if err != nil {
 				logger.Warningf("bootstrap buckets: error bootstrapping: %s", err)
 			}
+
 			select {
-			case <-time.After(dht.bootstrapCfg.RoutingTableScanInterval):
+			case now := <-scanInterval.C:
+				// It doesn't make sense to query for self unless we're _also_ going to fill out the routing table.
+				walkSelf = now.After(lastSelfWalk.Add(dht.bootstrapCfg.SelfQueryInterval))
 			case <-dht.triggerBootstrap:
-				triggerBootstrapFnc()
+				walkSelf = true
+				logger.Infof("triggering a bootstrap: RT has %d peers", dht.routingTable.Size())
 			case <-ctx.Done():
 				return
 			}
 		}
-	}()
+	})
 
 	return nil
 }
@@ -166,11 +163,14 @@ func (dht *IpfsDHT) selfWalk(ctx context.Context) error {
 	return err
 }
 
-// synchronous bootstrap.
-func (dht *IpfsDHT) bootstrapOnce(ctx context.Context) error {
-	if err := dht.selfWalk(ctx); err != nil {
-		return errors.Wrap(err, "failed bootstrap while searching for self")
-	} else {
-		return dht.bootstrapBuckets(ctx)
+// Bootstrap tells the DHT to get into a bootstrapped state.
+//
+// Note: the context is ignored.
+func (dht *IpfsDHT) Bootstrap(_ context.Context) error {
+	// Returns an error just in case we want to do that in the future.
+	select {
+	case dht.triggerBootstrap <- struct{}{}:
+	default:
 	}
+	return nil
 }

--- a/dht_bootstrap.go
+++ b/dht_bootstrap.go
@@ -43,7 +43,7 @@ func init() {
 	}
 }
 
-// Bootstrap  i
+// Start the bootstrap worker.
 func (dht *IpfsDHT) startBootstrapping() error {
 	// scan the RT table periodically & do a random walk on k-buckets that haven't been queried since the given bucket period
 	dht.proc.Go(func(proc process.Process) {
@@ -58,7 +58,7 @@ func (dht *IpfsDHT) startBootstrapping() error {
 				logger.Warningf("bootstrap error: %s", err)
 			}
 		} else {
-			// disable the "auto-bootstrap" ticker so that no more ticks are sent to his channel
+			// disable the "auto-bootstrap" ticker so that no more ticks are sent to this channel
 			scanInterval.Stop()
 		}
 

--- a/ext_test.go
+++ b/ext_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/routing"
+	opts "github.com/libp2p/go-libp2p-kad-dht/opts"
 
 	ggio "github.com/gogo/protobuf/io"
 	u "github.com/ipfs/go-ipfs-util"
@@ -29,7 +30,8 @@ func TestGetFailures(t *testing.T) {
 	}
 	hosts := mn.Hosts()
 
-	d, err := New(ctx, hosts[0])
+	os := []opts.Option{opts.DisableAutoBootstrap()}
+	d, err := New(ctx, hosts[0], os...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -149,7 +151,9 @@ func TestNotFound(t *testing.T) {
 		t.Fatal(err)
 	}
 	hosts := mn.Hosts()
-	d, err := New(ctx, hosts[0])
+
+	os := []opts.Option{opts.DisableAutoBootstrap()}
+	d, err := New(ctx, hosts[0], os...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -228,7 +232,8 @@ func TestLessThanKResponses(t *testing.T) {
 	}
 	hosts := mn.Hosts()
 
-	d, err := New(ctx, hosts[0])
+	os := []opts.Option{opts.DisableAutoBootstrap()}
+	d, err := New(ctx, hosts[0], os...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -297,7 +302,8 @@ func TestMultipleQueries(t *testing.T) {
 		t.Fatal(err)
 	}
 	hosts := mn.Hosts()
-	d, err := New(ctx, hosts[0])
+	os := []opts.Option{opts.DisableAutoBootstrap()}
+	d, err := New(ctx, hosts[0], os...)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/notif.go
+++ b/notif.go
@@ -34,9 +34,9 @@ func (nn *netNotifiee) Connected(n network.Network, v network.Conn) {
 		if dht.host.Network().Connectedness(p) == network.Connected {
 			bootstrap := dht.routingTable.Size() <= minRTBootstrapThreshold
 			dht.Update(dht.Context(), p)
-			if bootstrap {
+			if bootstrap && dht.triggerAutoBootstrap {
 				select {
-				case dht.triggerBootstrap <- struct{}{}:
+				case dht.triggerBootstrap <- makeBootstrapReq():
 				default:
 				}
 			}
@@ -80,9 +80,9 @@ func (nn *netNotifiee) testConnection(v network.Conn) {
 	if dht.host.Network().Connectedness(p) == network.Connected {
 		bootstrap := dht.routingTable.Size() <= minRTBootstrapThreshold
 		dht.Update(dht.Context(), p)
-		if bootstrap {
+		if bootstrap && dht.triggerAutoBootstrap {
 			select {
-			case dht.triggerBootstrap <- struct{}{}:
+			case dht.triggerBootstrap <- makeBootstrapReq():
 			default:
 			}
 		}

--- a/notif.go
+++ b/notif.go
@@ -36,7 +36,7 @@ func (nn *netNotifiee) Connected(n network.Network, v network.Conn) {
 			dht.Update(dht.Context(), p)
 			if bootstrap && dht.triggerAutoBootstrap {
 				select {
-				case dht.triggerBootstrap <- makeBootstrapReq():
+				case dht.triggerBootstrap <- struct{}{}:
 				default:
 				}
 			}
@@ -82,7 +82,7 @@ func (nn *netNotifiee) testConnection(v network.Conn) {
 		dht.Update(dht.Context(), p)
 		if bootstrap && dht.triggerAutoBootstrap {
 			select {
-			case dht.triggerBootstrap <- makeBootstrapReq():
+			case dht.triggerBootstrap <- struct{}{}:
 			default:
 			}
 		}

--- a/opts/options.go
+++ b/opts/options.go
@@ -149,7 +149,9 @@ func BucketSize(bucketSize int) Option {
 	}
 }
 
-// DisableAutoBootstrap disables auto bootstrap on the dht
+// DisableAutoBootstrap completely disables 'auto-bootstrap' on the Dht
+// This means that neither will we do periodic bootstrap nor will we
+// bootstrap the Dht even if the Routing Table size goes below the minimum threshold
 func DisableAutoBootstrap() Option {
 	return func(o *Options) error {
 		o.TriggerAutoBootstrap = false

--- a/opts/options.go
+++ b/opts/options.go
@@ -21,20 +21,20 @@ var (
 
 // BootstrapConfig specifies parameters used for bootstrapping the DHT.
 type BootstrapConfig struct {
-	BucketPeriod             time.Duration // how long to wait for a k-bucket to be queried before doing a random walk on it
-	Timeout                  time.Duration // how long to wait for a bootstrap query to run
-	RoutingTableScanInterval time.Duration // how often to scan the RT for k-buckets that haven't been queried since the given period
-	SelfQueryInterval        time.Duration // how often to query for self
+	BucketPeriod      time.Duration // how long to wait for a k-bucket to be queried before doing a random walk on it
+	Timeout           time.Duration // how long to wait for a bootstrap query to run
+	SelfQueryInterval time.Duration // how often to query for self
 }
 
 // Options is a structure containing all the options that can be used when constructing a DHT.
 type Options struct {
-	Datastore       ds.Batching
-	Validator       record.Validator
-	Client          bool
-	Protocols       []protocol.ID
-	BucketSize      int
-	BootstrapConfig BootstrapConfig
+	Datastore            ds.Batching
+	Validator            record.Validator
+	Client               bool
+	Protocols            []protocol.ID
+	BucketSize           int
+	BootstrapConfig      BootstrapConfig
+	TriggerAutoBootstrap bool
 }
 
 // Apply applies the given options to this Option
@@ -63,13 +63,12 @@ var Defaults = func(o *Options) error {
 		// same as that mentioned in the kad dht paper
 		BucketPeriod: 1 * time.Hour,
 
-		// since the default bucket period is 1 hour, a scan interval of 30 minutes sounds reasonable
-		RoutingTableScanInterval: 30 * time.Minute,
-
 		Timeout: 10 * time.Second,
 
 		SelfQueryInterval: 1 * time.Hour,
 	}
+
+	o.TriggerAutoBootstrap = true
 
 	return nil
 }
@@ -146,6 +145,14 @@ func Protocols(protocols ...protocol.ID) Option {
 func BucketSize(bucketSize int) Option {
 	return func(o *Options) error {
 		o.BucketSize = bucketSize
+		return nil
+	}
+}
+
+// DisableAutoBootstrap disables auto bootstrap on the dht
+func DisableAutoBootstrap() Option {
+	return func(o *Options) error {
+		o.TriggerAutoBootstrap = false
 		return nil
 	}
 }


### PR DESCRIPTION
@Stebalien 

This takes #402 to completion. Main changes made are:

1. Bootstrap(ctx) should be synchronous so that errors in bootstrapping flow to the client
2. A flag to disable auto bootstrapping so that tests which depend on a specific number of peers in the RT/query results do not fail
3. Replace RoutingTableScanInterval with BucketPeriod.