### PR TITLE
fullrt rework batching

### DIFF
--- a/fullrt/dht.go
+++ b/fullrt/dht.go
@@ -1113,7 +1113,10 @@ func (dht *FullRT) bulkMessageSend(ctx context.Context, keys []peer.ID, fn func(
 
 	numSendsSuccessful := 0
 	numFails := 0
+	// generate a histogram of how many successful sends occurred per key
 	successHist := make(map[int]int)
+	// generate a histogram of how many failed sends occurred per key
+	// this does not include sends to peers that were skipped and had no messages sent to them at all
 	failHist := make(map[int]int)
 	for _, v := range keySuccesses {
 		if v.successes > 0 {
@@ -1132,7 +1135,7 @@ func (dht *FullRT) bulkMessageSend(ctx context.Context, keys []peer.ID, fn func(
 	logger.Infof("bulk send complete: %d keys, %d unique, %d successful, %d skipped peers, %d fails",
 		len(keys), len(keySuccesses), numSendsSuccessful, numSkipped, numFails)
 
-	logger.Infof("bulk send summary: sucessHist %v, failHist %v", successHist, failHist)
+	logger.Infof("bulk send summary: successHist %v, failHist %v", successHist, failHist)
 
 	return nil
 }

--- a/fullrt/dht.go
+++ b/fullrt/dht.go
@@ -1090,6 +1090,7 @@ func divideIntoChunks(keys []peer.ID, chunkSize int) [][]peer.ID {
 		if chunkProgress == chunkSize {
 			keyChunks = append(keyChunks, nextChunk)
 			chunkProgress = 0
+			nextChunk = make([]peer.ID, 0, len(nextChunk))
 		}
 	}
 	return keyChunks

--- a/fullrt/dht.go
+++ b/fullrt/dht.go
@@ -1042,6 +1042,8 @@ func (dht *FullRT) bulkMessageSend(ctx context.Context, keys []peer.ID, fn func(
 			}
 		}
 
+		logger.Infof("bulk send: %d peers for group size %d", len(keysPerPeer), len(g))
+
 	keyloop:
 		for p, workKeys := range keysPerPeer {
 			select {

--- a/fullrt/dht.go
+++ b/fullrt/dht.go
@@ -1115,10 +1115,14 @@ func (dht *FullRT) bulkMessageSend(ctx context.Context, keys []peer.ID, fn func(
 
 	numSendsSuccessful := 0
 	numFails := 0
+	successHist := make(map[int]int)
+	failHist := make(map[int]int)
 	for _, v := range keySuccesses {
 		if v.successes > 0 {
 			numSendsSuccessful++
 		}
+		successHist[v.successes]++
+		failHist[v.failures]++
 		numFails += v.failures
 	}
 
@@ -1129,6 +1133,8 @@ func (dht *FullRT) bulkMessageSend(ctx context.Context, keys []peer.ID, fn func(
 
 	logger.Infof("bulk send complete: %d keys, %d unique, %d successful, %d skipped peers, %d fails",
 		len(keys), len(keySuccesses), numSendsSuccessful, numSkipped, numFails)
+
+	logger.Infof("bulk send summary: sucessHist %v, failHist %v", successHist, failHist)
 
 	return nil
 }

--- a/fullrt/dht.go
+++ b/fullrt/dht.go
@@ -175,7 +175,7 @@ func NewFullRT(h host.Host, protocolPrefix protocol.ID, options ...Option) (*Ful
 
 		crawlerInterval: time.Minute * 60,
 
-		bulkSendParallelism: 40,
+		bulkSendParallelism: 20,
 	}
 
 	rt.wg.Add(1)
@@ -1013,7 +1013,7 @@ func (dht *FullRT) bulkMessageSend(ctx context.Context, keys []peer.ID, fn func(
 	for i := 0; i < dht.bulkSendParallelism; i++ {
 		go func() {
 			defer wg.Done()
-			defer logger.Infof("bulk send goroutine done")
+			defer logger.Debugf("bulk send goroutine done")
 			for {
 				select {
 				case wmsg, ok := <-workCh:
@@ -1093,7 +1093,7 @@ func (dht *FullRT) bulkMessageSend(ctx context.Context, keys []peer.ID, fn func(
 			}
 		}
 
-		logger.Infof("bulk send: %d peers for group size %d", len(keysPerPeer), len(g))
+		logger.Debugf("bulk send: %d peers for group size %d", len(keysPerPeer), len(g))
 
 	keyloop:
 		for p, workKeys := range keysPerPeer {
@@ -1109,7 +1109,7 @@ func (dht *FullRT) bulkMessageSend(ctx context.Context, keys []peer.ID, fn func(
 
 	close(workCh)
 
-	logger.Infof("bulk send complete, waiting on goroutines to close")
+	logger.Debugf("bulk send complete, waiting on goroutines to close")
 
 	wg.Wait()
 

--- a/fullrt/dht.go
+++ b/fullrt/dht.go
@@ -1036,7 +1036,7 @@ func (dht *FullRT) bulkMessageSend(ctx context.Context, keys []peer.ID, fn func(
 					dht.h.ConnManager().Protect(p, connmgrTag)
 					for _, k := range workKeys {
 						successMapLk.RLock()
-						keyReport := keySuccesses[k]
+						keyReport := *keySuccesses[k]
 						successMapLk.RUnlock()
 
 						queryTimeout := dht.timeoutPerOp
@@ -1052,7 +1052,9 @@ func (dht *FullRT) bulkMessageSend(ctx context.Context, keys []peer.ID, fn func(
 							successMapLk.Lock()
 							s := keySuccesses[k]
 							s.successes++
-							s.lastSuccess = time.Now()
+							if s.successes >= numSuccessfulToWaitFor {
+								s.lastSuccess = time.Now()
+							}
 							successMapLk.Unlock()
 						} else {
 							successMapLk.Lock()

--- a/fullrt/dht.go
+++ b/fullrt/dht.go
@@ -175,7 +175,7 @@ func NewFullRT(h host.Host, protocolPrefix protocol.ID, options ...Option) (*Ful
 
 		crawlerInterval: time.Minute * 60,
 
-		bulkSendParallelism: 10,
+		bulkSendParallelism: 40,
 	}
 
 	rt.wg.Add(1)
@@ -973,7 +973,7 @@ func (dht *FullRT) bulkMessageSend(ctx context.Context, keys []peer.ID, fn func(
 	numPeers := len(dht.keyToPeerMap)
 	dht.kMapLk.RUnlock()
 
-	chunkSize := (len(sortedKeys) * dht.bucketSize) / numPeers
+	chunkSize := (len(sortedKeys) * dht.bucketSize * 2) / numPeers
 	if chunkSize == 0 {
 		chunkSize = 1
 	}

--- a/fullrt/dht_test.go
+++ b/fullrt/dht_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/libp2p/go-libp2p-core/peer"
 )
 
-func TestDivideIntoGroups(t *testing.T) {
+func TestDivideByChunkSize(t *testing.T) {
 	var keys []peer.ID
 	for i := 0; i < 10; i++ {
 		keys = append(keys, peer.ID(strconv.Itoa(i)))
@@ -34,7 +34,7 @@ func TestDivideIntoGroups(t *testing.T) {
 	}
 
 	t.Run("Divides", func(t *testing.T) {
-		gr := divideIntoGroups(keys, 2)
+		gr := divideByChunkSize(keys, 5)
 		if len(gr) != 2 {
 			t.Fatal("incorrect number of groups")
 		}
@@ -46,22 +46,25 @@ func TestDivideIntoGroups(t *testing.T) {
 		}
 	})
 	t.Run("Remainder", func(t *testing.T) {
-		gr := divideIntoGroups(keys, 3)
-		if len(gr) != 3 {
+		gr := divideByChunkSize(keys, 3)
+		if len(gr) != 4 {
 			t.Fatal("incorrect number of groups")
 		}
-		if g, expected := convertToStrings(gr[0]), []string{"0", "1", "2", "3"}; !pidsEquals(g, expected) {
+		if g, expected := convertToStrings(gr[0]), []string{"0", "1", "2"}; !pidsEquals(g, expected) {
 			t.Fatalf("expected %v, got %v", expected, g)
 		}
-		if g, expected := convertToStrings(gr[1]), []string{"4", "5", "6"}; !pidsEquals(g, expected) {
+		if g, expected := convertToStrings(gr[1]), []string{"3", "4", "5"}; !pidsEquals(g, expected) {
 			t.Fatalf("expected %v, got %v", expected, g)
 		}
-		if g, expected := convertToStrings(gr[2]), []string{"7", "8", "9"}; !pidsEquals(g, expected) {
+		if g, expected := convertToStrings(gr[2]), []string{"6", "7", "8"}; !pidsEquals(g, expected) {
+			t.Fatalf("expected %v, got %v", expected, g)
+		}
+		if g, expected := convertToStrings(gr[3]), []string{"9"}; !pidsEquals(g, expected) {
 			t.Fatalf("expected %v, got %v", expected, g)
 		}
 	})
 	t.Run("OneEach", func(t *testing.T) {
-		gr := divideIntoGroups(keys, 10)
+		gr := divideByChunkSize(keys, 1)
 		if len(gr) != 10 {
 			t.Fatal("incorrect number of groups")
 		}
@@ -71,15 +74,13 @@ func TestDivideIntoGroups(t *testing.T) {
 			}
 		}
 	})
-	t.Run("TooManyGroups", func(t *testing.T) {
-		gr := divideIntoGroups(keys, 11)
-		if len(gr) != 10 {
+	t.Run("ChunkSizeLargerThanKeys", func(t *testing.T) {
+		gr := divideByChunkSize(keys, 11)
+		if len(gr) != 1 {
 			t.Fatal("incorrect number of groups")
 		}
-		for i := 0; i < 10; i++ {
-			if g, expected := convertToStrings(gr[i]), []string{strconv.Itoa(i)}; !pidsEquals(g, expected) {
-				t.Fatalf("expected %v, got %v", expected, g)
-			}
+		if g, expected := convertToStrings(gr[0]), convertToStrings(keys); !pidsEquals(g, expected) {
+			t.Fatalf("expected %v, got %v", expected, g)
 		}
 	})
 }


### PR DESCRIPTION
Reworked full batching so that it's more explicitly peer oriented rather than key oriented.

There's still room for improvement here on dealing with slow peers (e.g. having more message-based rather than peer-based parallelism).

Some tests on a 2 core machine with about 800k CIDs being provided (after a fresh crawl, although that is hopefully not super relevant)
- Using the current heuristic: 20-30 minutes to provide and about 17/20 peers received each record
- Waiting a full timeout for each message: ~1hr to provide and about 19-20/20 peers received each record
- Aborting after rough 7/20 peers received each record: 5 minutes