### PR TITLE
refactor: ProviderManager

### DIFF
--- a/providers/provider_set.go
+++ b/providers/provider_set.go
@@ -1,0 +1,34 @@
+package providers
+
+import (
+	"time"
+
+	"github.com/libp2p/go-libp2p-core/peer"
+)
+
+// A providerSet has the list of providers and the time that they were added
+// It is used as an intermediary data struct between what is stored in the datastore
+// and the list of providers that get passed to the consumer of a .GetProviders call
+type providerSet struct {
+	providers []peer.ID
+	set       map[peer.ID]time.Time
+}
+
+func newProviderSet() *providerSet {
+	return &providerSet{
+		set: make(map[peer.ID]time.Time),
+	}
+}
+
+func (ps *providerSet) Add(p peer.ID) {
+	ps.setVal(p, time.Now())
+}
+
+func (ps *providerSet) setVal(p peer.ID, t time.Time) {
+	_, found := ps.set[p]
+	if !found {
+		ps.providers = append(ps.providers, p)
+	}
+
+	ps.set[p] = t
+}

--- a/providers/providers_manager_test.go
+++ b/providers/providers_manager_test.go
@@ -105,7 +105,7 @@ func TestProvidersSerialization(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	pset, err := loadProvSet(dstore, k)
+	pset, err := loadProviderSet(dstore, k)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/providers/providers_test.go
+++ b/providers/providers_test.go
@@ -31,16 +31,27 @@ func TestProviderManager(t *testing.T) {
 	p.AddProvider(ctx, a, peer.ID("testingprovider"))
 
 	// Not cached
+	// TODO verify that cache is empty
 	resp := p.GetProviders(ctx, a)
 	if len(resp) != 1 {
 		t.Fatal("Could not retrieve provider.")
 	}
 
 	// Cached
+	// TODO verify that cache is populated
 	resp = p.GetProviders(ctx, a)
 	if len(resp) != 1 {
 		t.Fatal("Could not retrieve provider.")
 	}
+
+	p.AddProvider(ctx, a, peer.ID("testingprovider2"))
+	p.AddProvider(ctx, a, peer.ID("testingprovider3"))
+	// TODO verify that cache is already up to date
+	resp = p.GetProviders(ctx, a)
+	if len(resp) != 3 {
+		t.Fatalf("Should have got 3 providers, got %d", len(resp))
+	}
+
 	p.proc.Close()
 }
 
@@ -182,7 +193,7 @@ func TestProvidesExpire(t *testing.T) {
 	// Stop to prevent data races
 	p.Process().Close()
 
-	if p.providers.Len() != 0 {
+	if p.cache.Len() != 0 {
 		t.Fatal("providers map not cleaned up")
 	}
 


### PR DESCRIPTION
Hi folks! As I was going through #487, I found myself having to jump often through the code and keep a lot of things in my brain cache to parse through the codebase, nothing terrible but I couldn't resist the urge to order things a bit and add some code comments.

I hope this refactor is non contentious. It mostly does:
- [x] Add one more set to the TestProviderManager. I also left some TODO as the cache was actually not being checked, there is an assumption that it is working.
- [x] Make sure that names of funcs are consist
- [x] Order funcs (you see the funcs for adding Providers all next to each other and then the ones for getting Providers
- [x] It moves the providerSet into its own file, making the provider-manager file less big
- [x] Adds a lot of code comments