### PR TITLE
fix: use the routing table filter

### DIFF
--- a/dht_filters_test.go
+++ b/dht_filters_test.go
@@ -1,9 +1,16 @@
 package dht
 
 import (
+	"context"
+	"net"
 	"testing"
 
+	ic "github.com/libp2p/go-libp2p-core/crypto"
+	"github.com/libp2p/go-libp2p-core/network"
+	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/multiformats/go-multiaddr"
+	ma "github.com/multiformats/go-multiaddr"
+	manet "github.com/multiformats/go-multiaddr-net"
 )
 
 func TestIsRelay(t *testing.T) {
@@ -20,4 +27,40 @@ func TestIsRelay(t *testing.T) {
 		t.Fatalf("thought %s was a relay", a)
 	}
 
+}
+
+type mockConn struct {
+	local  peer.AddrInfo
+	remote peer.AddrInfo
+}
+
+func (m *mockConn) Close() error                       { return nil }
+func (m *mockConn) NewStream() (network.Stream, error) { return nil, nil }
+func (m *mockConn) GetStreams() []network.Stream       { return []network.Stream{} }
+func (m *mockConn) Stat() network.Stat                 { return network.Stat{Direction: network.DirOutbound} }
+func (m *mockConn) LocalMultiaddr() ma.Multiaddr       { return m.local.Addrs[0] }
+func (m *mockConn) RemoteMultiaddr() ma.Multiaddr      { return m.remote.Addrs[0] }
+func (m *mockConn) LocalPeer() peer.ID                 { return m.local.ID }
+func (m *mockConn) LocalPrivateKey() ic.PrivKey        { return nil }
+func (m *mockConn) RemotePeer() peer.ID                { return m.remote.ID }
+func (m *mockConn) RemotePublicKey() ic.PubKey         { return nil }
+
+func TestFilterCaching(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	d := setupDHT(ctx, t, true)
+
+	remote, _ := manet.FromIP(net.IPv4(8, 8, 8, 8))
+	if PrivateRoutingTableFilter(d, []network.Conn{&mockConn{
+		local:  d.Host().Peerstore().PeerInfo(d.Host().ID()),
+		remote: peer.AddrInfo{ID: "", Addrs: []ma.Multiaddr{remote}},
+	}}) {
+		t.Fatal("filter should prevent public remote peers.")
+	}
+
+	r1 := getCachedRouter()
+	r2 := getCachedRouter()
+	if r1 != r2 {
+		t.Fatal("router should be returned multiple times.")
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/gogo/protobuf v1.3.1
+	github.com/google/gopacket v1.1.17
 	github.com/google/uuid v1.1.1
 	github.com/hashicorp/go-multierror v1.1.0
 	github.com/hashicorp/golang-lru v0.5.4
@@ -24,7 +25,6 @@ require (
 	github.com/libp2p/go-libp2p-testing v0.1.1
 	github.com/libp2p/go-msgio v0.0.4
 	github.com/libp2p/go-netroute v0.1.2
-	github.com/mr-tron/base58 v1.1.3
 	github.com/multiformats/go-base32 v0.0.3
 	github.com/multiformats/go-multiaddr v0.2.1
 	github.com/multiformats/go-multiaddr-dns v0.2.0

--- a/subscriber_notifee.go
+++ b/subscriber_notifee.go
@@ -172,11 +172,11 @@ func handleLocalReachabilityChangedEvent(dht *IpfsDHT, e event.EvtLocalReachabil
 // routing table
 func (dht *IpfsDHT) validRTPeer(p peer.ID) (bool, error) {
 	protos, err := dht.peerstore.SupportsProtocols(p, protocol.ConvertToStrings(dht.protocols)...)
-	if err != nil {
+	if len(protos) == 0 || err != nil {
 		return false, err
 	}
 
-	return len(protos) > 0, nil
+	return dht.routingTablePeerFilter == nil || dht.routingTablePeerFilter(dht, dht.Host().Network().ConnsToPeer(p)), nil
 }
 
 func (nn *subscriberNotifee) Disconnected(n network.Network, v network.Conn) {


### PR DESCRIPTION
Also, cache routing info so we don't need to repeatedly recompute it.

We should also consider caching known-filtered peers... but we can do that after
profiling.