### PR TITLE
Adjust PeerSet logic in the DHT lookup process

### DIFF
--- a/routing.go
+++ b/routing.go
@@ -492,7 +492,7 @@ func (dht *IpfsDHT) findProvidersAsyncRoutine(ctx context.Context, key multihash
 		psLock.Lock()
 		defer psLock.Unlock()
 		pi, ok := ps[p.ID]
-		if (!ok && (len(ps) < count || findAll)) || ((len(pi.Addrs) == 0) && len(p.Addrs) > 0){
+		if (!ok && (len(ps) < count || findAll)) || ((len(pi.Addrs) == 0) && len(p.Addrs) > 0) {
 			ps[p.ID] = p
 			return true
 		}

--- a/routing.go
+++ b/routing.go
@@ -492,7 +492,7 @@ func (dht *IpfsDHT) findProvidersAsyncRoutine(ctx context.Context, key multihash
 		psLock.Lock()
 		defer psLock.Unlock()
 		pi, ok := ps[p.ID]
-		if (!ok && (len(ps) < count || findAll)) || ((len(pi.Addrs) == 0) && len(p.Addrs) > 0) {
+		if (!ok || ((len(pi.Addrs) == 0) && len(p.Addrs) > 0)) && (len(ps) < count || findAll) {
 			ps[p.ID] = p
 			return true
 		}


### PR DESCRIPTION
The current logic of the `PeerSet` (taking the name from the previous `go-libp2p-core/peer.Set`) defines the result of the lookup process based on the first `AddrInfo` that we discover from the lookup for each provider. 

We have spotted in [`RFM17.1`](https://github.com/protocol/network-measurements/pull/22) that this logic would severely impact the effect of extending the provider Multiaddress' TTL [`#795`](https://github.com/libp2p/go-libp2p-kad-dht/pull/795), forcing in some occasions to make that second DHT lookup to map the `PeerID` with the `Maddrs` when it wouldn't be necessary because other PR Holders still have a valid `Maddrs`.

This PR aims to solve that weird behavior from the `PeerSet` by notifying as well whenever a second PR for the same provider comes with the `Maddrs`.

to go from a lookup result that looks like this (distribution of the content of the PRs as a result of the DHT lookups over time):

![image](https://user-images.githubusercontent.com/45786396/206233009-7982a8d7-1de7-4bf4-ad17-750f73ee652b.png)

to something that looks like this:

![image](https://user-images.githubusercontent.com/45786396/206242758-d0349f41-a807-4cce-a20e-a02f05ec4d6f.png)

Let me know what you think about it.

TODO: I still need to check why the modification doesn't pass the `dht_test.go` test.  

CC: @yiannisbot @guillaumemichel @dennis-tra