### PR TITLE
Fix race condition in execOnMany

### DIFF
--- a/fullrt/dht.go
+++ b/fullrt/dht.go
@@ -852,7 +852,10 @@ func (dht *FullRT) execOnMany(ctx context.Context, fn func(context.Context, peer
 	}
 
 	var numFail, numSuccess int
-	t := time.NewTimer(time.Hour)
+	t := time.NewTimer(0)
+	if !t.Stop() {
+		<-t.C
+	}
 	defer t.Stop()
 	for numFail+numSuccess != len(peers) {
 		select {


### PR DESCRIPTION
The `execOnMany` function was exiting prematurely due to an error, leaving its child goroutines running.  These would write to a channel that closed after `execOnMany` returned in `findProvidersAsyncRoutine`.  Fixed counting error so that goroutines all finish before `execOnMany` exits.

This fixes https://github.com/ipfs/go-ipfs/issues/8146