### PR TITLE
fix: re-validate peers whenever their state changes

### DIFF
--- a/dht.go
+++ b/dht.go
@@ -32,6 +32,7 @@ import (
 	"github.com/jbenet/goprocess"
 	goprocessctx "github.com/jbenet/goprocess/context"
 	"github.com/multiformats/go-base32"
+	ma "github.com/multiformats/go-multiaddr"
 	"github.com/multiformats/go-multihash"
 )
 
@@ -701,4 +702,12 @@ func (dht *IpfsDHT) newContextWithLocalTags(ctx context.Context, extraTags ...ta
 		extraTags...,
 	) // ignoring error as it is unrelated to the actual function of this code.
 	return ctx
+}
+
+func (dht *IpfsDHT) maybeAddAddrs(p peer.ID, addrs []ma.Multiaddr, ttl time.Duration) {
+	// Don't add addresses for self or our connected peers. We have better ones.
+	if p == dht.self || dht.host.Network().Connectedness(p) == network.Connected {
+		return
+	}
+	dht.peerstore.AddAddrs(p, addrs, ttl)
 }

--- a/query.go
+++ b/query.go
@@ -416,7 +416,7 @@ func (q *query) queryPeer(ctx context.Context, ch chan<- *queryUpdate, p peer.ID
 
 		// add their addresses to the dialer's peerstore
 		if q.dht.queryPeerFilter(q.dht, *next) {
-			q.dht.peerstore.AddAddrs(next.ID, next.Addrs, pstore.TempAddrTTL)
+			q.dht.maybeAddAddrs(next.ID, next.Addrs, pstore.TempAddrTTL)
 			saw = append(saw, next.ID)
 		}
 	}

--- a/routing.go
+++ b/routing.go
@@ -575,9 +575,7 @@ func (dht *IpfsDHT) findProvidersAsyncRoutine(ctx context.Context, key multihash
 
 			// Add unique providers from request, up to 'count'
 			for _, prov := range provs {
-				if prov.ID != dht.self {
-					dht.peerstore.AddAddrs(prov.ID, prov.Addrs, peerstore.TempAddrTTL)
-				}
+				dht.maybeAddAddrs(prov.ID, prov.Addrs, peerstore.TempAddrTTL)
 				logger.Debugf("got provider: %s", prov)
 				if ps.TryAdd(prov.ID) {
 					logger.Debugf("using provider: %s", prov)


### PR DESCRIPTION
1. When a peer changes their listening addresses, we need to re-run our routing table filters, possibly removing them.
2. When a peer _starts_ supporting the DHT protocol, we need to add them to our routing table. Previously, we'd only do the inverse.
3. Don't add temporary, discovered addresses to our peerstore if we have better ones. That's a very bad idea.


Depends on https://github.com/libp2p/go-libp2p/pull/898