### PR TITLE
fix: handle empty keys

### DIFF
--- a/handlers_test.go
+++ b/handlers_test.go
@@ -67,6 +67,27 @@ func TestCleanRecord(t *testing.T) {
 	}
 }
 
+func TestBadMessage(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	dht := setupDHT(ctx, t, false)
+
+	for _, typ := range []pb.Message_MessageType{
+		pb.Message_PUT_VALUE, pb.Message_GET_VALUE, pb.Message_ADD_PROVIDER,
+		pb.Message_GET_PROVIDERS, pb.Message_FIND_NODE,
+	} {
+		msg := &pb.Message{
+			Type: typ,
+			// explicitly avoid the key.
+		}
+		_, err := dht.handlerForMsgType(typ)(ctx, dht.Host().ID(), msg)
+		if err == nil {
+			t.Fatalf("expected processing message to fail for type %s", pb.Message_FIND_NODE)
+		}
+	}
+}
+
 func BenchmarkHandleFindPeer(b *testing.B) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/lookup.go
+++ b/lookup.go
@@ -72,6 +72,9 @@ func (lk loggableKeyBytes) String() string {
 // If the context is canceled, this function will return the context error along
 // with the closest K peers it has found so far.
 func (dht *IpfsDHT) GetClosestPeers(ctx context.Context, key string) (<-chan peer.ID, error) {
+	if key == "" {
+		return nil, fmt.Errorf("can't lookup empty key")
+	}
 	//TODO: I can break the interface! return []peer.ID
 	lookupRes, err := dht.runLookupWithFollowup(ctx, key,
 		func(ctx context.Context, p peer.ID) ([]*peer.AddrInfo, error) {

--- a/pb/message.go
+++ b/pb/message.go
@@ -5,7 +5,6 @@ import (
 	"github.com/libp2p/go-libp2p-core/peer"
 
 	logging "github.com/ipfs/go-log"
-	b58 "github.com/mr-tron/base58/base58"
 	ma "github.com/multiformats/go-multiaddr"
 )
 
@@ -136,16 +135,6 @@ func (m *Message) GetClusterLevel() int {
 func (m *Message) SetClusterLevel(level int) {
 	lvl := int32(level)
 	m.ClusterLevelRaw = lvl + 1
-}
-
-// Loggable turns a Message into machine-readable log output
-func (m *Message) Loggable() map[string]interface{} {
-	return map[string]interface{}{
-		"message": map[string]string{
-			"type": m.Type.String(),
-			"key":  b58.Encode([]byte(m.GetKey())),
-		},
-	}
 }
 
 // ConnectionType returns a Message_ConnectionType associated with the


### PR DESCRIPTION
Handle empty keys, both when sent in RPC requests and in the local API.