### PR TITLE
Upgrade DHT version

### DIFF
--- a/dht.go
+++ b/dht.go
@@ -510,6 +510,9 @@ func (dht *IpfsDHT) setMode(m mode) error {
 	}
 }
 
+// moveToServerMode advertises (via libp2p identify updates) that we are able to respond to DHT queries and sets the appropriate stream handlers.
+// Note: We may support responding to queries with protocols aside from our primary ones in order to support
+// interoperability with older versions of the DHT protocol.
 func (dht *IpfsDHT) moveToServerMode() error {
 	dht.mode = modeServer
 	for _, p := range dht.serverProtocols {
@@ -518,6 +521,11 @@ func (dht *IpfsDHT) moveToServerMode() error {
 	return nil
 }
 
+// moveToClientMode stops advertising (and rescinds advertisements via libp2p identify updates) that we are able to
+// respond to DHT queries and removes the appropriate stream handlers. We also kill all inbound streams that were
+// utilizing the handled protocols.
+// Note: We may support responding to queries with protocols aside from our primary ones in order to support
+// interoperability with older versions of the DHT protocol.
 func (dht *IpfsDHT) moveToClientMode() error {
 	dht.mode = modeClient
 	for _, p := range dht.serverProtocols {

--- a/dht.go
+++ b/dht.go
@@ -567,15 +567,6 @@ func (dht *IpfsDHT) Close() error {
 	return dht.proc.Close()
 }
 
-func (dht *IpfsDHT) protocolStrs() []string {
-	pstrs := make([]string, len(dht.protocols))
-	for idx, proto := range dht.protocols {
-		pstrs[idx] = string(proto)
-	}
-
-	return pstrs
-}
-
 func mkDsKey(s string) ds.Key {
 	return ds.NewKey(base32.RawStdEncoding.EncodeToString([]byte(s)))
 }

--- a/dht.go
+++ b/dht.go
@@ -188,7 +188,7 @@ func NewDHT(ctx context.Context, h host.Host, dstore ds.Batching) *IpfsDHT {
 // requests. If you need a peer to respond to DHT requests, use NewDHT instead.
 // NewDHTClient creates a new DHT object with the given peer as the 'local' host
 func NewDHTClient(ctx context.Context, h host.Host, dstore ds.Batching) *IpfsDHT {
-	dht, err := New(ctx, h, Datastore(dstore), Client(true))
+	dht, err := New(ctx, h, Datastore(dstore), Mode(ModeClient))
 	if err != nil {
 		panic(err)
 	}

--- a/dht_net.go
+++ b/dht_net.go
@@ -318,7 +318,7 @@ func (ms *messageSender) prep(ctx context.Context) error {
 		return nil
 	}
 
-	nstr, err := ms.dht.host.NewStream(ctx, ms.p, ms.dht.clientProtocols...)
+	nstr, err := ms.dht.host.NewStream(ctx, ms.p, ms.dht.protocols...)
 	if err != nil {
 		return err
 	}

--- a/dht_net.go
+++ b/dht_net.go
@@ -318,6 +318,9 @@ func (ms *messageSender) prep(ctx context.Context) error {
 		return nil
 	}
 
+	// We only want to speak to peers using our primary protocols. We do not want to query any peer that only speaks
+	// one of the secondary "server" protocols that we happen to support (e.g. older nodes that we can respond to for
+	// backwards compatibility reasons).
 	nstr, err := ms.dht.host.NewStream(ctx, ms.p, ms.dht.protocols...)
 	if err != nil {
 		return err

--- a/dht_net.go
+++ b/dht_net.go
@@ -318,7 +318,7 @@ func (ms *messageSender) prep(ctx context.Context) error {
 		return nil
 	}
 
-	nstr, err := ms.dht.host.NewStream(ctx, ms.p, ms.dht.protocols...)
+	nstr, err := ms.dht.host.NewStream(ctx, ms.p, ms.dht.clientProtocols...)
 	if err != nil {
 		return err
 	}

--- a/dht_options.go
+++ b/dht_options.go
@@ -161,18 +161,6 @@ func Datastore(ds ds.Batching) Option {
 	}
 }
 
-// Client configures whether or not the DHT operates in client-only mode.
-//
-// Defaults to false.
-func Client(only bool) Option {
-	return func(c *config) error {
-		if only {
-			c.mode = ModeClient
-		}
-		return nil
-	}
-}
-
 // Mode configures which mode the DHT operates in (Client, Server, Auto).
 //
 // Defaults to ModeAuto.

--- a/dht_options.go
+++ b/dht_options.go
@@ -23,12 +23,14 @@ const (
 	ModeServer
 )
 
+const DefaultPrefix protocol.ID = "/ipfs"
+
 // Options is a structure containing all the options that can be used when constructing a DHT.
 type config struct {
 	datastore       ds.Batching
 	validator       record.Validator
 	mode            ModeOpt
-	protocols       []protocol.ID
+	protocolPrefix  protocol.ID
 	bucketSize      int
 	disjointPaths   int
 	concurrency     int
@@ -42,12 +44,18 @@ type config struct {
 		autoRefresh         bool
 		latencyTolerance    time.Duration
 	}
+
+	// internal parameters, not publicly exposed
+	protocols, serverProtocols []protocol.ID
+
+	// test parameters
+	testProtocols []protocol.ID
 }
 
-// Apply applies the given options to this Option
-func (o *config) Apply(opts ...Option) error {
+// apply applies the given options to this Option
+func (c *config) apply(opts ...Option) error {
 	for i, opt := range opts {
-		if err := opt(o); err != nil {
+		if err := opt(c); err != nil {
 			return fmt.Errorf("dht option %d failed: %s", i, err)
 		}
 	}
@@ -57,6 +65,8 @@ func (o *config) Apply(opts ...Option) error {
 // Option DHT option type.
 type Option func(*config) error
 
+const defaultBucketSize = 20
+
 // defaults are the default DHT options. This option will be automatically
 // prepended to any options you pass to the DHT constructor.
 var defaults = func(o *config) error {
@@ -64,7 +74,7 @@ var defaults = func(o *config) error {
 		"pk": record.PublicKeyValidator{},
 	}
 	o.datastore = dssync.MutexWrap(ds.NewMapDatastore())
-	o.protocols = DefaultProtocols
+	o.protocolPrefix = DefaultPrefix
 	o.enableProviders = true
 	o.enableValues = true
 
@@ -74,17 +84,47 @@ var defaults = func(o *config) error {
 	o.routingTable.autoRefresh = true
 	o.maxRecordAge = time.Hour * 36
 
-	o.bucketSize = 20
+	o.bucketSize = defaultBucketSize
 	o.concurrency = 3
 
+	return nil
+}
+
+// applyFallbacks sets default DHT options. It is applied after Defaults and any options passed to the constructor in
+// order to allow for defaults that are based on other set options.
+func (c *config) applyFallbacks() error {
+	if c.disjointPaths == 0 {
+		c.disjointPaths = c.bucketSize / 2
+	}
+	return nil
+}
+
+func (c *config) validate() error {
+	if c.protocolPrefix == DefaultPrefix {
+		if c.bucketSize != defaultBucketSize {
+			return fmt.Errorf("protocol prefix %s must use bucket size %d", DefaultPrefix, defaultBucketSize)
+		}
+		if !c.enableProviders {
+			return fmt.Errorf("protocol prefix %s must have providers enabled", DefaultPrefix)
+		}
+		if !c.enableValues {
+			return fmt.Errorf("protocol prefix %s must have values enabled", DefaultPrefix)
+		}
+		if nsval, ok := c.validator.(record.NamespacedValidator); !ok {
+			return fmt.Errorf("protocol prefix %s must use a namespaced validator", DefaultPrefix)
+		} else if len(nsval) > 2 || nsval["pk"] == nil || nsval["ipns"] == nil {
+			return fmt.Errorf("protocol prefix %s must support only the /pk and /ipns namespaces", DefaultPrefix)
+		}
+		return nil
+	}
 	return nil
 }
 
 // RoutingTableLatencyTolerance sets the maximum acceptable latency for peers
 // in the routing table's cluster.
 func RoutingTableLatencyTolerance(latency time.Duration) Option {
-	return func(o *config) error {
-		o.routingTable.latencyTolerance = latency
+	return func(c *config) error {
+		c.routingTable.latencyTolerance = latency
 		return nil
 	}
 }
@@ -92,8 +132,8 @@ func RoutingTableLatencyTolerance(latency time.Duration) Option {
 // RoutingTableRefreshQueryTimeout sets the timeout for routing table refresh
 // queries.
 func RoutingTableRefreshQueryTimeout(timeout time.Duration) Option {
-	return func(o *config) error {
-		o.routingTable.refreshQueryTimeout = timeout
+	return func(c *config) error {
+		c.routingTable.refreshQueryTimeout = timeout
 		return nil
 	}
 }
@@ -105,8 +145,8 @@ func RoutingTableRefreshQueryTimeout(timeout time.Duration) Option {
 // 1. Then searching for a random key in each bucket that hasn't been queried in
 //    the last refresh period.
 func RoutingTableRefreshPeriod(period time.Duration) Option {
-	return func(o *config) error {
-		o.routingTable.refreshPeriod = period
+	return func(c *config) error {
+		c.routingTable.refreshPeriod = period
 		return nil
 	}
 }
@@ -115,8 +155,8 @@ func RoutingTableRefreshPeriod(period time.Duration) Option {
 //
 // Defaults to an in-memory (temporary) map.
 func Datastore(ds ds.Batching) Option {
-	return func(o *config) error {
-		o.datastore = ds
+	return func(c *config) error {
+		c.datastore = ds
 		return nil
 	}
 }
@@ -125,9 +165,9 @@ func Datastore(ds ds.Batching) Option {
 //
 // Defaults to false.
 func Client(only bool) Option {
-	return func(o *config) error {
+	return func(c *config) error {
 		if only {
-			o.mode = ModeClient
+			c.mode = ModeClient
 		}
 		return nil
 	}
@@ -137,8 +177,8 @@ func Client(only bool) Option {
 //
 // Defaults to ModeAuto.
 func Mode(m ModeOpt) Option {
-	return func(o *config) error {
-		o.mode = m
+	return func(c *config) error {
+		c.mode = m
 		return nil
 	}
 }
@@ -147,8 +187,8 @@ func Mode(m ModeOpt) Option {
 //
 // Defaults to a namespaced validator that can only validate public keys.
 func Validator(v record.Validator) Option {
-	return func(o *config) error {
-		o.validator = v
+	return func(c *config) error {
+		c.validator = v
 		return nil
 	}
 }
@@ -161,8 +201,8 @@ func Validator(v record.Validator) Option {
 // myValidator)`, all records with keys starting with `/ipns/` will be validated
 // with `myValidator`.
 func NamespacedValidator(ns string, v record.Validator) Option {
-	return func(o *config) error {
-		nsval, ok := o.validator.(record.NamespacedValidator)
+	return func(c *config) error {
+		nsval, ok := c.validator.(record.NamespacedValidator)
 		if !ok {
 			return fmt.Errorf("can only add namespaced validators to a NamespacedValidator")
 		}
@@ -171,12 +211,13 @@ func NamespacedValidator(ns string, v record.Validator) Option {
 	}
 }
 
-// Protocols sets the protocols for the DHT
+// ProtocolPrefix sets an application specific prefix to be attached to all DHT protocols. For example,
+// /myapp/kad/1.0.0 instead of /ipfs/kad/1.0.0. Prefix should be of the form /myapp.
 //
-// Defaults to dht.DefaultProtocols
-func Protocols(protocols ...protocol.ID) Option {
-	return func(o *config) error {
-		o.protocols = protocols
+// Defaults to dht.DefaultPrefix
+func ProtocolPrefix(prefix protocol.ID) Option {
+	return func(c *config) error {
+		c.protocolPrefix = prefix
 		return nil
 	}
 }
@@ -185,8 +226,8 @@ func Protocols(protocols ...protocol.ID) Option {
 //
 // The default value is 20.
 func BucketSize(bucketSize int) Option {
-	return func(o *config) error {
-		o.bucketSize = bucketSize
+	return func(c *config) error {
+		c.bucketSize = bucketSize
 		return nil
 	}
 }
@@ -195,8 +236,8 @@ func BucketSize(bucketSize int) Option {
 //
 // The default value is 3.
 func Concurrency(alpha int) Option {
-	return func(o *config) error {
-		o.concurrency = alpha
+	return func(c *config) error {
+		c.concurrency = alpha
 		return nil
 	}
 }
@@ -205,8 +246,8 @@ func Concurrency(alpha int) Option {
 //
 // The default value is BucketSize/2.
 func DisjointPaths(d int) Option {
-	return func(o *config) error {
-		o.disjointPaths = d
+	return func(c *config) error {
+		c.disjointPaths = d
 		return nil
 	}
 }
@@ -218,8 +259,8 @@ func DisjointPaths(d int) Option {
 // until the year 2020 (a great time in the future). For that record to stick around
 // it must be rebroadcasted more frequently than once every 'MaxRecordAge'
 func MaxRecordAge(maxAge time.Duration) Option {
-	return func(o *config) error {
-		o.maxRecordAge = maxAge
+	return func(c *config) error {
+		c.maxRecordAge = maxAge
 		return nil
 	}
 }
@@ -228,8 +269,8 @@ func MaxRecordAge(maxAge time.Duration) Option {
 // table. This means that we will neither refresh the routing table periodically
 // nor when the routing table size goes below the minimum threshold.
 func DisableAutoRefresh() Option {
-	return func(o *config) error {
-		o.routingTable.autoRefresh = false
+	return func(c *config) error {
+		c.routingTable.autoRefresh = false
 		return nil
 	}
 }
@@ -241,8 +282,8 @@ func DisableAutoRefresh() Option {
 // WARNING: do not change this unless you're using a forked DHT (i.e., a private
 // network and/or distinct DHT protocols with the `Protocols` option).
 func DisableProviders() Option {
-	return func(o *config) error {
-		o.enableProviders = false
+	return func(c *config) error {
+		c.enableProviders = false
 		return nil
 	}
 }
@@ -255,8 +296,17 @@ func DisableProviders() Option {
 // WARNING: do not change this unless you're using a forked DHT (i.e., a private
 // network and/or distinct DHT protocols with the `Protocols` option).
 func DisableValues() Option {
-	return func(o *config) error {
-		o.enableValues = false
+	return func(c *config) error {
+		c.enableValues = false
+		return nil
+	}
+}
+
+// customProtocols is only to be used for testing. It sets the protocols that the DHT listens on and queries with to be
+// the ones passed in. The custom protocols are still augmented by the Prefix.
+func customProtocols(protos ...protocol.ID) Option {
+	return func(c *config) error {
+		c.testProtocols = protos
 		return nil
 	}
 }

--- a/dht_test.go
+++ b/dht_test.go
@@ -1559,8 +1559,8 @@ func TestProvideDisabled(t *testing.T) {
 			var (
 				optsA, optsB []Option
 			)
-			optsA = append(optsA, opts.Protocols("/dht/provMaybeDisabled"))
-			optsB = append(optsB, opts.Protocols("/dht/provMaybeDisabled"))
+			optsA = append(optsA, opts.ProtocolPrefix("/provMaybeDisabled"))
+			optsB = append(optsB, opts.ProtocolPrefix("/provMaybeDisabled"))
 
 			if !enabledA {
 				optsA = append(optsA, DisableProviders())
@@ -1617,10 +1617,9 @@ func TestProvideDisabled(t *testing.T) {
 }
 
 func TestHandleRemotePeerProtocolChanges(t *testing.T) {
-	proto := protocol.ID("/v1/dht")
 	ctx := context.Background()
 	os := []Option{
-		Protocols(proto),
+		ProtocolPrefix("/test"),
 		Mode(ModeServer),
 		NamespacedValidator("v", blankValidator{}),
 		DisableAutoRefresh(),
@@ -1660,7 +1659,7 @@ func TestGetSetPluggedProtocol(t *testing.T) {
 		defer cancel()
 
 		os := []Option{
-			Protocols("/esh/dht"),
+			ProtocolPrefix("/esh"),
 			Mode(ModeServer),
 			NamespacedValidator("v", blankValidator{}),
 			DisableAutoRefresh(),
@@ -1699,7 +1698,7 @@ func TestGetSetPluggedProtocol(t *testing.T) {
 		defer cancel()
 
 		dhtA, err := New(ctx, bhost.New(swarmt.GenSwarm(t, ctx, swarmt.OptDisableReuseport)), []Option{
-			Protocols("/esh/dht"),
+			ProtocolPrefix("/esh"),
 			Mode(ModeServer),
 			NamespacedValidator("v", blankValidator{}),
 			DisableAutoRefresh(),
@@ -1709,7 +1708,7 @@ func TestGetSetPluggedProtocol(t *testing.T) {
 		}
 
 		dhtB, err := New(ctx, bhost.New(swarmt.GenSwarm(t, ctx, swarmt.OptDisableReuseport)), []Option{
-			Protocols("/lsr/dht"),
+			ProtocolPrefix("/lsr"),
 			Mode(ModeServer),
 			NamespacedValidator("v", blankValidator{}),
 			DisableAutoRefresh(),
@@ -1837,23 +1836,22 @@ func TestProtocolUpgrade(t *testing.T) {
 	// DHT, but only act as a client of the new DHT. In it's capacity as a server it should also only tell queriers
 	// about other DHT servers in the new DHT.
 
-	protoNew := protocol.ID("/dht/B")
-	protoOld := protocol.ID("/dht/C")
+	prefix := opts.ProtocolPrefix(protocol.ID("/test"))
 
 	dhtA, err := New(ctx, bhost.New(swarmt.GenSwarm(t, ctx, swarmt.OptDisableReuseport)),
-		append([]opts.Option{opts.Protocols(protoNew, protoOld), opts.ClientProtocols(protoNew)}, os...)...)
+		append([]opts.Option{prefix}, os...)...)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	dhtB, err := New(ctx, bhost.New(swarmt.GenSwarm(t, ctx, swarmt.OptDisableReuseport)),
-		append([]opts.Option{opts.Protocols(protoNew, protoOld), opts.ClientProtocols(protoNew)}, os...)...)
+		append([]opts.Option{prefix}, os...)...)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	dhtC, err := New(ctx, bhost.New(swarmt.GenSwarm(t, ctx, swarmt.OptDisableReuseport)),
-		append([]opts.Option{opts.Protocols(protoOld)}, os...)...)
+		append([]opts.Option{prefix}, os...)...)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/dht_test.go
+++ b/dht_test.go
@@ -1559,6 +1559,9 @@ func TestProvideDisabled(t *testing.T) {
 			var (
 				optsA, optsB []Option
 			)
+			optsA = append(optsA, opts.Protocols("/dht/provMaybeDisabled"))
+			optsB = append(optsB, opts.Protocols("/dht/provMaybeDisabled"))
+
 			if !enabledA {
 				optsA = append(optsA, DisableProviders())
 			}

--- a/ext_test.go
+++ b/ext_test.go
@@ -30,7 +30,7 @@ func TestHungRequest(t *testing.T) {
 	}
 	hosts := mn.Hosts()
 
-	os := []Option{DisableAutoRefresh()}
+	os := []Option{testPrefix, DisableAutoRefresh()}
 	d, err := New(ctx, hosts[0], os...)
 	if err != nil {
 		t.Fatal(err)
@@ -80,7 +80,7 @@ func TestGetFailures(t *testing.T) {
 	host1 := bhost.New(swarmt.GenSwarm(t, ctx, swarmt.OptDisableReuseport))
 	host2 := bhost.New(swarmt.GenSwarm(t, ctx, swarmt.OptDisableReuseport))
 
-	d, err := New(ctx, host1, DisableAutoRefresh(), Mode(ModeServer))
+	d, err := New(ctx, host1, testPrefix, DisableAutoRefresh(), Mode(ModeServer))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -207,7 +207,7 @@ func TestNotFound(t *testing.T) {
 	}
 	hosts := mn.Hosts()
 
-	os := []Option{DisableAutoRefresh()}
+	os := []Option{testPrefix, DisableAutoRefresh()}
 	d, err := New(ctx, hosts[0], os...)
 	if err != nil {
 		t.Fatal(err)
@@ -287,7 +287,7 @@ func TestLessThanKResponses(t *testing.T) {
 	}
 	hosts := mn.Hosts()
 
-	os := []Option{DisableAutoRefresh()}
+	os := []Option{testPrefix, DisableAutoRefresh()}
 	d, err := New(ctx, hosts[0], os...)
 	if err != nil {
 		t.Fatal(err)
@@ -357,7 +357,7 @@ func TestMultipleQueries(t *testing.T) {
 		t.Fatal(err)
 	}
 	hosts := mn.Hosts()
-	os := []Option{DisableAutoRefresh()}
+	os := []Option{testPrefix, DisableAutoRefresh()}
 	d, err := New(ctx, hosts[0], os...)
 	if err != nil {
 		t.Fatal(err)

--- a/opts/options.go
+++ b/opts/options.go
@@ -11,13 +11,11 @@ import (
 	"github.com/libp2p/go-libp2p-record"
 )
 
-// Deprecated: The old format did not support more than one message per stream, and is not supported
-// or relevant with stream pooling. ProtocolDHT should be used instead.
-const ProtocolDHTOld = "/ipfs/dht"
+const DefaultPrefix protocol.ID = "/ipfs"
 
 var (
-	ProtocolDHT      = dht.ProtocolDHT
-	DefaultProtocols = dht.DefaultProtocols
+	ProtocolDHT      protocol.ID = "/ipfs/kad/2.0.0"
+	DefaultProtocols             = []protocol.ID{ProtocolDHT, "/ipfs/kad/1.0.0"}
 )
 
 // Deprecated: use dht.RoutingTableLatencyTolerance

--- a/opts/options.go
+++ b/opts/options.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	ds "github.com/ipfs/go-datastore"
-	"github.com/libp2p/go-libp2p-core/protocol"
 	"github.com/libp2p/go-libp2p-kad-dht"
 	"github.com/libp2p/go-libp2p-record"
 )
@@ -29,8 +28,16 @@ func RoutingTableRefreshPeriod(period time.Duration) dht.Option {
 // Deprecated: use dht.Datastore
 func Datastore(ds ds.Batching) dht.Option { return dht.Datastore(ds) }
 
-// Deprecated: use dht.Client
-func Client(only bool) dht.Option { return dht.Client(only) }
+// Client configures whether or not the DHT operates in client-only mode.
+//
+// Defaults to false (which is ModeAuto).
+// Deprecated: use dht.Mode(ModeClient)
+func Client(only bool) dht.Option {
+	if only {
+		return dht.Mode(dht.ModeClient)
+	}
+	return dht.Mode(dht.ModeAuto)
+}
 
 // Deprecated: use dht.Mode
 func Mode(m dht.ModeOpt) dht.Option { return dht.Mode(m) }
@@ -42,9 +49,6 @@ func Validator(v record.Validator) dht.Option { return dht.Validator(v) }
 func NamespacedValidator(ns string, v record.Validator) dht.Option {
 	return dht.NamespacedValidator(ns, v)
 }
-
-// Deprecated: use dht.Protocols
-func Protocols(protocols ...protocol.ID) dht.Option { return dht.Protocols(protocols...) }
 
 // Deprecated: use dht.BucketSize
 func BucketSize(bucketSize int) dht.Option { return dht.BucketSize(bucketSize) }

--- a/opts/options.go
+++ b/opts/options.go
@@ -11,13 +11,6 @@ import (
 	"github.com/libp2p/go-libp2p-record"
 )
 
-const DefaultPrefix protocol.ID = "/ipfs"
-
-var (
-	ProtocolDHT      protocol.ID = "/ipfs/kad/2.0.0"
-	DefaultProtocols             = []protocol.ID{ProtocolDHT, "/ipfs/kad/1.0.0"}
-)
-
 // Deprecated: use dht.RoutingTableLatencyTolerance
 func RoutingTableLatencyTolerance(latency time.Duration) dht.Option {
 	return dht.RoutingTableLatencyTolerance(latency)

--- a/records_test.go
+++ b/records_test.go
@@ -318,8 +318,8 @@ func TestValuesDisabled(t *testing.T) {
 			var (
 				optsA, optsB []Option
 			)
-			optsA = append(optsA, dhtopt.ProtocolPrefix("/valuesMaybeDisabled"))
-			optsB = append(optsB, dhtopt.ProtocolPrefix("/valuesMaybeDisabled"))
+			optsA = append(optsA, ProtocolPrefix("/valuesMaybeDisabled"))
+			optsB = append(optsB, ProtocolPrefix("/valuesMaybeDisabled"))
 
 			if !enabledA {
 				optsA = append(optsA, DisableValues())

--- a/records_test.go
+++ b/records_test.go
@@ -318,6 +318,9 @@ func TestValuesDisabled(t *testing.T) {
 			var (
 				optsA, optsB []Option
 			)
+			optsA = append(optsA, dhtopt.Protocols("/dht/valuesMaybeDisabled"))
+			optsB = append(optsB, dhtopt.Protocols("/dht/valuesMaybeDisabled"))
+
 			if !enabledA {
 				optsA = append(optsA, DisableValues())
 			}

--- a/records_test.go
+++ b/records_test.go
@@ -318,8 +318,8 @@ func TestValuesDisabled(t *testing.T) {
 			var (
 				optsA, optsB []Option
 			)
-			optsA = append(optsA, dhtopt.Protocols("/dht/valuesMaybeDisabled"))
-			optsB = append(optsB, dhtopt.Protocols("/dht/valuesMaybeDisabled"))
+			optsA = append(optsA, dhtopt.ProtocolPrefix("/valuesMaybeDisabled"))
+			optsB = append(optsB, dhtopt.ProtocolPrefix("/valuesMaybeDisabled"))
 
 			if !enabledA {
 				optsA = append(optsA, DisableValues())

--- a/subscriber_notifee.go
+++ b/subscriber_notifee.go
@@ -56,7 +56,7 @@ func newSubscriberNotifiee(dht *IpfsDHT) (*subscriberNotifee, error) {
 	dht.plk.Lock()
 	defer dht.plk.Unlock()
 	for _, p := range dht.host.Network().Peers() {
-		protos, err := dht.peerstore.SupportsProtocols(p, dht.protocolStrs()...)
+		protos, err := dht.peerstore.SupportsProtocols(p, dht.clientProtocolStrs()...)
 		if err != nil {
 			return nil, fmt.Errorf("could not check peerstore for protocol support: err: %s", err)
 		}
@@ -110,7 +110,7 @@ func handlePeerIdentificationCompletedEvent(dht *IpfsDHT, e event.EvtPeerIdentif
 	}
 
 	// if the peer supports the DHT protocol, add it to our RT and kick a refresh if needed
-	protos, err := dht.peerstore.SupportsProtocols(e.Peer, dht.protocolStrs()...)
+	protos, err := dht.peerstore.SupportsProtocols(e.Peer, dht.clientProtocolStrs()...)
 	if err != nil {
 		logger.Errorf("could not check peerstore for protocol support: err: %s", err)
 		return
@@ -122,7 +122,7 @@ func handlePeerIdentificationCompletedEvent(dht *IpfsDHT, e event.EvtPeerIdentif
 }
 
 func handlePeerProtocolsUpdatedEvent(dht *IpfsDHT, e event.EvtPeerProtocolsUpdated) {
-	protos, err := dht.peerstore.SupportsProtocols(e.Peer, dht.protocolStrs()...)
+	protos, err := dht.peerstore.SupportsProtocols(e.Peer, dht.clientProtocolStrs()...)
 	if err != nil {
 		logger.Errorf("could not check peerstore for protocol support: err: %s", err)
 		return
@@ -167,7 +167,7 @@ func fixLowPeers(dht *IpfsDHT) {
 	// Passively add peers we already know about
 	for _, p := range dht.host.Network().Peers() {
 		// Don't bother probing, we do that on connect.
-		protos, err := dht.peerstore.SupportsProtocols(p, dht.protocolStrs()...)
+		protos, err := dht.peerstore.SupportsProtocols(p, dht.clientProtocolStrs()...)
 		if err == nil && len(protos) != 0 {
 			dht.Update(dht.Context(), p)
 		}

--- a/subscriber_notifee.go
+++ b/subscriber_notifee.go
@@ -56,7 +56,7 @@ func newSubscriberNotifiee(dht *IpfsDHT) (*subscriberNotifee, error) {
 	dht.plk.Lock()
 	defer dht.plk.Unlock()
 	for _, p := range dht.host.Network().Peers() {
-		protos, err := dht.peerstore.SupportsProtocols(p, dht.clientProtocolStrs()...)
+		protos, err := dht.peerstore.SupportsProtocols(p, dht.protocolStrs()...)
 		if err != nil {
 			return nil, fmt.Errorf("could not check peerstore for protocol support: err: %s", err)
 		}
@@ -110,7 +110,7 @@ func handlePeerIdentificationCompletedEvent(dht *IpfsDHT, e event.EvtPeerIdentif
 	}
 
 	// if the peer supports the DHT protocol, add it to our RT and kick a refresh if needed
-	protos, err := dht.peerstore.SupportsProtocols(e.Peer, dht.clientProtocolStrs()...)
+	protos, err := dht.peerstore.SupportsProtocols(e.Peer, dht.protocolStrs()...)
 	if err != nil {
 		logger.Errorf("could not check peerstore for protocol support: err: %s", err)
 		return
@@ -122,7 +122,7 @@ func handlePeerIdentificationCompletedEvent(dht *IpfsDHT, e event.EvtPeerIdentif
 }
 
 func handlePeerProtocolsUpdatedEvent(dht *IpfsDHT, e event.EvtPeerProtocolsUpdated) {
-	protos, err := dht.peerstore.SupportsProtocols(e.Peer, dht.clientProtocolStrs()...)
+	protos, err := dht.peerstore.SupportsProtocols(e.Peer, dht.protocolStrs()...)
 	if err != nil {
 		logger.Errorf("could not check peerstore for protocol support: err: %s", err)
 		return
@@ -167,7 +167,7 @@ func fixLowPeers(dht *IpfsDHT) {
 	// Passively add peers we already know about
 	for _, p := range dht.host.Network().Peers() {
 		// Don't bother probing, we do that on connect.
-		protos, err := dht.peerstore.SupportsProtocols(p, dht.clientProtocolStrs()...)
+		protos, err := dht.peerstore.SupportsProtocols(p, dht.protocolStrs()...)
 		if err == nil && len(protos) != 0 {
 			dht.Update(dht.Context(), p)
 		}


### PR DESCRIPTION
Relates to libp2p/go-libp2p#780

- Allows for DHT upgrades by having different client and server protocols
- Updates the default protocol IDs.
- Includes a defensive check against people messing with DHT options but still utilizing the default protocol ID

Is currently targeted as merging into `feat/mode-switching`, but after #469 is merged this PR will be redirected to merge onto `cypress`