### PR TITLE
fix protocolsStrs missing lanExtension

### DIFF
--- a/dht.go
+++ b/dht.go
@@ -59,6 +59,8 @@ const (
 const (
 	kad1 protocol.ID = "/kad/1.0.0"
 	kad2 protocol.ID = "/kad/2.0.0"
+	// LanExtension is used to differentiate local protocol requests from those on the WAN DHT.
+	LanExtension protocol.ID = "/lan"
 )
 
 const (
@@ -247,13 +249,19 @@ func makeDHT(ctx context.Context, h host.Host, cfg config) (*IpfsDHT, error) {
 		// 2. We'll have V1 peers in our routing table.
 		//
 		// In other words, we'll pollute the V2 network.
-		protocols = []protocol.ID{cfg.protocolPrefix + kad1}
-		serverProtocols = []protocol.ID{cfg.protocolPrefix + kad1}
+		protocols = []protocol.ID{cfg.protocolPrefix + kad1,
+			cfg.protocolPrefix + LanExtension + kad1}
+		serverProtocols = []protocol.ID{cfg.protocolPrefix + kad1,
+			cfg.protocolPrefix + LanExtension + kad1}
 	} else {
 		// In v2 mode, serve on both protocols, but only
 		// query/accept peers in v2 mode.
-		protocols = []protocol.ID{cfg.protocolPrefix + kad2}
-		serverProtocols = []protocol.ID{cfg.protocolPrefix + kad2, cfg.protocolPrefix + kad1}
+		protocols = []protocol.ID{cfg.protocolPrefix + kad2,
+			cfg.protocolPrefix + LanExtension + kad2}
+		serverProtocols = []protocol.ID{cfg.protocolPrefix + kad2,
+			cfg.protocolPrefix + LanExtension + kad2,
+			cfg.protocolPrefix + kad1,
+			cfg.protocolPrefix + LanExtension + kad1}
 	}
 
 	dht := &IpfsDHT{

--- a/dual/dual.go
+++ b/dual/dual.go
@@ -12,7 +12,6 @@ import (
 	ci "github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/libp2p/go-libp2p-core/peer"
-	"github.com/libp2p/go-libp2p-core/protocol"
 	"github.com/libp2p/go-libp2p-core/routing"
 	kb "github.com/libp2p/go-libp2p-kbucket"
 	helper "github.com/libp2p/go-libp2p-routing-helpers"
@@ -27,9 +26,6 @@ type DHT struct {
 	WAN *dht.IpfsDHT
 	LAN *dht.IpfsDHT
 }
-
-// LanExtension is used to differentiate local protocol requests from those on the WAN DHT.
-const LanExtension protocol.ID = "/lan"
 
 // Assert that IPFS assumptions about interfaces aren't broken. These aren't a
 // guarantee, but we can use them to aid refactoring.
@@ -59,7 +55,7 @@ func New(ctx context.Context, h host.Host, options ...dht.Option) (*DHT, error) 
 	// Unless overridden by user supplied options, the LAN DHT should default
 	// to 'AutoServer' mode.
 	lanOpts := append(options,
-		dht.ProtocolExtension(LanExtension),
+		dht.ProtocolExtension(dht.LanExtension),
 		dht.QueryFilter(dht.PrivateQueryFilter),
 		dht.RoutingTableFilter(dht.PrivateRoutingTableFilter),
 	)


### PR DESCRIPTION
1. peers behind nat will use '/ipfs/lan/kad/1.0.0' , it not match protocolsStrs when calling dht.validRTPeer,  cause peers not add to routingtable when calling dht.peerFound 

2. due to 1. peers behind nat connect to another peer B(config in bootstrap) not in B routing table will cause "failed to find any peer in table"

3. due to 1 and 2, peers after nat  cannot dht find (content or peers) eventhrough it active connect to a peer when bootstrap

4. due to 1 and 2, peers after nat  cannot bitswap eventhrough autorelay works