### PR TITLE
feat: delete GetValues

### DIFF
--- a/dht_test.go
+++ b/dht_test.go
@@ -470,54 +470,6 @@ func TestSearchValue(t *testing.T) {
 	}
 }
 
-func TestGetValues(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	dhtA := setupDHT(ctx, t, false)
-	dhtB := setupDHT(ctx, t, false)
-
-	defer dhtA.Close()
-	defer dhtB.Close()
-	defer dhtA.host.Close()
-	defer dhtB.host.Close()
-
-	connect(t, ctx, dhtA, dhtB)
-
-	ctxT, cancel := context.WithTimeout(ctx, time.Second)
-	defer cancel()
-
-	err := dhtB.PutValue(ctxT, "/v/hello", []byte("newer"))
-	if err != nil {
-		t.Error(err)
-	}
-
-	err = dhtA.PutValue(ctxT, "/v/hello", []byte("valid"))
-	if err != nil {
-		t.Error(err)
-	}
-
-	ctxT, cancel = context.WithTimeout(ctx, time.Second*2)
-	defer cancel()
-	vals, err := dhtA.GetValues(ctxT, "/v/hello", 16)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if len(vals) != 2 {
-		t.Fatalf("expected to get 2 values, got %d", len(vals))
-	}
-
-	sort.Slice(vals, func(i, j int) bool { return string(vals[i].Val) < string(vals[j].Val) })
-
-	if string(vals[0].Val) != "valid" {
-		t.Errorf("unexpected vals[0]: %s", string(vals[0].Val))
-	}
-	if string(vals[1].Val) != "valid" {
-		t.Errorf("unexpected vals[1]: %s", string(vals[1].Val))
-	}
-}
-
 func TestValueGetInvalid(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()


### PR DESCRIPTION
This was a somewhat strange interface that returned one value from each _peer_. It has been replaced by `SearchValue` that returns better and better values as we get them.

In the future, we should be able to introduce a _new_ `GetValues` that returns a "bag" of values (possibly multiple values from individual peers).

fixes #416 

While breaking, there are currently no users of this method. This used to be used in namesys, but that now uses `SearchValue`.