### PR TITLE
feat: add a v1 compatibility mode

### DIFF
--- a/dht.go
+++ b/dht.go
@@ -223,13 +223,7 @@ func makeDHT(ctx context.Context, h host.Host, cfg config) (*IpfsDHT, error) {
 	var protocols, serverProtocols []protocol.ID
 
 	// check if custom test protocols were set
-	if len(cfg.testProtocols) > 0 {
-		protocols = make([]protocol.ID, len(cfg.testProtocols))
-		for i, p := range cfg.testProtocols {
-			protocols[i] = cfg.protocolPrefix + p
-		}
-		serverProtocols = protocols
-	} else if cfg.v1CompatibleMode {
+	if cfg.v1CompatibleMode {
 		// In compat mode, query/serve using the old protocol.
 		//
 		// DO NOT accept requests on the new protocol. Otherwise:

--- a/dht_options.go
+++ b/dht_options.go
@@ -52,6 +52,9 @@ type config struct {
 
 	// test parameters
 	testProtocols []protocol.ID
+
+	// set to true if we're operating in v1 dht compatible mode
+	v1CompatibleMode bool
 }
 
 func emptyQueryFilter(_ *IpfsDHT, ai peer.AddrInfo) bool  { return true }
@@ -94,6 +97,8 @@ var defaults = func(o *config) error {
 	o.bucketSize = defaultBucketSize
 	o.concurrency = 3
 	o.resiliency = 3
+
+	o.v1CompatibleMode = true
 
 	return nil
 }
@@ -312,6 +317,21 @@ func RoutingTableFilter(filter RouteTableFilterFunc) Option {
 func customProtocols(protos ...protocol.ID) Option {
 	return func(c *config) error {
 		c.testProtocols = protos
+		return nil
+	}
+}
+
+// V1CompatibleMode sets the DHT to operate in V1 compatible mode. In this mode,
+// the DHT node will act like a V1 DHT node (use the V1 protocol names) but will
+// use the V2 query and routing table logic.
+//
+// For now, this option defaults to true for backwards compatibility. In the
+// near future, it will switch to false.
+//
+// This option is perma-unstable and may be removed in the future.
+func V1CompatibleMode(enable bool) Option {
+	return func(c *config) error {
+		c.v1CompatibleMode = enable
 		return nil
 	}
 }

--- a/dht_options.go
+++ b/dht_options.go
@@ -50,9 +50,6 @@ type config struct {
 		peerFilter          RouteTableFilterFunc
 	}
 
-	// test parameters
-	testProtocols []protocol.ID
-
 	// set to true if we're operating in v1 dht compatible mode
 	v1CompatibleMode bool
 }
@@ -308,15 +305,6 @@ func QueryFilter(filter QueryFilterFunc) Option {
 func RoutingTableFilter(filter RouteTableFilterFunc) Option {
 	return func(c *config) error {
 		c.routingTable.peerFilter = filter
-		return nil
-	}
-}
-
-// customProtocols is only to be used for testing. It sets the protocols that the DHT listens on and queries with to be
-// the ones passed in. The custom protocols are still augmented by the Prefix.
-func customProtocols(protos ...protocol.ID) Option {
-	return func(c *config) error {
-		c.testProtocols = protos
 		return nil
 	}
 }

--- a/dht_test.go
+++ b/dht_test.go
@@ -1810,6 +1810,7 @@ func TestProtocolUpgrade(t *testing.T) {
 	defer cancel()
 
 	os := []Option{
+		testPrefix,
 		Mode(ModeServer),
 		NamespacedValidator("v", blankValidator{}),
 		DisableAutoRefresh(),
@@ -1820,19 +1821,19 @@ func TestProtocolUpgrade(t *testing.T) {
 	// about other DHT servers in the new DHT.
 
 	dhtA, err := New(ctx, bhost.New(swarmt.GenSwarm(t, ctx, swarmt.OptDisableReuseport)),
-		append([]Option{testPrefix}, os...)...)
+		append([]Option{V1CompatibleMode(false)}, os...)...)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	dhtB, err := New(ctx, bhost.New(swarmt.GenSwarm(t, ctx, swarmt.OptDisableReuseport)),
-		append([]Option{testPrefix}, os...)...)
+		append([]Option{V1CompatibleMode(false)}, os...)...)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	dhtC, err := New(ctx, bhost.New(swarmt.GenSwarm(t, ctx, swarmt.OptDisableReuseport)),
-		append([]Option{testPrefix, customProtocols(kad1)}, os...)...)
+		append([]Option{V1CompatibleMode(true)}, os...)...)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/subscriber_notifee.go
+++ b/subscriber_notifee.go
@@ -6,6 +6,7 @@ import (
 	"github.com/libp2p/go-libp2p-core/event"
 	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/libp2p/go-libp2p-core/protocol"
 
 	"github.com/libp2p/go-eventbus"
 
@@ -170,12 +171,7 @@ func handleLocalReachabilityChangedEvent(dht *IpfsDHT, e event.EvtLocalReachabil
 // supporting the primary protocols, we do not want to add peers that are speaking obsolete secondary protocols to our
 // routing table
 func (dht *IpfsDHT) validRTPeer(p peer.ID) (bool, error) {
-	pstrs := make([]string, len(dht.protocols))
-	for idx, proto := range dht.protocols {
-		pstrs[idx] = string(proto)
-	}
-
-	protos, err := dht.peerstore.SupportsProtocols(p, pstrs...)
+	protos, err := dht.peerstore.SupportsProtocols(p, protocol.ConvertToStrings(dht.protocols)...)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
When this option is passed, the DHT node will listen on and query _only_ using the old DHT protocol. Importantly, the node won't even pretend to be a new DHT node because it's routing table includes V1 peers.