### PR TITLE
testing: disable QUIC in DHT testing due to flaky results in tests

### DIFF
--- a/dht_test.go
+++ b/dht_test.go
@@ -117,7 +117,7 @@ func setupDHT(ctx context.Context, t *testing.T, client bool, options ...Option)
 		baseOpts = append(baseOpts, Mode(ModeServer))
 	}
 
-	host, err := bhost.NewHost(swarmt.GenSwarm(t, swarmt.OptDisableReuseport), new(bhost.HostOpts))
+	host, err := bhost.NewHost(swarmt.GenSwarm(t, swarmt.OptDisableReuseport, swarmt.OptDisableQUIC), new(bhost.HostOpts))
 	require.NoError(t, err)
 	t.Cleanup(func() { host.Close() })
 


### PR DESCRIPTION
I recall there were some previous suspicions around if some of our flaky tests are caused by the test swarm utilizing QUIC. I'm having trouble reproducing locally, but CI is always good at finding flakes so seemed worth a try 😄 