### PR TITLE
feat: protect all peers in low buckets, tag everyone else with 5

### DIFF
--- a/dht.go
+++ b/dht.go
@@ -47,17 +47,6 @@ const (
 	// manager "kbucket" tag. It is added with the common prefix length
 	// between two peer IDs.
 	baseConnMgrScore = 5
-
-	// UsefulConnMgrScore is given to peers that are among the first peers
-	// to respond to a query.
-	//
-	// This score is given to peers the first time they're useful and lasts
-	// until we disconnect from the peer.
-	usefulConnMgrScore = 20
-
-	// UsefulConnMgrProtectedBuckets is the number of buckets where useful
-	// peers are _protected_, instead of just given the useful score.
-	usefulConnMgrProtectedBuckets = 2
 )
 
 type mode int
@@ -73,8 +62,8 @@ const (
 )
 
 const (
-	dhtUsefulTag = "dht-useful"
-	kbucketTag   = "kbucket"
+	kbucketTag       = "kbucket"
+	protectedBuckets = 2
 )
 
 // IpfsDHT is an implementation of Kademlia with S/Kademlia modifications.
@@ -362,17 +351,15 @@ func makeRoutingTable(dht *IpfsDHT, cfg config, maxLastSuccessfulOutboundThresho
 	cmgr := dht.host.ConnManager()
 
 	rt.PeerAdded = func(p peer.ID) {
-		// We tag our closest peers with higher and higher scores so we
-		// stay connected to our nearest neighbors.
-		//
-		// We _also_ (elsewhere) protect useful peers in the furthest
-		// buckets (our "core" routing nodes) and give high scores to
-		// all other useful peers.
 		commonPrefixLen := kb.CommonPrefixLen(dht.selfKey, kb.ConvertPeerID(p))
-		cmgr.TagPeer(p, kbucketTag, baseConnMgrScore+commonPrefixLen)
+		if commonPrefixLen < protectedBuckets {
+			cmgr.Protect(p, kbucketTag)
+		} else {
+			cmgr.TagPeer(p, kbucketTag, baseConnMgrScore)
+		}
 	}
 	rt.PeerRemoved = func(p peer.ID) {
-		cmgr.Unprotect(p, dhtUsefulTag)
+		cmgr.Unprotect(p, kbucketTag)
 		cmgr.UntagPeer(p, kbucketTag)
 
 		// try to fix the RT

--- a/query.go
+++ b/query.go
@@ -187,20 +187,6 @@ func (q *query) recordPeerIsValuable(p peer.ID) {
 		// not in routing table
 		return
 	}
-
-	// Protect useful peers, when they're actually useful. This will last
-	// through disconnects. However, we'll still evict them if they keep
-	// disconnecting from us.
-	//
-	// Restrict to buckets 0, 1 (75% of requests, max 40 peers), so we don't
-	// protect _too_ many peers.
-	commonPrefixLen := kb.CommonPrefixLen(q.dht.selfKey, kb.ConvertPeerID(p))
-	cmgr := q.dht.host.ConnManager()
-	if commonPrefixLen < usefulConnMgrProtectedBuckets {
-		cmgr.Protect(p, dhtUsefulTag)
-	} else {
-		cmgr.TagPeer(p, dhtUsefulTag, usefulConnMgrScore)
-	}
 }
 
 func (q *query) recordValuablePeers() {


### PR DESCRIPTION
Anything else is easy to game. This way, we remain connected to the core peers and slightly prefer all others.

Pruning doesn't really matter as we'll just reconnect. The only concern is that this will lock in 40 connections. However, that's nothing for libp2p anyways. and the DHT will create that many connections _just_ for a single query.