### PR TITLE
feat: add option to skip sending closer peers in GetProviders responses

### DIFF
--- a/dht.go
+++ b/dht.go
@@ -138,6 +138,9 @@ type IpfsDHT struct {
 	// networks).
 	enableProviders, enableValues bool
 
+	// Disable sending of closer peers for GetProviders queries
+	disableGetProvidersCloserPeers bool
+
 	disableFixLowPeers bool
 	fixLowPeersChan    chan struct{}
 
@@ -278,21 +281,22 @@ func makeDHT(ctx context.Context, h host.Host, cfg dhtcfg.Config) (*IpfsDHT, err
 	serverProtocols = []protocol.ID{v1proto}
 
 	dht := &IpfsDHT{
-		datastore:              cfg.Datastore,
-		self:                   h.ID(),
-		selfKey:                kb.ConvertPeerID(h.ID()),
-		peerstore:              h.Peerstore(),
-		host:                   h,
-		birth:                  time.Now(),
-		protocols:              protocols,
-		protocolsStrs:          protocol.ConvertToStrings(protocols),
-		serverProtocols:        serverProtocols,
-		bucketSize:             cfg.BucketSize,
-		alpha:                  cfg.Concurrency,
-		beta:                   cfg.Resiliency,
-		queryPeerFilter:        cfg.QueryPeerFilter,
-		routingTablePeerFilter: cfg.RoutingTable.PeerFilter,
-		rtPeerDiversityFilter:  cfg.RoutingTable.DiversityFilter,
+		datastore:                      cfg.Datastore,
+		self:                           h.ID(),
+		selfKey:                        kb.ConvertPeerID(h.ID()),
+		peerstore:                      h.Peerstore(),
+		host:                           h,
+		birth:                          time.Now(),
+		protocols:                      protocols,
+		protocolsStrs:                  protocol.ConvertToStrings(protocols),
+		serverProtocols:                serverProtocols,
+		bucketSize:                     cfg.BucketSize,
+		alpha:                          cfg.Concurrency,
+		beta:                           cfg.Resiliency,
+		queryPeerFilter:                cfg.QueryPeerFilter,
+		routingTablePeerFilter:         cfg.RoutingTable.PeerFilter,
+		rtPeerDiversityFilter:          cfg.RoutingTable.DiversityFilter,
+		disableGetProvidersCloserPeers: cfg.DisableGetProvidersCloserPeers,
 
 		fixLowPeersChan: make(chan struct{}, 1),
 

--- a/dht_options.go
+++ b/dht_options.go
@@ -291,6 +291,16 @@ func RoutingTablePeerDiversityFilter(pg peerdiversity.PeerIPGroupFilter) Option 
 	}
 }
 
+// DisableGetProvidersCloserPeers always returns an empty closer peers list for a GetProviders response.
+// WARNING: do not change this unless you're using a forked DHT (i.e., a private
+// network and/or distinct DHT protocols with the `Protocols` option).
+func DisableGetProvidersCloserPeers() Option {
+	return func(c *dhtcfg.Config) error {
+		c.DisableGetProvidersCloserPeers = true
+		return nil
+	}
+}
+
 // disableFixLowPeersRoutine disables the "fixLowPeers" routine in the DHT.
 // This is ONLY for tests.
 func disableFixLowPeersRoutine(t *testing.T) Option {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,20 +32,21 @@ type RouteTableFilterFunc func(dht interface{}, p peer.ID) bool
 
 // Config is a structure containing all the options that can be used when constructing a DHT.
 type Config struct {
-	Datastore          ds.Batching
-	Validator          record.Validator
-	ValidatorChanged   bool // if true implies that the validator has been changed and that Defaults should not be used
-	Mode               ModeOpt
-	ProtocolPrefix     protocol.ID
-	V1ProtocolOverride protocol.ID
-	BucketSize         int
-	Concurrency        int
-	Resiliency         int
-	MaxRecordAge       time.Duration
-	EnableProviders    bool
-	EnableValues       bool
-	ProviderStore      providers.ProviderStore
-	QueryPeerFilter    QueryFilterFunc
+	Datastore                      ds.Batching
+	Validator                      record.Validator
+	ValidatorChanged               bool // if true implies that the validator has been changed and that Defaults should not be used
+	Mode                           ModeOpt
+	ProtocolPrefix                 protocol.ID
+	V1ProtocolOverride             protocol.ID
+	BucketSize                     int
+	Concurrency                    int
+	Resiliency                     int
+	MaxRecordAge                   time.Duration
+	EnableProviders                bool
+	EnableValues                   bool
+	DisableGetProvidersCloserPeers bool
+	ProviderStore                  providers.ProviderStore
+	QueryPeerFilter                QueryFilterFunc
 
 	RoutingTable struct {
 		RefreshQueryTimeout time.Duration


### PR DESCRIPTION
This will enable hydra boosters to always return empty closer peers lists in GetProviders responses, minimizing the amount of useful outbound traffic from Hydra nodes to reduce costs, as that is the most significant cost contributor. This option should generally NOT be used, as widespread use could negatively impact network performance and content availability. This is a temporary stopgap until delegated routing is more widely available in IPFS implementations.