### PR TITLE
Fix test logging & document timing issue on Windows

### DIFF
--- a/dht.go
+++ b/dht.go
@@ -36,7 +36,7 @@ import (
 )
 
 var logger = logging.Logger("dht")
-var rtPvLogger = logging.Logger("dht/rt/peer-validation")
+var rtPvLogger = logging.Logger("dht/rt-validation")
 
 const BaseConnMgrScore = 5
 
@@ -256,7 +256,7 @@ func makeRoutingTable(h host.Host, cfg config) (*kb.RoutingTable, error) {
 	// construct the routing table with a peer validation function
 	pvF := func(c context.Context, p peer.ID) bool {
 		if err := h.Connect(c, peer.AddrInfo{ID: p}); err != nil {
-			rtPvLogger.Errorf("failed to connect to peer %s for validation, err=%s", p, err)
+			rtPvLogger.Infof("failed to connect to peer %s for validation, err=%s", p, err)
 			return false
 		}
 		return true

--- a/notify_test.go
+++ b/notify_test.go
@@ -11,6 +11,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TODO Debug test failures due to timing issue on windows
+// Both tests are timing dependent as can be seen in the 2 seconds timed context that we use in "tu.WaitFor".
+// While both tests work fine on OSX and complete in under a second,
+// they repeatedly fail to complete in the stipulated time on Windows.
+// However, increasing the timeout makes them pass on Windows.
+
 func TestNotifieeMultipleConn(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()


### PR DESCRIPTION
For https://github.com/libp2p/go-libp2p-kad-dht/issues/494