### PR TITLE
fix: incorrect format handling

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -342,7 +342,7 @@ func (dht *IpfsDHT) handleAddProvider(ctx context.Context, p peer.ID, pmes *pb.M
 		return nil, fmt.Errorf("handleAddProvider key is empty")
 	}
 
-	logger.Debugf("adding provider", "from", p, "key", internal.LoggableProviderRecordBytes(key))
+	logger.Debugw("adding provider", "from", p, "key", internal.LoggableProviderRecordBytes(key))
 
 	// add provider should use the address given in the message
 	pinfos := pb.PBPeersToPeerInfos(pmes.GetProviderPeers())


### PR DESCRIPTION
Fix
```
adding provider%!(EXTRA string=from, peer.ID=Qmbs3VhnSz7V5DTQt9FXb7iYnWcyHiEMDYisoR1cPno84A, string=key, internal.LoggableProviderRecordBytes=bciqfn7ajoxq3kfhtak5g66chbodhumhpx6kydwhishcnhz3ngft6igy)
```
Logging string