### PR TITLE
Add structured routing table event logging

### DIFF
--- a/dht.go
+++ b/dht.go
@@ -294,7 +294,7 @@ func makeRoutingTable(dht *IpfsDHT, cfg config) (*kb.RoutingTable, error) {
 	cmgr := dht.host.ConnManager()
 
 	rt.PeerAdded = func(p peer.ID) {
-		PublishRoutingTableEvent(dht.ctx, NewRTEvent(NewRoutingTablePeerUpdatedEvent(
+		PublishRoutingTableEvent(dht.ctx, NewRoutingTableEvent(NewRoutingTablePeerUpdatedEvent(
 			[]peer.ID{p},
 			nil,
 			nil,
@@ -304,7 +304,7 @@ func makeRoutingTable(dht *IpfsDHT, cfg config) (*kb.RoutingTable, error) {
 		cmgr.TagPeer(p, "kbucket", BaseConnMgrScore+commonPrefixLen)
 	}
 	rt.PeerRemoved = func(p peer.ID) {
-		PublishRoutingTableEvent(dht.ctx, NewRTEvent(NewRoutingTablePeerUpdatedEvent(
+		PublishRoutingTableEvent(dht.ctx, NewRoutingTableEvent(NewRoutingTablePeerUpdatedEvent(
 			nil,
 			[]peer.ID{p},
 			nil,

--- a/dht.go
+++ b/dht.go
@@ -294,10 +294,22 @@ func makeRoutingTable(dht *IpfsDHT, cfg config) (*kb.RoutingTable, error) {
 	cmgr := dht.host.ConnManager()
 
 	rt.PeerAdded = func(p peer.ID) {
+		PublishRoutingTableEvent(dht.ctx, NewRTEvent(NewRoutingTablePeerUpdatedEvent(
+			[]peer.ID{p},
+			nil,
+			nil,
+		), nil))
+
 		commonPrefixLen := kb.CommonPrefixLen(self, kb.ConvertPeerID(p))
 		cmgr.TagPeer(p, "kbucket", BaseConnMgrScore+commonPrefixLen)
 	}
 	rt.PeerRemoved = func(p peer.ID) {
+		PublishRoutingTableEvent(dht.ctx, NewRTEvent(NewRoutingTablePeerUpdatedEvent(
+			nil,
+			[]peer.ID{p},
+			nil,
+		), nil))
+
 		cmgr.UntagPeer(p, "kbucket")
 
 		// try to fix the RT

--- a/dht_bootstrap.go
+++ b/dht_bootstrap.go
@@ -59,6 +59,10 @@ func (dht *IpfsDHT) startSelfLookup() {
 			// batch multiple refresh requests if they're all waiting at the same time.
 			waiting = append(waiting, collectWaitingChannels(dht.triggerSelfLookup)...)
 
+			PublishRoutingTableEvent(dht.ctx, NewRTEvent(nil,
+				NewBucketRefreshLaunchedEvent(255, false),
+			))
+
 			// Do a self walk
 			queryCtx, cancel := context.WithTimeout(ctx, dht.rtRefreshQueryTimeout)
 			_, err := dht.GetClosestPeers(queryCtx, string(dht.self))
@@ -194,6 +198,11 @@ func (dht *IpfsDHT) refreshCpls(ctx context.Context) error {
 		}()
 		queryCtx, cancel := context.WithTimeout(ctx, dht.rtRefreshQueryTimeout)
 		defer cancel()
+
+		PublishRoutingTableEvent(dht.ctx, NewRTEvent(nil,
+			NewBucketRefreshLaunchedEvent(int(cpl), false),
+		))
+
 		err := f(queryCtx)
 		if err == context.DeadlineExceeded && queryCtx.Err() == context.DeadlineExceeded && ctx.Err() == nil {
 			return nil
@@ -206,6 +215,9 @@ func (dht *IpfsDHT) refreshCpls(ctx context.Context) error {
 	var merr error
 	for cpl, lastRefreshedAt := range trackedCpls {
 		if time.Since(lastRefreshedAt) <= dht.rtRefreshInterval {
+			PublishRoutingTableEvent(dht.ctx, NewRTEvent(nil,
+				NewBucketRefreshLaunchedEvent(cpl, true),
+			))
 			continue
 		}
 
@@ -213,6 +225,9 @@ func (dht *IpfsDHT) refreshCpls(ctx context.Context) error {
 		randPeer, err := dht.routingTable.GenRandPeerID(uint(cpl))
 		if err != nil {
 			logger.Errorw("failed to generate peer ID", "cpl", cpl, "error", err)
+			PublishRoutingTableEvent(dht.ctx, NewRTEvent(nil,
+				NewBucketRefreshLaunchedEvent(cpl, true),
+			))
 			continue
 		}
 

--- a/dht_bootstrap.go
+++ b/dht_bootstrap.go
@@ -59,7 +59,7 @@ func (dht *IpfsDHT) startSelfLookup() {
 			// batch multiple refresh requests if they're all waiting at the same time.
 			waiting = append(waiting, collectWaitingChannels(dht.triggerSelfLookup)...)
 
-			PublishRoutingTableEvent(dht.ctx, NewRTEvent(nil,
+			PublishRoutingTableEvent(dht.ctx, NewRoutingTableEvent(nil,
 				NewBucketRefreshLaunchedEvent(255, false),
 			))
 
@@ -199,7 +199,7 @@ func (dht *IpfsDHT) refreshCpls(ctx context.Context) error {
 		queryCtx, cancel := context.WithTimeout(ctx, dht.rtRefreshQueryTimeout)
 		defer cancel()
 
-		PublishRoutingTableEvent(dht.ctx, NewRTEvent(nil,
+		PublishRoutingTableEvent(dht.ctx, NewRoutingTableEvent(nil,
 			NewBucketRefreshLaunchedEvent(int(cpl), false),
 		))
 
@@ -215,7 +215,7 @@ func (dht *IpfsDHT) refreshCpls(ctx context.Context) error {
 	var merr error
 	for cpl, lastRefreshedAt := range trackedCpls {
 		if time.Since(lastRefreshedAt) <= dht.rtRefreshInterval {
-			PublishRoutingTableEvent(dht.ctx, NewRTEvent(nil,
+			PublishRoutingTableEvent(dht.ctx, NewRoutingTableEvent(nil,
 				NewBucketRefreshLaunchedEvent(cpl, true),
 			))
 			continue
@@ -225,7 +225,7 @@ func (dht *IpfsDHT) refreshCpls(ctx context.Context) error {
 		randPeer, err := dht.routingTable.GenRandPeerID(uint(cpl))
 		if err != nil {
 			logger.Errorw("failed to generate peer ID", "cpl", cpl, "error", err)
-			PublishRoutingTableEvent(dht.ctx, NewRTEvent(nil,
+			PublishRoutingTableEvent(dht.ctx, NewRoutingTableEvent(nil,
 				NewBucketRefreshLaunchedEvent(cpl, true),
 			))
 			continue

--- a/rt_events.go
+++ b/rt_events.go
@@ -8,7 +8,7 @@ import (
 	"github.com/libp2p/go-libp2p-core/peer"
 )
 
-func NewRTEvent(
+func NewRoutingTableEvent(
 	peerUpdate *RoutingTablePeerUpdatedEvent,
 	bucketEvt *BucketRefreshLaunchedEvent,
 ) *RoutingTableEvent {

--- a/rt_events.go
+++ b/rt_events.go
@@ -1,0 +1,144 @@
+package dht
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/libp2p/go-libp2p-core/peer"
+)
+
+func NewRTEvent(
+	peerUpdate *RoutingTablePeerUpdatedEvent,
+	bucketEvt *BucketRefreshLaunchedEvent,
+) *RoutingTableEvent {
+	return &RoutingTableEvent{
+		PeerUpdated:           peerUpdate,
+		BucketRefreshLaunched: bucketEvt,
+	}
+}
+
+// RoutingTableEvent is emitted for every notable event that happens to the routing table.
+// RoutingTableEvent supports JSON marshalling because all of its fields do, recursively.
+type RoutingTableEvent struct {
+	// PeerUpdated, if not nil, describes a peer's state in the routing table being modified
+	PeerUpdated *RoutingTablePeerUpdatedEvent
+	// BucketRefreshLaunched, if not nil, describes a bucket refresh being attempted
+	BucketRefreshLaunched *BucketRefreshLaunchedEvent
+}
+
+func NewRoutingTablePeerUpdatedEvent(
+	added []peer.ID,
+	removed []peer.ID,
+	updated []*RTPeerScoreUpdate,
+) *RoutingTablePeerUpdatedEvent {
+	return &RoutingTablePeerUpdatedEvent{
+		Added:   NewPeerKadIDSlice(added),
+		Removed: NewPeerKadIDSlice(removed),
+		Updated: updated,
+	}
+}
+
+// RoutingTablePeerUpdatedEvent describes a peer being added to the routing table
+type RoutingTablePeerUpdatedEvent struct {
+	// Added is a set of peers whose are being added to the routing table
+	Added []*PeerKadID
+	// Removed is a set of peers whose are being removed from the routing table
+	Removed []*PeerKadID
+	// Updated is a set of peer whose routing table scores are being updated
+	Updated []*RTPeerScoreUpdate
+}
+
+type RTPeerScoreUpdate struct {
+	Peer  *PeerKadID
+	Score time.Time
+}
+
+func NewRTPeerScoreUpdate(p peer.ID, score time.Time) *RTPeerScoreUpdate {
+	return &RTPeerScoreUpdate{Peer: NewPeerKadID(p), Score: score}
+}
+
+// BucketRefreshLaunchedEvent describes a bucket refresh event.
+type BucketRefreshLaunchedEvent struct {
+	// CPL is the common prefix length of the bucket being refreshed
+	CPL int
+	// Skipped is whether the refresh is being skipped
+	Skipped bool
+}
+
+func NewBucketRefreshLaunchedEvent(cpl int, skipped bool) *BucketRefreshLaunchedEvent {
+	return &BucketRefreshLaunchedEvent{CPL: cpl, Skipped: skipped}
+}
+
+type rtEventKey struct{}
+
+// TODO: rtEventChannel copies the implementation of eventChanel.
+// The two should be refactored to use a common event channel implementation.
+// A common implementation needs to rethink the signature of RegisterForEvents,
+// because returning a typed channel cannot be made polymorphic without creating
+// additional "adapter" channels. This will be easier to handle when Go
+// introduces generics.
+type rtEventChannel struct {
+	mu  sync.Mutex
+	ctx context.Context
+	ch  chan<- *RoutingTableEvent
+}
+
+// waitThenClose is spawned in a goroutine when the channel is registered. This
+// safely cleans up the channel when the context has been canceled.
+func (e *rtEventChannel) waitThenClose() {
+	<-e.ctx.Done()
+	e.mu.Lock()
+	close(e.ch)
+	// 1. Signals that we're done.
+	// 2. Frees memory (in case we end up hanging on to this for a while).
+	e.ch = nil
+	e.mu.Unlock()
+}
+
+// send sends an event on the event channel, aborting if either the passed or
+// the internal context expire.
+func (e *rtEventChannel) send(ctx context.Context, ev *RoutingTableEvent) {
+	e.mu.Lock()
+	// Closed.
+	if e.ch == nil {
+		e.mu.Unlock()
+		return
+	}
+	// in case the passed context is unrelated, wait on both.
+	select {
+	case e.ch <- ev:
+	case <-e.ctx.Done():
+	case <-ctx.Done():
+	}
+	e.mu.Unlock()
+}
+
+// RegisterForRoutingTableEvents registers a routing table event channel with the given context.
+// The returned context can be passed in when creating a DHT to receive routing table events on
+// the returned channels.
+//
+// The passed context MUST be canceled when the caller is no longer interested
+// in query events.
+func RegisterForRoutingTableEvents(ctx context.Context) (context.Context, <-chan *RoutingTableEvent) {
+	ch := make(chan *RoutingTableEvent, RoutingTableEventBufferSize)
+	ech := &rtEventChannel{ch: ch, ctx: ctx}
+	go ech.waitThenClose()
+	return context.WithValue(ctx, rtEventKey{}, ech), ch
+}
+
+// Number of events to buffer.
+var RoutingTableEventBufferSize = 16
+
+// PublishRoutingTableEvent publishes a query event to the query event channel
+// associated with the given context, if any.
+func PublishRoutingTableEvent(ctx context.Context, ev *RoutingTableEvent) {
+	ich := ctx.Value(rtEventKey{})
+	if ich == nil {
+		return
+	}
+
+	// We *want* to panic here.
+	ech := ich.(*rtEventChannel)
+	ech.send(ctx, ev)
+}


### PR DESCRIPTION
Seeing the events emitted from the routing table in a structured way should allow us to reason about things more clearly. This preliminary stab at things has already proven helpful in discovering the routing table issues in https://github.com/libp2p/go-libp2p-kbucket/pull/71, some unit tests or Go integration tests probably should've caught that but logging could be useful for understanding routing table evolution as well.

@petar lmk if this is the kind of thing you had in mind and if you have any suggestions