### PR TITLE
feat: provider manager option

### DIFF
--- a/dht_options.go
+++ b/dht_options.go
@@ -11,6 +11,7 @@ import (
 	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/protocol"
+	"github.com/libp2p/go-libp2p-kad-dht/providers"
 	record "github.com/libp2p/go-libp2p-record"
 )
 
@@ -45,6 +46,7 @@ type config struct {
 	maxRecordAge     time.Duration
 	enableProviders  bool
 	enableValues     bool
+	providerStore    providers.ProviderStore
 	queryPeerFilter  QueryFilterFunc
 
 	routingTable struct {
@@ -344,6 +346,14 @@ func DisableProviders() Option {
 func DisableValues() Option {
 	return func(c *config) error {
 		c.enableValues = false
+		return nil
+	}
+}
+
+// ProviderStore sets the provider storage manager.
+func ProviderStore(ps providers.ProviderStore) Option {
+	return func(c *config) error {
+		c.providerStore = ps
 		return nil
 	}
 }

--- a/dht_test.go
+++ b/dht_test.go
@@ -24,8 +24,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	pb "github.com/libp2p/go-libp2p-kad-dht/pb"
 	test "github.com/libp2p/go-libp2p-kad-dht/internal/testing"
+	pb "github.com/libp2p/go-libp2p-kad-dht/pb"
 
 	"github.com/ipfs/go-cid"
 	u "github.com/ipfs/go-ipfs-util"
@@ -664,7 +664,7 @@ func TestLocalProvides(t *testing.T) {
 
 	for _, c := range testCaseCids {
 		for i := 0; i < 3; i++ {
-			provs := dhts[i].ProviderManager.GetProviders(ctx, c.Hash())
+			provs := dhts[i].ProviderStore().GetProviders(ctx, c.Hash())
 			if len(provs) > 0 {
 				t.Fatal("shouldnt know this")
 			}
@@ -1277,7 +1277,7 @@ func TestClientModeConnect(t *testing.T) {
 
 	c := testCaseCids[0]
 	p := peer.ID("TestPeer")
-	a.ProviderManager.AddProvider(ctx, c.Hash(), p)
+	a.ProviderStore().AddProvider(ctx, c.Hash(), p)
 	time.Sleep(time.Millisecond * 5) // just in case...
 
 	provs, err := b.FindProviders(ctx, c)
@@ -1542,7 +1542,7 @@ func TestProvideDisabled(t *testing.T) {
 				if err != routing.ErrNotSupported {
 					t.Fatal("get should have failed on node B")
 				}
-				provs := dhtB.ProviderManager.GetProviders(ctx, kHash)
+				provs := dhtB.providerStore.GetProviders(ctx, kHash)
 				if len(provs) != 0 {
 					t.Fatal("node B should not have found local providers")
 				}
@@ -1558,7 +1558,7 @@ func TestProvideDisabled(t *testing.T) {
 					t.Fatal("node A should not have found providers")
 				}
 			}
-			provAddrs := dhtA.ProviderManager.GetProviders(ctx, kHash)
+			provAddrs := dhtA.ProviderStore().GetProviders(ctx, kHash)
 			if len(provAddrs) != 0 {
 				t.Fatal("node A should not have found local providers")
 			}

--- a/handlers.go
+++ b/handlers.go
@@ -317,7 +317,7 @@ func (dht *IpfsDHT) handleGetProviders(ctx context.Context, p peer.ID, pmes *pb.
 	resp := pb.NewMessage(pmes.GetType(), pmes.GetKey(), pmes.GetClusterLevel())
 
 	// setup providers
-	providers := dht.ProviderManager.GetProviders(ctx, key)
+	providers := dht.providerStore.GetProviders(ctx, key)
 
 	if len(providers) > 0 {
 		// TODO: pstore.PeerInfos should move to core (=> peerstore.AddrInfos).
@@ -365,7 +365,7 @@ func (dht *IpfsDHT) handleAddProvider(ctx context.Context, p peer.ID, pmes *pb.M
 			// add the received addresses to our peerstore.
 			dht.peerstore.AddAddrs(pi.ID, pi.Addrs, peerstore.ProviderAddrTTL)
 		}
-		dht.ProviderManager.AddProvider(ctx, key, p)
+		dht.providerStore.AddProvider(ctx, key, p)
 	}
 
 	return nil, nil

--- a/providers/providers_manager.go
+++ b/providers/providers_manager.go
@@ -30,6 +30,12 @@ var lruCacheSize = 256
 var batchBufferSize = 256
 var log = logging.Logger("providers")
 
+// ProviderStore stores and retrieves provider records.
+type ProviderStore interface {
+	AddProvider(ctx context.Context, k []byte, val peer.ID)
+	GetProviders(ctx context.Context, k []byte) []peer.ID
+}
+
 // ProviderManager adds and pulls providers out of the datastore,
 // caching them in between
 type ProviderManager struct {

--- a/providers/providers_manager_test.go
+++ b/providers/providers_manager_test.go
@@ -21,6 +21,10 @@ import (
 	// lds "github.com/ipfs/go-ds-leveldb"
 )
 
+func TestProviderManagerImplementsProviderStore(t *testing.T) {
+	var _ ProviderStore = (*ProviderManager)(nil)
+}
+
 func TestProviderManager(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/routing.go
+++ b/routing.go
@@ -403,7 +403,7 @@ func (dht *IpfsDHT) Provide(ctx context.Context, key cid.Cid, brdcst bool) (err 
 	keyMH := key.Hash()
 
 	// add self locally
-	dht.ProviderManager.AddProvider(ctx, keyMH, dht.self)
+	dht.providerStore.AddProvider(ctx, keyMH, dht.self)
 	if !brdcst {
 		return nil
 	}
@@ -537,7 +537,7 @@ func (dht *IpfsDHT) findProvidersAsyncRoutine(ctx context.Context, key multihash
 		ps = peer.NewLimitedSet(count)
 	}
 
-	provs := dht.ProviderManager.GetProviders(ctx, key)
+	provs := dht.providerStore.GetProviders(ctx, key)
 	for _, p := range provs {
 		// NOTE: Assuming that this list of peers is unique
 		if ps.TryAdd(p) {


### PR DESCRIPTION
The PR adds an option to allow passing your own instance of provider manager when constructing a DHT.

---

In Hydra, we have many heads (up to 200 currently) that have their own DHT instances and corresponding provider managers. They are _all_ caching records and performing GC on a shared datastore.

I'd like to avoid multiple GC runs and out-of-sync caches. In this PR I seek to fix this by enabling the DHT to accept a provider manager as an option, allowing a single provider manager to be used for _all hydra **heads**_.

We've defined a `ProviderStore` interface that `ProviderManager` (already) implements. By using an interface we give ourselves room to pass a custom implementation (at a later date maybe...since we will encounter the problem again when using the postgres datastore to share between _Hydras_, in addition to Hydra _heads_).

⚠️ BREAKING CHANGE - it removes the `dht.ProviderManager` property in favor of a `dht.ProviderStore()` function.