### PR TITLE
feat: make compatible with go-libp2p 0.15

### DIFF
--- a/ext_test.go
+++ b/ext_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/libp2p/go-libp2p-core/peerstore"
 	"github.com/libp2p/go-libp2p-core/protocol"
 	"github.com/libp2p/go-libp2p-core/routing"
+	"github.com/stretchr/testify/require"
 
 	record "github.com/libp2p/go-libp2p-record"
 	swarmt "github.com/libp2p/go-libp2p-swarm/testing"
@@ -100,13 +101,13 @@ func TestGetFailures(t *testing.T) {
 
 	ctx := context.Background()
 
-	host1 := bhost.New(swarmt.GenSwarm(t, ctx, swarmt.OptDisableReuseport))
-	host2 := bhost.New(swarmt.GenSwarm(t, ctx, swarmt.OptDisableReuseport))
+	host1, err := bhost.NewHost(ctx, swarmt.GenSwarm(t, ctx, swarmt.OptDisableReuseport), new(bhost.HostOpts))
+	require.NoError(t, err)
+	host2, err := bhost.NewHost(ctx, swarmt.GenSwarm(t, ctx, swarmt.OptDisableReuseport), new(bhost.HostOpts))
+	require.NoError(t, err)
 
 	d, err := New(ctx, host1, testPrefix, DisableAutoRefresh(), Mode(ModeServer))
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// Reply with failures to every message
 	for _, proto := range d.serverProtocols {
@@ -118,9 +119,7 @@ func TestGetFailures(t *testing.T) {
 
 	host1.Peerstore().AddAddrs(host2.ID(), host2.Addrs(), peerstore.ConnectedAddrTTL)
 	_, err = host1.Network().DialPeer(ctx, host2.ID())
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	time.Sleep(1 * time.Second)
 
 	// This one should time out

--- a/internal/net/message_manager_test.go
+++ b/internal/net/message_manager_test.go
@@ -9,6 +9,8 @@ import (
 
 	swarmt "github.com/libp2p/go-libp2p-swarm/testing"
 	bhost "github.com/libp2p/go-libp2p/p2p/host/basic"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestInvalidMessageSenderTracking(t *testing.T) {
@@ -17,14 +19,13 @@ func TestInvalidMessageSenderTracking(t *testing.T) {
 
 	foo := peer.ID("asdasd")
 
-	h := bhost.New(swarmt.GenSwarm(t, ctx, swarmt.OptDisableReuseport))
+	h, err := bhost.NewHost(ctx, swarmt.GenSwarm(t, ctx, swarmt.OptDisableReuseport), new(bhost.HostOpts))
+	require.NoError(t, err)
 
 	msgSender := NewMessageSenderImpl(h, []protocol.ID{"/test/kad/1.0.0"}).(*messageSenderImpl)
 
-	_, err := msgSender.messageSenderForPeer(ctx, foo)
-	if err == nil {
-		t.Fatal("that shouldnt have succeeded")
-	}
+	_, err = msgSender.messageSenderForPeer(ctx, foo)
+	require.Error(t, err, "should have failed to find message sender")
 
 	msgSender.smlk.Lock()
 	mscnt := len(msgSender.strmap)

--- a/records_test.go
+++ b/records_test.go
@@ -113,7 +113,7 @@ func TestPubkeyFromDHT(t *testing.T) {
 	pubk := identity.PublicKey()
 	id := identity.ID()
 	pkkey := routing.KeyForPublicKey(id)
-	pkbytes, err := pubk.Bytes()
+	pkbytes, err := ci.MarshalPublicKey(pubk)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -196,7 +196,7 @@ func TestPubkeyBadKeyFromDHT(t *testing.T) {
 	if pk == peer2.PublicKey() {
 		t.Fatal("Public keys shouldn't match here")
 	}
-	wrongbytes, err := peer2.PublicKey().Bytes()
+	wrongbytes, err := ci.MarshalPublicKey(peer2.PublicKey())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -235,7 +235,7 @@ func TestPubkeyBadKeyFromDHTGoodKeyDirect(t *testing.T) {
 	wrong := tnet.RandIdentityOrFatal(t)
 	pkkey := routing.KeyForPublicKey(dhtB.self)
 
-	wrongbytes, err := wrong.PublicKey().Bytes()
+	wrongbytes, err := ci.MarshalPublicKey(wrong.PublicKey())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -284,7 +284,7 @@ func TestPubkeyGoodKeyFromDHTGoodKeyDirect(t *testing.T) {
 	connect(t, ctx, dhtA, dhtB)
 
 	pubk := dhtB.peerstore.PubKey(dhtB.self)
-	pkbytes, err := pubk.Bytes()
+	pkbytes, err := ci.MarshalPublicKey(pubk)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -339,7 +339,7 @@ func TestValuesDisabled(t *testing.T) {
 			connect(t, ctx, dhtA, dhtB)
 
 			pubk := dhtB.peerstore.PubKey(dhtB.self)
-			pkbytes, err := pubk.Bytes()
+			pkbytes, err := ci.MarshalPublicKey(pubk)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/rt_diversity_filter_test.go
+++ b/rt_diversity_filter_test.go
@@ -14,8 +14,11 @@ import (
 )
 
 func TestRTPeerDiversityFilter(t *testing.T) {
-	ctx := context.Background()
-	h := bhost.New(swarmt.GenSwarm(t, ctx, swarmt.OptDisableReuseport))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	h, err := bhost.NewHost(ctx, swarmt.GenSwarm(t, ctx, swarmt.OptDisableReuseport), new(bhost.HostOpts))
+	require.NoError(t, err)
 	r := NewRTPeerDiversityFilter(h, 2, 3)
 
 	// table should only have 2 for each prefix per cpl
@@ -54,7 +57,8 @@ func TestRTPeerDiversityFilter(t *testing.T) {
 
 func TestRoutingTableEndToEndMaxPerCpl(t *testing.T) {
 	ctx := context.Background()
-	h := bhost.New(swarmt.GenSwarm(t, ctx, swarmt.OptDisableReuseport))
+	h, err := bhost.NewHost(ctx, swarmt.GenSwarm(t, ctx, swarmt.OptDisableReuseport), new(bhost.HostOpts))
+	require.NoError(t, err)
 	r := NewRTPeerDiversityFilter(h, 1, 2)
 
 	d, err := New(
@@ -107,8 +111,11 @@ func TestRoutingTableEndToEndMaxPerCpl(t *testing.T) {
 }
 
 func TestRoutingTableEndToEndMaxPerTable(t *testing.T) {
-	ctx := context.Background()
-	h := bhost.New(swarmt.GenSwarm(t, ctx, swarmt.OptDisableReuseport))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	h, err := bhost.NewHost(ctx, swarmt.GenSwarm(t, ctx, swarmt.OptDisableReuseport), new(bhost.HostOpts))
+	require.NoError(t, err)
 	r := NewRTPeerDiversityFilter(h, 100, 3)
 
 	d, err := New(


### PR DESCRIPTION
Specifically, remove deprecated calls in the tests. This also switches to "require" in some test cases.

Note: this doesn't actually _upgrade_ go-libp2p to avoid forcing users to make the switch. I wonder if we could provide a nice way to test against multiple go-lib2p versions...