### PR TITLE
fix and simplify some bootstrapping logic

### DIFF
--- a/dht.go
+++ b/dht.go
@@ -91,9 +91,9 @@ func New(ctx context.Context, h host.Host, options ...opts.Option) (*IpfsDHT, er
 		return nil, err
 	}
 	dht := makeDHT(ctx, h, cfg.Datastore, cfg.Protocols, cfg.BucketSize)
-	dht.autoRefresh = cfg.AutoRefresh
-	dht.rtRefreshPeriod = cfg.RoutingTableRefreshPeriod
-	dht.rtRefreshQueryTimeout = cfg.RoutingTableRefreshQueryTimeout
+	dht.autoRefresh = cfg.RoutingTable.AutoRefresh
+	dht.rtRefreshPeriod = cfg.RoutingTable.RefreshPeriod
+	dht.rtRefreshQueryTimeout = cfg.RoutingTable.RefreshQueryTimeout
 
 	// register for network notifs.
 	dht.host.Network().Notify((*netNotifiee)(dht))

--- a/dht_bootstrap.go
+++ b/dht_bootstrap.go
@@ -95,6 +95,12 @@ func (dht *IpfsDHT) bootstrapBuckets(ctx context.Context) {
 	}
 
 	buckets := dht.routingTable.GetAllBuckets()
