### PR TITLE
fix: protect useful peers in low buckets

### DIFF
--- a/query.go
+++ b/query.go
@@ -186,8 +186,11 @@ func (q *query) recordPeerIsValuable(p peer.ID) {
 	// Restrict to buckets 0, 1 (75% of requests, max 40 peers), so we don't
 	// protect _too_ many peers.
 	commonPrefixLen := kb.CommonPrefixLen(q.dht.selfKey, kb.ConvertPeerID(p))
+	cmgr := q.dht.host.ConnManager()
 	if commonPrefixLen < 2 {
-		q.dht.host.ConnManager().Protect(p, dhtUsefulTag)
+		cmgr.Protect(p, dhtUsefulTag)
+	} else {
+		cmgr.TagPeer(p, dhtUsefulTag, usefulConnMgrScore)
 	}
 }
 

--- a/query.go
+++ b/query.go
@@ -187,7 +187,7 @@ func (q *query) recordPeerIsValuable(p peer.ID) {
 	// protect _too_ many peers.
 	commonPrefixLen := kb.CommonPrefixLen(q.dht.selfKey, kb.ConvertPeerID(p))
 	cmgr := q.dht.host.ConnManager()
-	if commonPrefixLen < 2 {
+	if commonPrefixLen < usefulConnMgrProtectedBuckets {
 		cmgr.Protect(p, dhtUsefulTag)
 	} else {
 		cmgr.TagPeer(p, dhtUsefulTag, usefulConnMgrScore)


### PR DESCRIPTION
That way, we never disconnect from the core of the network.

We don't protect our closest peers as:

* We'll reconnect to them frequently when we query for ourself.
* We use the core nodes most frequently.