### PR TITLE
feat: reduce request read timeout

### DIFF
--- a/dht_net.go
+++ b/dht_net.go
@@ -23,7 +23,7 @@ import (
 	"go.opencensus.io/tag"
 )
 
-var dhtReadMessageTimeout = time.Minute
+var dhtReadMessageTimeout = 10 * time.Second
 var dhtStreamIdleTimeout = 1 * time.Minute
 var ErrReadTimeout = fmt.Errorf("timed out reading response")
 


### PR DESCRIPTION
This should stop us from waiting on unresponsive peers. This only kicks in when we've already _sent_ a request so this:

* Shouldn't be blocked on other requests we're planning on making.
* Shouldn't be blocked on dialing.

We already have a 5s tcp timeout so I'm pretty sure this is the timeout that's slowing us down on the live network.