### PR TITLE
fix: context cancel causes providers not to be returned in `findProvidersAsync`

### DIFF
--- a/query.go
+++ b/query.go
@@ -391,7 +391,7 @@ func (q *query) terminate(ctx context.Context, cancel context.CancelFunc, reason
 // queryPeer does not access the query state in queryPeers!
 func (q *query) queryPeer(ctx context.Context, ch chan<- *queryUpdate, p peer.ID) {
 	defer q.waitGroup.Done()
-	dialCtx, queryCtx := ctx, ctx
+	dialCtx, queryCtx := ctx, q.ctx
 
 	// dial the peer
 	if err := q.dht.dialPeer(dialCtx, p); err != nil {


### PR DESCRIPTION
I found an issue when testing the double-hashed prefix-lookup DHT; I noticed providers were being returned in the `queryFn` in `findProvidersAsync`, but they weren't being entered into the `peerOut` channel because the context was cancelled, resulting in no providers being returned.

Previously, context being passed to the `queryFn` gets cancelled when the query terminates in `query.Run`; however since the `queryFn` is run in a goroutine (query.go line 325) it's possible for the context passed to it to be cancelled before providers are put into the `peerOut` channel, resulting in no/less providers than expected being returned.

It seems to me like the `query.ctx` (which is passed by the user essentially) should be what stops values being put in the `peerOut` channel, which is what the PR now does (and also fixes the above issue).