### PR TITLE
feat: reduce stream idle timeout to 1m

### DIFF
--- a/dht_net.go
+++ b/dht_net.go
@@ -23,7 +23,7 @@ import (
 )
 
 var dhtReadMessageTimeout = time.Minute
-var dhtStreamIdleTimeout = 10 * time.Minute
+var dhtStreamIdleTimeout = 1 * time.Minute
 var ErrReadTimeout = fmt.Errorf("timed out reading response")
 
 // The Protobuf writer performs multiple small writes when writing a message.


### PR DESCRIPTION
It's currently 10 minutes. This change will kill all inbound DHT streams that haven't been used in 1 minute.

We keep streams around to avoid the cost of setting up new streams (the multistream overhead, mostly). However, each one of these takes at least one goroutine and some other state.

Ideally, this will let us run multiple DHTs side-by-side without keeping one stream per peer per DHT open.