### PR TITLE
query.go: Remove shuffle comment

### DIFF
--- a/query.go
+++ b/query.go
@@ -138,7 +138,7 @@ processFollowUp:
 }
 
 func (dht *IpfsDHT) runQuery(ctx context.Context, target string, queryFn queryFn, stopFn stopFn) (*lookupWithFollowupResult, error) {
-	// pick the K closest peers to the key in our Routing table and shuffle them.
+	// pick the K closest peers to the key in our Routing table.
 	targetKadID := kb.ConvertKey(target)
 	seedPeers := dht.routingTable.NearestPeers(targetKadID, dht.bucketSize)
 	if len(seedPeers) == 0 {


### PR DESCRIPTION
As far as I can tell the list of peers is not being shuffled in this function. In addition [`NearestPeers`](https://github.com/libp2p/go-libp2p-kbucket/blob/a8232c8ad2e784b3966d04f86a28f9223d1d11a8/table.go#L323) returns them in sorted order.

Hope I am not missing something.