### PR TITLE
feat: return target peer if we know about them

### DIFF
--- a/dht.go
+++ b/dht.go
@@ -487,12 +487,12 @@ func (dht *IpfsDHT) nearestPeersToQuery(pmes *pb.Message, count int) []peer.ID {
 }
 
 // betterPeersToQuery returns nearestPeersToQuery with some additional filtering
-func (dht *IpfsDHT) betterPeersToQuery(pmes *pb.Message, p peer.ID, count int) []peer.ID {
+func (dht *IpfsDHT) betterPeersToQuery(pmes *pb.Message, from peer.ID, count int) []peer.ID {
 	closer := dht.nearestPeersToQuery(pmes, count)
 
 	// no node? nil
 	if closer == nil {
-		logger.Warning("betterPeersToQuery: no closer peers to send:", p)
+		logger.Warning("betterPeersToQuery: no closer peers to send:", from)
 		return nil
 	}
 
@@ -505,7 +505,7 @@ func (dht *IpfsDHT) betterPeersToQuery(pmes *pb.Message, p peer.ID, count int) [
 			return nil
 		}
 		// Dont send a peer back themselves
-		if clp == p {
+		if clp == from {
 			continue
 		}
 


### PR DESCRIPTION
Previously, we'd only return the target peer if we were connected to them. However, this makes it difficult to impossible to find peers that are mostly disconnected from the network.

This change also changes `p` to `from` in several places as `p` is _very_ confusing. We should probably switch away from using `p` everywhere.