### PR TITLE
metrics: record message/request event even in case of error

### DIFF
--- a/dht_net.go
+++ b/dht_net.go
@@ -83,7 +83,7 @@ func (dht *IpfsDHT) handleNewMessage(s network.Stream) bool {
 		var req pb.Message
 		msgbytes, err := r.ReadMsg()
 		if err != nil {
-			defer r.ReleaseMsg(msgbytes)
+			r.ReleaseMsg(msgbytes)
 			if err == io.EOF {
 				return true
 			}

--- a/dht_net.go
+++ b/dht_net.go
@@ -82,6 +82,7 @@ func (dht *IpfsDHT) handleNewMessage(s network.Stream) bool {
 	for {
 		var req pb.Message
 		msgbytes, err := r.ReadMsg()
+		msgLen := len(msgbytes)
 		if err != nil {
 			r.ReleaseMsg(msgbytes)
 			if err == io.EOF {
@@ -92,25 +93,25 @@ func (dht *IpfsDHT) handleNewMessage(s network.Stream) bool {
 			if err.Error() != "stream reset" {
 				logger.Debugf("error reading message: %#v", err)
 			}
-			stats.RecordWithTags(
-				ctx,
-				[]tag.Mutator{tag.Upsert(metrics.KeyMessageType, "UNKNOWN")},
-				metrics.ReceivedMessageErrors.M(1),
-				metrics.ReceivedMessages.M(1),
-				metrics.ReceivedBytes.M(int64(req.Size())),
-			)
+			if msgLen > 0 {
+				stats.RecordWithTags(ctx,
+					[]tag.Mutator{tag.Upsert(metrics.KeyMessageType, "UNKNOWN")},
+					metrics.ReceivedMessages.M(1),
+					metrics.ReceivedMessageErrors.M(1),
+					metrics.ReceivedBytes.M(int64(msgLen)),
+				)
+			}
 			return false
 		}
 		err = req.Unmarshal(msgbytes)
 		r.ReleaseMsg(msgbytes)
 		if err != nil {
 			logger.Debugf("error unmarshalling message: %#v", err)
-			stats.RecordWithTags(
-				ctx,
+			stats.RecordWithTags(ctx,
 				[]tag.Mutator{tag.Upsert(metrics.KeyMessageType, "UNKNOWN")},
-				metrics.ReceivedMessageErrors.M(1),
 				metrics.ReceivedMessages.M(1),
-				metrics.ReceivedBytes.M(int64(req.Size())),
+				metrics.ReceivedMessageErrors.M(1),
+				metrics.ReceivedBytes.M(int64(msgLen)),
 			)
 			return false
 		}
@@ -118,15 +119,13 @@ func (dht *IpfsDHT) handleNewMessage(s network.Stream) bool {
 		timer.Reset(dhtStreamIdleTimeout)
 
 		startTime := time.Now()
-		ctx, _ := tag.New(
-			ctx,
+		ctx, _ := tag.New(ctx,
 			tag.Upsert(metrics.KeyMessageType, req.GetType().String()),
 		)
 
-		stats.Record(
-			ctx,
+		stats.Record(ctx,
 			metrics.ReceivedMessages.M(1),
-			metrics.ReceivedBytes.M(int64(req.Size())),
+			metrics.ReceivedBytes.M(int64(msgLen)),
 		)
 
 		handler := dht.handlerForMsgType(req.GetType())
@@ -168,15 +167,12 @@ func (dht *IpfsDHT) handleNewMessage(s network.Stream) bool {
 func (dht *IpfsDHT) sendRequest(ctx context.Context, p peer.ID, pmes *pb.Message) (*pb.Message, error) {
 	ctx, _ = tag.New(ctx, metrics.UpsertMessageType(pmes))
 
-	stats.Record(
-		ctx,
-		metrics.SentRequests.M(1),
-		metrics.SentBytes.M(int64(pmes.Size())),
-	)
-
 	ms, err := dht.messageSenderForPeer(ctx, p)
 	if err != nil {
-		stats.Record(ctx, metrics.SentRequestErrors.M(1))
+		stats.Record(ctx,
+			metrics.SentRequests.M(1),
+			metrics.SentRequestErrors.M(1),
+		)
 		return nil, err
 	}
 
@@ -184,18 +180,20 @@ func (dht *IpfsDHT) sendRequest(ctx context.Context, p peer.ID, pmes *pb.Message
 
 	rpmes, err := ms.SendRequest(ctx, pmes)
 	if err != nil {
-		stats.Record(ctx, metrics.SentRequestErrors.M(1))
+		stats.Record(ctx,
+			metrics.SentRequests.M(1),
+			metrics.SentRequestErrors.M(1),
+		)
 		return nil, err
 	}
 
 	// update the peer (on valid msgs only)
 	dht.updateFromMessage(ctx, p, rpmes)
 
-	stats.Record(
-		ctx,
-		metrics.OutboundRequestLatency.M(
-			float64(time.Since(start))/float64(time.Millisecond),
-		),
+	stats.Record(ctx,
+		metrics.SentRequests.M(1),
+		metrics.SentBytes.M(int64(pmes.Size())),
+		metrics.OutboundRequestLatency.M(float64(time.Since(start))/float64(time.Millisecond)),
 	)
 	dht.peerstore.RecordLatency(p, time.Since(start))
 	logger.Event(ctx, "dhtReceivedMessage", dht.self, p, rpmes)
@@ -206,22 +204,27 @@ func (dht *IpfsDHT) sendRequest(ctx context.Context, p peer.ID, pmes *pb.Message
 func (dht *IpfsDHT) sendMessage(ctx context.Context, p peer.ID, pmes *pb.Message) error {
 	ctx, _ = tag.New(ctx, metrics.UpsertMessageType(pmes))
 
-	stats.Record(
-		ctx,
-		metrics.SentMessages.M(1),
-		metrics.SentBytes.M(int64(pmes.Size())),
-	)
-
 	ms, err := dht.messageSenderForPeer(ctx, p)
 	if err != nil {
-		stats.Record(ctx, metrics.SentMessageErrors.M(1))
+		stats.Record(ctx,
+			metrics.SentMessages.M(1),
+			metrics.SentMessageErrors.M(1),
+		)
 		return err
 	}
 
 	if err := ms.SendMessage(ctx, pmes); err != nil {
-		stats.Record(ctx, metrics.SentMessageErrors.M(1))
+		stats.Record(ctx,
+			metrics.SentMessages.M(1),
+			metrics.SentMessageErrors.M(1),
+		)
 		return err
 	}
+
+	stats.Record(ctx,
+		metrics.SentMessages.M(1),
+		metrics.SentBytes.M(int64(pmes.Size())),
+	)
 
 	logger.Event(ctx, "dhtSentMessage", dht.self, p, pmes)
 	return nil


### PR DESCRIPTION
Stumbled upon this while working on https://github.com/libp2p/go-libp2p-kad-dht/issues/453

The metric for message/request sent/received was not incremented when an error occurred but the error count was. This would lead to a meaningless error ratio.
