### PR TITLE
Extract validation from ProtocolMessenger

### DIFF
--- a/dht.go
+++ b/dht.go
@@ -191,7 +191,7 @@ func New(ctx context.Context, h host.Host, options ...Option) (*IpfsDHT, error) 
 
 	dht.Validator = cfg.Validator
 	dht.msgSender = net.NewMessageSenderImpl(h, dht.protocols)
-	dht.protoMessenger, err = pb.NewProtocolMessenger(dht.msgSender, pb.WithValidator(dht.Validator))
+	dht.protoMessenger, err = pb.NewProtocolMessenger(dht.msgSender)
 	if err != nil {
 		return nil, err
 	}

--- a/fullrt/dht.go
+++ b/fullrt/dht.go
@@ -596,27 +596,6 @@ func (dht *FullRT) searchValueQuorum(ctx context.Context, key string, valCh <-ch
 		})
 }
 
-// GetValues gets nvals values corresponding to the given key.
-func (dht *FullRT) GetValues(ctx context.Context, key string, nvals int) (_ []RecvdVal, err error) {
-	if !dht.enableValues {
-		return nil, routing.ErrNotSupported
-	}
-
-	queryCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	valCh, _ := dht.getValues(queryCtx, key, nil)
-
-	out := make([]RecvdVal, 0, nvals)
-	for val := range valCh {
-		out = append(out, val)
-		if len(out) == nvals {
-			cancel()
-		}
-	}
-
-	return out, ctx.Err()
-}
-
 func (dht *FullRT) processValues(ctx context.Context, key string, vals <-chan RecvdVal,
 	newVal func(ctx context.Context, v RecvdVal, better bool) bool) (best []byte, peersWithBest map[peer.ID]struct{}, aborted bool) {
 loop:

--- a/internal/errors.go
+++ b/internal/errors.go
@@ -2,4 +2,4 @@ package internal
 
 import "errors"
 
-var ErrInvalidRecord = errors.New("received invalid record")
+var ErrIncorrectRecord = errors.New("received incorrect record")


### PR DESCRIPTION
Validation being done inside the ProtocolMessenger was a bit annoying for anyone trying to utilize the protocol messages more directly (debugging, making an alternative client, etc.).

Additionally, this fixes a bug where even though `WithValidation` appeared optional the ProtocolMessenger actually panicked if you didn't pass one in and called `GetValue()`.