### PR TITLE
fix incorrect error handling during provider record lookups

### DIFF
--- a/routing.go
+++ b/routing.go
@@ -606,7 +606,7 @@ func (dht *IpfsDHT) findProvidersAsyncRoutine(ctx context.Context, key multihash
 		},
 	)
 
-	if err != nil && ctx.Err() == nil {
+	if err == nil && ctx.Err() == nil {
 		dht.refreshRTIfNoShortcut(kb.ConvertKey(string(key)), lookupRes)
 	}
 }


### PR DESCRIPTION
🤦‍♂

@Stebalien do we want a unit test here that just checks that we don't panic when doing a FindProviders with an empty routing table, or not worth it? 