### PR TITLE
feat: set provider manager options

### DIFF
--- a/dht.go
+++ b/dht.go
@@ -275,7 +275,11 @@ func makeDHT(ctx context.Context, h host.Host, cfg config) (*IpfsDHT, error) {
 	// the DHT context should be done when the process is closed
 	dht.ctx = goprocessctx.WithProcessClosing(ctxTags, dht.proc)
 
-	dht.ProviderManager = providers.NewProviderManager(dht.ctx, h.ID(), cfg.datastore)
+	pm, err := providers.NewProviderManager(dht.ctx, h.ID(), cfg.datastore, cfg.providersOptions...)
+	if err != nil {
+		return nil, err
+	}
+	dht.ProviderManager = pm
 
 	return dht, nil
 }

--- a/dht_options.go
+++ b/dht_options.go
@@ -351,6 +351,10 @@ func DisableValues() Option {
 }
 
 // ProvidersOptions are options passed directly to the provider manager.
+//
+// The provider manager adds and gets provider records from the datastore, cahing
+// them in between. These options are passed to the provider manager allowing
+// customisation of things like the GC interval and cache implementation.
 func ProvidersOptions(opts []providers.Option) Option {
 	return func(c *config) error {
 		c.providersOptions = opts

--- a/dht_options.go
+++ b/dht_options.go
@@ -11,6 +11,7 @@ import (
 	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/protocol"
+	"github.com/libp2p/go-libp2p-kad-dht/providers"
 	record "github.com/libp2p/go-libp2p-record"
 )
 
@@ -45,6 +46,7 @@ type config struct {
 	maxRecordAge     time.Duration
 	enableProviders  bool
 	enableValues     bool
+	providersOptions []providers.Option
 	queryPeerFilter  QueryFilterFunc
 
 	routingTable struct {
@@ -344,6 +346,14 @@ func DisableProviders() Option {
 func DisableValues() Option {
 	return func(c *config) error {
 		c.enableValues = false
+		return nil
+	}
+}
+
+// ProvidersOptions are options passed directly to the provider manager.
+func ProvidersOptions(opts []providers.Option) Option {
+	return func(c *config) error {
+		c.providersOptions = opts
 		return nil
 	}
 }

--- a/providers/providers_manager.go
+++ b/providers/providers_manager.go
@@ -102,17 +102,17 @@ type getProv struct {
 
 // NewProviderManager constructor
 func NewProviderManager(ctx context.Context, local peer.ID, dstore ds.Batching, opts ...Option) (*ProviderManager, error) {
-	var options options
-	if err := options.apply(append([]Option{defaults}, opts...)...); err != nil {
+	var cfg options
+	if err := cfg.apply(append([]Option{defaults}, opts...)...); err != nil {
 		return nil, err
 	}
 	pm := new(ProviderManager)
 	pm.getprovs = make(chan *getProv)
 	pm.newprovs = make(chan *addProv)
 	pm.dstore = autobatch.NewAutoBatching(dstore, batchBufferSize)
-	pm.cache = options.cache
+	pm.cache = cfg.cache
 	pm.proc = goprocessctx.WithContext(ctx)
-	pm.cleanupInterval = options.cleanupInterval
+	pm.cleanupInterval = cfg.cleanupInterval
 	pm.proc.Go(pm.run)
 	return pm, nil
 }

--- a/providers/providers_manager_test.go
+++ b/providers/providers_manager_test.go
@@ -26,7 +26,10 @@ func TestProviderManager(t *testing.T) {
 	defer cancel()
 
 	mid := peer.ID("testing")
-	p := NewProviderManager(ctx, mid, dssync.MutexWrap(ds.NewMapDatastore()))
+	p, err := NewProviderManager(ctx, mid, dssync.MutexWrap(ds.NewMapDatastore()))
+	if err != nil {
+		t.Fatal(err)
+	}
 	a := u.Hash([]byte("test"))
 	p.AddProvider(ctx, a, peer.ID("testingprovider"))
 
@@ -64,7 +67,10 @@ func TestProvidersDatastore(t *testing.T) {
 	defer cancel()
 
 	mid := peer.ID("testing")
-	p := NewProviderManager(ctx, mid, dssync.MutexWrap(ds.NewMapDatastore()))
+	p, err := NewProviderManager(ctx, mid, dssync.MutexWrap(ds.NewMapDatastore()))
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer p.proc.Close()
 
 	friend := peer.ID("friend")
@@ -144,7 +150,10 @@ func TestProvidesExpire(t *testing.T) {
 
 	ds := dssync.MutexWrap(ds.NewMapDatastore())
 	mid := peer.ID("testing")
-	p := NewProviderManager(ctx, mid, ds)
+	p, err := NewProviderManager(ctx, mid, ds)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	peers := []peer.ID{"a", "b"}
 	var mhs []mh.Multihash
@@ -249,7 +258,10 @@ func TestLargeProvidersSet(t *testing.T) {
 	}
 
 	mid := peer.ID("myself")
-	p := NewProviderManager(ctx, mid, dstore)
+	p, err := NewProviderManager(ctx, mid, dstore)
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer p.proc.Close()
 
 	var mhs []mh.Multihash
@@ -281,7 +293,10 @@ func TestUponCacheMissProvidersAreReadFromDatastore(t *testing.T) {
 	p1, p2 := peer.ID("a"), peer.ID("b")
 	h1 := u.Hash([]byte("1"))
 	h2 := u.Hash([]byte("2"))
-	pm := NewProviderManager(ctx, p1, dssync.MutexWrap(ds.NewMapDatastore()))
+	pm, err := NewProviderManager(ctx, p1, dssync.MutexWrap(ds.NewMapDatastore()))
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// add provider
 	pm.AddProvider(ctx, h1, p1)
@@ -302,7 +317,10 @@ func TestWriteUpdatesCache(t *testing.T) {
 
 	p1, p2 := peer.ID("a"), peer.ID("b")
 	h1 := u.Hash([]byte("1"))
-	pm := NewProviderManager(ctx, p1, dssync.MutexWrap(ds.NewMapDatastore()))
+	pm, err := NewProviderManager(ctx, p1, dssync.MutexWrap(ds.NewMapDatastore()))
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// add provider
 	pm.AddProvider(ctx, h1, p1)


### PR DESCRIPTION
## Summary

This PR enables the provider manager to accept options and exposes the `cleanupInterval` and `cache` (cache implementation) as options that can be set.

This also adds `providersOptions []providers.Option` as a main option to the DHT.

## Context

Currently _all_ Hydra _heads_ share a datastore and they _all_ perform GC on that same datastore. We really only need one Hydra head to perform GC. Exposing the `cleanupInterval` option allows us to disable GC on all other heads (by setting it really high).

Originally I opened https://github.com/libp2p/go-libp2p-kad-dht/pull/591 to expose the `ProviderManager` as a constructor option, the idea being to construct a single provider manager instance and pass it to all DHTs. However, this would have only solved the GC problem for a single Hydra i.e. we wouldn't be able to stop _multiple Hydras_ sharing the same datastore from GC-ing and additionally, all heads for a single Hydra would share the same cache. Since Hydra Peer IDs are balanced, the overlap between the caches should be minimal and we'd end up with a thrashy cache not tuned for a particular peer ID.

The cache implementation is exposed as an option because Hydra heads who are not performing GC still need a way to invalidate their caches (the cache is cleared _only_ when GC begins). An LRU cache _with expiry_ will be passed instead (maybe this one https://github.com/hnlq715/golang-lru).

⚠️ BREAKING CHANGE `NewProviderManager` now returns an error instead of panicing...