### PR TITLE
feat: increase the max record age to 48h (PUT_VALUE, RFM17)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -114,7 +114,7 @@ var Defaults = func(o *Config) error {
 	o.RoutingTable.RefreshInterval = 10 * time.Minute
 	o.RoutingTable.AutoRefresh = true
 	o.RoutingTable.PeerFilter = EmptyRTFilter
-	o.MaxRecordAge = time.Hour * 48
+	o.MaxRecordAge = providers.ProvideValidity
 
 	o.BucketSize = defaultBucketSize
 	o.Concurrency = 10

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -114,7 +114,7 @@ var Defaults = func(o *Config) error {
 	o.RoutingTable.RefreshInterval = 10 * time.Minute
 	o.RoutingTable.AutoRefresh = true
 	o.RoutingTable.PeerFilter = EmptyRTFilter
-	o.MaxRecordAge = time.Hour * 36
+	o.MaxRecordAge = time.Hour * 48
 
 	o.BucketSize = defaultBucketSize
 	o.Concurrency = 10

--- a/providers/providers_manager.go
+++ b/providers/providers_manager.go
@@ -30,7 +30,8 @@ const ProvidersKeyPrefix = "/providers/"
 // the records we return will require an extra lookup.
 const ProviderAddrTTL = time.Minute * 30
 
-// ProvideValidity is the default time that a provider record should last
+// ProvideValidity is the default time that a Provider Record should last on DHT
+// This value is also known as Provider Record Expiration Interval.
 var ProvideValidity = time.Hour * 48
 var defaultCleanupInterval = time.Hour
 var lruCacheSize = 256


### PR DESCRIPTION
## Description
This PR aims to increase the default value for the IPNS records stored through the PUT_VALUE method from `36h` to `48h` based on [RFM17](https://github.com/protocol/network-measurements/blob/master/results/rfm17-provider-record-liveness.md) as discussed in [libp2p/specs#451](https://github.com/libp2p/specs/pull/451#issue-1372605284). 

## Motivation
The measurements from RFM17 were promising and have led to modifying the current republish-interval ([ipfs/kubo#9326](https://github.com/ipfs/kubo/pull/9326)) and record's expiration time ([libp2p/go-libp2p-kad-dht#793](https://github.com/libp2p/go-libp2p-kad-dht/pull/793)). This PR aims to homogenize the expiration of the records to `48h`.

## Modifications
- Increase `Config.MaxRecordAge` from `36h` -> `48h`  