### PR TITLE
fix: try to re-add existing peers when the routing table is empty

### DIFF
--- a/notif.go
+++ b/notif.go
@@ -109,6 +109,16 @@ func (nn *netNotifiee) Disconnected(n network.Network, v network.Conn) {
 	}
 
 	dht.routingTable.Remove(p)
+	if dht.routingTable.Size() < minRTRefreshThreshold {
+		// TODO: Actively bootstrap. For now, just try to add the currently connected peers.
+		for _, p := range dht.host.Network().Peers() {
+			// Don't bother probing, we do that on connect.
+			protos, err := dht.peerstore.SupportsProtocols(p, dht.protocolStrs()...)
+			if err == nil && len(protos) != 0 {
+				dht.Update(dht.Context(), p)
+			}
+		}
+	}
 
 	dht.smlk.Lock()
 	defer dht.smlk.Unlock()


### PR DESCRIPTION
Otherwise, we could decide to _not_ add a peer, disconnect from most peers, and
be unable to query the DHT even if we're technically connected to a peer in the
DHT.

This is a small subset of active bootstrapping.