### PR TITLE
Fix constructor ordering

### DIFF
--- a/dht_options.go
+++ b/dht_options.go
@@ -64,7 +64,7 @@ type config struct {
 		diversityFilter     peerdiversity.PeerIPGroupFilter
 	}
 
-	bootstrapPeers   []peer.AddrInfo
+	bootstrapPeers []peer.AddrInfo
 
 	// test specific config options
 	disableFixLowPeers          bool

--- a/dht_test.go
+++ b/dht_test.go
@@ -1871,12 +1871,12 @@ func TestV1ProtocolOverride(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	d1 := setupDHT(ctx, t, false, V1ProtocolOverride("/myproto") )
-	d2 := setupDHT(ctx, t, false, V1ProtocolOverride("/myproto") )
+	d1 := setupDHT(ctx, t, false, V1ProtocolOverride("/myproto"))
+	d2 := setupDHT(ctx, t, false, V1ProtocolOverride("/myproto"))
 	d3 := setupDHT(ctx, t, false, V1ProtocolOverride("/myproto2"))
 	d4 := setupDHT(ctx, t, false)
 
-	dhts := []*IpfsDHT{d1,d2,d3,d4}
+	dhts := []*IpfsDHT{d1, d2, d3, d4}
 
 	for i, dout := range dhts {
 		for _, din := range dhts[i+1:] {
@@ -1893,7 +1893,7 @@ func TestV1ProtocolOverride(t *testing.T) {
 		t.Fatal("should have one peer in the routing table")
 	}
 
-	if d3.RoutingTable().Size() > 0  || d4.RoutingTable().Size() > 0{
+	if d3.RoutingTable().Size() > 0 || d4.RoutingTable().Size() > 0 {
 		t.Fatal("should have an empty routing table")
 	}
 }

--- a/subscriber_notifee.go
+++ b/subscriber_notifee.go
@@ -56,13 +56,6 @@ func newSubscriberNotifiee(dht *IpfsDHT) (*subscriberNotifee, error) {
 	// register for network notifications
 	dht.host.Network().Notify(nn)
 
-	// Fill routing table with currently connected peers that are DHT servers
-	dht.plk.Lock()
-	defer dht.plk.Unlock()
-	for _, p := range dht.host.Network().Peers() {
-		dht.peerFound(dht.ctx, p, false)
-	}
-
 	return nn, nil
 }
 


### PR DESCRIPTION
fixes #697

We seem to have a ordering problem where https://github.com/libp2p/go-libp2p-kad-dht/blob/7db4172fea89359edcbb7624c25529bd7c27304f/dht.go#L212-L227

`subscriberNotifiee` is called before `rtPeerLoop` is started this means that:
https://github.com/libp2p/go-libp2p-kad-dht/blob/7db4172fea89359edcbb7624c25529bd7c27304f/subscriber_notifee.go#L59-L64

is called which calls:

https://github.com/libp2p/go-libp2p-kad-dht/blob/7db4172fea89359edcbb7624c25529bd7c27304f/dht.go#L682-L686

which happens before we've started processing the channel in `rtPeerLoop`  https://github.com/libp2p/go-libp2p-kad-dht/blob/7db4172fea89359edcbb7624c25529bd7c27304f/dht.go#L626