### PR TITLE
feat: increase expiration time for Provider Records to 48h (RFM17)

### DIFF
--- a/providers/providers_manager.go
+++ b/providers/providers_manager.go
@@ -26,7 +26,7 @@ import (
 const ProvidersKeyPrefix = "/providers/"
 
 // ProvideValidity is the default time that a provider record should last
-var ProvideValidity = time.Hour * 24
+var ProvideValidity = time.Hour * 48
 var defaultCleanupInterval = time.Hour
 var lruCacheSize = 256
 var batchBufferSize = 256


### PR DESCRIPTION
## Description
This PR materializes the discussion in [libp2p/specs#451](https://github.com/libp2p/specs/pull/451#issue-1372605284) increasing the provider record's default `TTL` or `ProvideValidity` from `24h` to `48h` based on [RFM17](https://github.com/protocol/network-measurements/blob/master/results/rfm17-provider-record-liveness.md).

## Motivation
The measurements from RFM17 were quite promising for the steady provider record's liveness gathered in the IPFS live network. Based on the average of 70% of online PR holders and 70% of PR holders being among the 20 closest peers for over +48 hours, we suggest increasing the republish interval for the CIDs and extending the expiration time to help reduce part of the overhead that providing large sets of CIDs implies.

**Why 48 hours?**
Since the republish interval is intended to be increased up to `22h` by a twin PR in [ipfs/kubo#9326](https://github.com/ipfs/kubo/pull/9326), setting it to 48h of PR's TTL makes sure that providers have enough margin to publish back the PR before they expire.

## Modifications
Increase `ProvideValidity` from `24h` -> `48h`