+	if len(buckets) > 16 {
+		// Don't bother bootstrapping more than 16 buckets.
+		// GenRandPeerID can't generate target peer IDs with more than
+		// 16 bits specified anyways.
+		buckets = buckets[:16]
+	}
 	for bucketID, bucket := range buckets {
 		if time.Since(bucket.RefreshedAt()) > dht.bootstrapPeriod {
 			// gen rand peer in the bucket

--- a/dht_bootstrap.go
+++ b/dht_bootstrap.go
@@ -13,6 +13,8 @@ import (
 
 var DefaultBootstrapPeers []multiaddr.Multiaddr
 
+// Minimum number of peers in the routing table. If we drop below this and we
+// see a new peer, we trigger a bootstrap round.
 var minRTRefreshThreshold = 4
 
 func init() {

--- a/dht_bootstrap.go
+++ b/dht_bootstrap.go
@@ -118,7 +118,7 @@ func (dht *IpfsDHT) refreshBuckets(ctx context.Context) {
 		}
 
 		if err := doQuery(bucketID, randPeerInBucket.String(), walkFnc); err != nil {
-			logger.Warningf("failed to do a random walk on bucket %d", bucketID)
+			logger.Warningf("failed to do a random walk on bucket %d: %s", bucketID, err)
 		}
 	}
 }

--- a/dht_bootstrap.go
+++ b/dht_bootstrap.go
@@ -108,7 +108,7 @@ func (dht *IpfsDHT) refreshBuckets(ctx context.Context) {
 
 			// walk to the generated peer
 			walkFnc := func(c context.Context) error {
-				_, err := dht.FindPeer(ctx, randPeerInBucket)
+				_, err := dht.FindPeer(c, randPeerInBucket)
 				if err == routing.ErrNotFound {
 					return nil
 				}

--- a/dht_bootstrap.go
+++ b/dht_bootstrap.go
@@ -45,20 +45,20 @@ func (dht *IpfsDHT) startRefreshing() error {
 	dht.proc.Go(func(proc process.Process) {
 		ctx := processctx.OnClosingContext(proc)
 
-		scanInterval := time.NewTicker(dht.rtRefreshPeriod)
-		defer scanInterval.Stop()
+		refreshTicker := time.NewTicker(dht.rtRefreshPeriod)
+		defer refreshTicker.Stop()
 
 		// refresh if option is set
 		if dht.autoRefresh {
 			dht.doRefresh(ctx)
 		} else {
 			// disable the "auto-refresh" ticker so that no more ticks are sent to this channel
-			scanInterval.Stop()
+			refreshTicker.Stop()
 		}
 
 		for {
 			select {
-			case <-scanInterval.C:
+			case <-refreshTicker.C:
 			case <-dht.triggerRtRefresh:
 				logger.Infof("triggering a refresh: RT has %d peers", dht.routingTable.Size())
 			case <-ctx.Done():

--- a/ext_test.go
+++ b/ext_test.go
@@ -30,7 +30,7 @@ func TestGetFailures(t *testing.T) {
 	}
 	hosts := mn.Hosts()
 
-	os := []opts.Option{opts.DisableAutoBootstrap()}
+	os := []opts.Option{opts.DisableAutoRefresh()}
 	d, err := New(ctx, hosts[0], os...)
 	if err != nil {
 		t.Fatal(err)
@@ -152,7 +152,7 @@ func TestNotFound(t *testing.T) {
 	}
 	hosts := mn.Hosts()
 
-	os := []opts.Option{opts.DisableAutoBootstrap()}
+	os := []opts.Option{opts.DisableAutoRefresh()}
 	d, err := New(ctx, hosts[0], os...)
 	if err != nil {
 		t.Fatal(err)
@@ -232,7 +232,7 @@ func TestLessThanKResponses(t *testing.T) {
 	}
 	hosts := mn.Hosts()
 
-	os := []opts.Option{opts.DisableAutoBootstrap()}
+	os := []opts.Option{opts.DisableAutoRefresh()}
 	d, err := New(ctx, hosts[0], os...)
 	if err != nil {
 		t.Fatal(err)
@@ -302,7 +302,7 @@ func TestMultipleQueries(t *testing.T) {
 		t.Fatal(err)
 	}
 	hosts := mn.Hosts()
-	os := []opts.Option{opts.DisableAutoBootstrap()}
+	os := []opts.Option{opts.DisableAutoRefresh()}
 	d, err := New(ctx, hosts[0], os...)
 	if err != nil {
 		t.Fatal(err)

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.12
 
 require (
 	github.com/gogo/protobuf v1.3.0
-	github.com/google/uuid v1.1.1
 	github.com/hashicorp/golang-lru v0.5.3
 	github.com/ipfs/go-cid v0.0.3
 	github.com/ipfs/go-datastore v0.1.0
@@ -25,7 +24,6 @@ require (
 	github.com/multiformats/go-multiaddr v0.0.4
 	github.com/multiformats/go-multiaddr-dns v0.0.3
 	github.com/multiformats/go-multistream v0.1.0
-	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.3.0
 	github.com/whyrusleeping/base32 v0.0.0-20170828182744-c30ac30633cc
 	go.opencensus.io v0.22.1

--- a/go.sum
+++ b/go.sum
@@ -395,8 +395,6 @@ golang.org/x/tools v0.0.0-20181130052023-1c3d964395ce/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
-golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 h1:9zdDQZ7Thm29KFXgAX/+yaf3eVbP7djjWp/dXAppNCc=
-golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898 h1:/atklqdjdhuosWIl6AIbOeHJjicWYPqR9bpxqxYG2pA=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=

--- a/notif.go
+++ b/notif.go
@@ -34,7 +34,7 @@ func (nn *netNotifiee) Connected(n network.Network, v network.Conn) {
 		if dht.host.Network().Connectedness(p) == network.Connected {
 			bootstrap := dht.routingTable.Size() <= minRTBootstrapThreshold
 			dht.Update(dht.Context(), p)
-			if bootstrap && dht.triggerAutoBootstrap {
+			if bootstrap && dht.autoBootstrap {
 				select {
 				case dht.triggerBootstrap <- struct{}{}:
 				default:
@@ -80,7 +80,7 @@ func (nn *netNotifiee) testConnection(v network.Conn) {
 	if dht.host.Network().Connectedness(p) == network.Connected {
 		bootstrap := dht.routingTable.Size() <= minRTBootstrapThreshold
 		dht.Update(dht.Context(), p)
-		if bootstrap && dht.triggerAutoBootstrap {
+		if bootstrap && dht.autoBootstrap {
 			select {
 			case dht.triggerBootstrap <- struct{}{}:
 			default:

--- a/notif.go
+++ b/notif.go
@@ -32,11 +32,11 @@ func (nn *netNotifiee) Connected(n network.Network, v network.Conn) {
 		dht.plk.Lock()
 		defer dht.plk.Unlock()
 		if dht.host.Network().Connectedness(p) == network.Connected {
-			bootstrap := dht.routingTable.Size() <= minRTBootstrapThreshold
+			refresh := dht.routingTable.Size() <= minRTRefreshThreshold
 			dht.Update(dht.Context(), p)
-			if bootstrap && dht.autoBootstrap {
+			if refresh && dht.autoRefresh {
 				select {
-				case dht.triggerBootstrap <- struct{}{}:
+				case dht.triggerRtRefresh <- struct{}{}:
 				default:
 				}
 			}
@@ -78,11 +78,11 @@ func (nn *netNotifiee) testConnection(v network.Conn) {
 	dht.plk.Lock()
 	defer dht.plk.Unlock()
 	if dht.host.Network().Connectedness(p) == network.Connected {
-		bootstrap := dht.routingTable.Size() <= minRTBootstrapThreshold
+		refresh := dht.routingTable.Size() <= minRTRefreshThreshold
 		dht.Update(dht.Context(), p)
-		if bootstrap && dht.autoBootstrap {
+		if refresh && dht.autoRefresh {
 			select {
-			case dht.triggerBootstrap <- struct{}{}:
+			case dht.triggerRtRefresh <- struct{}{}:
 			default:
 			}
 		}

--- a/opts/options.go
+++ b/opts/options.go
@@ -27,9 +27,11 @@ type Options struct {
 	Protocols  []protocol.ID
 	BucketSize int
 
-	RoutingTableRefreshQueryTimeout time.Duration
-	RoutingTableRefreshPeriod       time.Duration
-	AutoRefresh                     bool
+	RoutingTable struct {
+		RefreshQueryTimeout time.Duration
+		RefreshPeriod       time.Duration
+		AutoRefresh         bool
+	}
 }
 
 // Apply applies the given options to this Option
@@ -54,9 +56,9 @@ var Defaults = func(o *Options) error {
 	o.Datastore = dssync.MutexWrap(ds.NewMapDatastore())
 	o.Protocols = DefaultProtocols
 
-	o.RoutingTableRefreshQueryTimeout = 10 * time.Second
-	o.RoutingTableRefreshPeriod = 1 * time.Hour
-	o.AutoRefresh = true
+	o.RoutingTable.RefreshQueryTimeout = 10 * time.Second
+	o.RoutingTable.RefreshPeriod = 1 * time.Hour
+	o.RoutingTable.AutoRefresh = true
 
 	return nil
 }
@@ -65,7 +67,7 @@ var Defaults = func(o *Options) error {
 // queries.
 func RoutingTableRefreshQueryTimeout(timeout time.Duration) Option {
 	return func(o *Options) error {
-		o.RoutingTableRefreshQueryTimeout = timeout
+		o.RoutingTable.RefreshQueryTimeout = timeout
 		return nil
 	}
 }
@@ -78,7 +80,7 @@ func RoutingTableRefreshQueryTimeout(timeout time.Duration) Option {
 //    the last refresh period.
 func RoutingTableRefreshPeriod(period time.Duration) Option {
 	return func(o *Options) error {
-		o.RoutingTableRefreshPeriod = period
+		o.RoutingTable.RefreshPeriod = period
 		return nil
 	}
 }
@@ -156,7 +158,7 @@ func BucketSize(bucketSize int) Option {
 // nor when the routing table size goes below the minimum threshold.
 func DisableAutoRefresh() Option {
 	return func(o *Options) error {
-		o.AutoRefresh = false
+		o.RoutingTable.AutoRefresh = false
 		return nil
 	}
 }

--- a/opts/options.go
+++ b/opts/options.go
@@ -27,9 +27,9 @@ type Options struct {
 	Protocols  []protocol.ID
 	BucketSize int
 
-	BootstrapTimeout time.Duration
-	BootstrapPeriod  time.Duration
-	AutoBootstrap    bool
+	RoutingTableRefreshQueryTimeout time.Duration
+	RoutingTableRefreshPeriod       time.Duration
+	AutoRefresh                     bool
 }
 
 // Apply applies the given options to this Option
@@ -54,30 +54,31 @@ var Defaults = func(o *Options) error {
 	o.Datastore = dssync.MutexWrap(ds.NewMapDatastore())
 	o.Protocols = DefaultProtocols
 
-	o.BootstrapTimeout = 10 * time.Second
-	o.BootstrapPeriod = 1 * time.Hour
-	o.AutoBootstrap = true
+	o.RoutingTableRefreshQueryTimeout = 10 * time.Second
+	o.RoutingTableRefreshPeriod = 1 * time.Hour
+	o.AutoRefresh = true
 
 	return nil
 }
 
-// BootstrapTimeout sets the timeout for bootstrap queries.
-func BootstrapTimeout(timeout time.Duration) Option {
+// RoutingTableRefreshQueryTimeout sets the timeout for routing table refresh
+// queries.
+func RoutingTableRefreshQueryTimeout(timeout time.Duration) Option {
 	return func(o *Options) error {
-		o.BootstrapTimeout = timeout
+		o.RoutingTableRefreshQueryTimeout = timeout
 		return nil
 	}
 }
 
-// BootstrapPeriod sets the period for bootstrapping. The DHT will bootstrap
-// every bootstrap period by:
+// RoutingTableRefreshPeriod sets the period for refreshing buckets in the
+// routing table. The DHT will refresh buckets every period by:
 //
 // 1. First searching for nearby peers to figure out how many buckets we should try to fill.
 // 1. Then searching for a random key in each bucket that hasn't been queried in
-//    the last bootstrap period.
-func BootstrapPeriod(period time.Duration) Option {
+//    the last refresh period.
+func RoutingTableRefreshPeriod(period time.Duration) Option {
 	return func(o *Options) error {
-		o.BootstrapPeriod = period
+		o.RoutingTableRefreshPeriod = period
 		return nil
 	}
 }
@@ -150,12 +151,12 @@ func BucketSize(bucketSize int) Option {
 	}
 }
 
-// DisableAutoBootstrap completely disables 'auto-bootstrap' on the Dht
-// This means that neither will we do periodic bootstrap nor will we
-// bootstrap the Dht even if the Routing Table size goes below the minimum threshold
-func DisableAutoBootstrap() Option {
+// DisableAutoRefresh completely disables 'auto-refresh' on the DHT routing
+// table. This means that we will neither refresh the routing table periodically
+// nor when the routing table size goes below the minimum threshold.
+func DisableAutoRefresh() Option {
 	return func(o *Options) error {
-		o.AutoBootstrap = false
+		o.AutoRefresh = false
 		return nil
 	}
 }


### PR DESCRIPTION
* Don't bootstrap more than 16 buckets: We can't generate target IDs in buckets beyond bucket 15 so there's no point.
* Bootstrap sequentially: The default timeout is 10s so this won't take that long anyways. On the other hand, if we do this all at once, we max the swarms dial queue.
* Rename triggerAutoBootstrap to autoBootstrap. This variable used to control _triggering_ only but now completely disables automatic bootstrapping.
* Remove the BootstrapConfig. We introduced this before we switched to functional options. Now that we're breaking the interfaces anyways, we might as well use functional options all the way (easier to extend).
* Always query self when bootstrapping. This really isn't that expensive and ensures that we know how many buckets we _should_ bootstrap.
* Don't abort the bootstrap process if we timeout finding ourselves.
* Rename bootstrap to refresh everywhere as these aren't really the same thing (pointed out by @raulk).