### PR TITLE
fullrt routing table loading option

### DIFF
--- a/fullrt/dht.go
+++ b/fullrt/dht.go
@@ -225,6 +225,16 @@ func (dht *FullRT) Stat() map[string]peer.ID {
 	return newMap
 }
 
+func (dht *FullRT) GetRoutingTablePeers() []peer.AddrInfo {
+	dht.peerAddrsLk.RLock()
+	defer dht.peerAddrsLk.RUnlock()
+	ais := make([]peer.AddrInfo, 0, len(dht.peerAddrs))
+	for id, addrs := range dht.peerAddrs {
+		ais = append(ais, peer.AddrInfo{ID: id, Addrs: addrs})
+	}
+	return ais
+}
+
 func (dht *FullRT) Ready() bool {
 	dht.rtLk.RLock()
 	lastCrawlTime := dht.lastCrawlTime

--- a/fullrt/options.go
+++ b/fullrt/options.go
@@ -2,11 +2,14 @@ package fullrt
 
 import (
 	"fmt"
+	"github.com/libp2p/go-libp2p-core/peer"
 	kaddht "github.com/libp2p/go-libp2p-kad-dht"
 )
 
 type config struct {
-	dhtOpts []kaddht.Option
+	dhtOpts                   []kaddht.Option
+	initialRTPeers            []peer.AddrInfo
+	skipInitialRTVerification bool
 }
 
 func (cfg *config) apply(opts ...Option) error {
@@ -23,6 +26,23 @@ type Option func(opt *config) error
 func DHTOption(opts ...kaddht.Option) Option {
 	return func(c *config) error {
 		c.dhtOpts = append(c.dhtOpts, opts...)
+		return nil
+	}
+}
+
+// LoadRoutingTable loads the given set of peers into the routing table.
+// If skipInitialVerification is true then the DHT client will be immediately usable,
+// instead of using the peers as seeds for the initial routing table scan.
+//
+// Note: While skipping the initial verification will result in the DHT client being
+// usable more quickly on startup, if the persisted routing table is out of date or
+// corrupted then any initial operations might not give accurate results (e.g. not
+// finding data present in the network or putting data to fewer nodes or nodes
+// that are no longer closest to the keys)
+func LoadRoutingTable(peers []peer.AddrInfo, skipInitialVerification bool) Option {
+	return func(c *config) error {
+		c.initialRTPeers = peers
+		c.skipInitialRTVerification = skipInitialVerification
 		return nil
 	}
 }


### PR DESCRIPTION
Adds an option for preloading a routing table on startup as well as a function for getting the routing table peers and addresses.

This is using the addresses stored in the internal map rather than also leveraging the peerstore.

cc @whyrusleeping 