### PR TITLE
Fix context handling and the TestHang test

### DIFF
--- a/ext_test.go
+++ b/ext_test.go
@@ -21,7 +21,9 @@ import (
 	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
 )
 
-func TestHang(t *testing.T) {
+// Test that one hung request to a peer doesn't prevent another request
+// using that same peer from obeying its context.
+func TestHungRequest(t *testing.T) {
 	ctx := context.Background()
 	mn, err := mocknet.FullMeshConnected(ctx, 2)
 	if err != nil {

--- a/lookup.go
+++ b/lookup.go
@@ -68,6 +68,9 @@ func multihashLoggableKey(mh multihash.Multihash) logging.LoggableMap {
 
 // Kademlia 'node lookup' operation. Returns a channel of the K closest peers
 // to the given key
+//
+// If the context is canceled, this function will return the context error along
+// with the closest K peers it has found so far.
 func (dht *IpfsDHT) GetClosestPeers(ctx context.Context, key string) (<-chan peer.ID, error) {
 	//TODO: I can break the interface! return []peer.ID
 	e := logger.EventBegin(ctx, "getClosestPeers", loggableKey(key))
@@ -121,5 +124,5 @@ func (dht *IpfsDHT) GetClosestPeers(ctx context.Context, key string) (<-chan pee
 		dht.routingTable.ResetCplRefreshedAtForID(kadID, time.Now())
 	}
 
-	return out, nil
+	return out, ctx.Err()
 }


### PR DESCRIPTION
We used to run GetClosestPeers till the context was _about_ to expire, then we'd do the put. That way, we'd succeed even though our query logic was broken. We no longer need to do that.