### PR TITLE
feat: ping peers on routing table refresh

### DIFF
--- a/dht.go
+++ b/dht.go
@@ -365,10 +365,15 @@ func makeRtRefreshManager(dht *IpfsDHT, cfg dhtcfg.Config, maxLastSuccessfulOutb
 		return err
 	}
 
+	pingFnc := func(ctx context.Context, p peer.ID) error {
+		return dht.protoMessenger.Ping(ctx, p)
+	}
+
 	r, err := rtrefresh.NewRtRefreshManager(
 		dht.host, dht.routingTable, cfg.RoutingTable.AutoRefresh,
 		keyGenFnc,
 		queryFnc,
+		pingFnc,
 		cfg.RoutingTable.RefreshQueryTimeout,
 		cfg.RoutingTable.RefreshInterval,
 		maxLastSuccessfulOutboundThreshold,

--- a/dht.go
+++ b/dht.go
@@ -366,7 +366,8 @@ func makeRtRefreshManager(dht *IpfsDHT, cfg dhtcfg.Config, maxLastSuccessfulOutb
 	}
 
 	pingFnc := func(ctx context.Context, p peer.ID) error {
-		return dht.protoMessenger.Ping(ctx, p)
+		_, err := dht.protoMessenger.GetClosestPeers(ctx, p, p) // don't use the PING message type as it's deprecated
+		return err
 	}
 
 	r, err := rtrefresh.NewRtRefreshManager(

--- a/dht.go
+++ b/dht.go
@@ -69,6 +69,11 @@ const (
 	protectedBuckets = 2
 )
 
+const (
+	// MAGIC: timeout for receiving a pong from a peer in our routing table
+	pingTimeout = 5 * time.Second
+)
+
 type addPeerRTReq struct {
 	p         peer.ID
 	queryPeer bool
@@ -367,7 +372,7 @@ func makeRtRefreshManager(dht *IpfsDHT, cfg dhtcfg.Config, maxLastSuccessfulOutb
 	}
 
 	pingFnc := func(ctx context.Context, p peer.ID) error {
-		timeoutCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		timeoutCtx, cancel := context.WithTimeout(ctx, pingTimeout)
 		defer cancel()
 
 		// Just wait for a single ping


### PR DESCRIPTION
We have seen in the past that there are peers in the IPFS DHT that let you connect to them but then refuse to speak any protocol. This was mainly due to the resource manager killing the connection if limits were exceeded. We have seen that such peers are already pushed to the edge of the DHT - meaning they get pruned from lower buckets. However, they won't get pruned from higher ones because we only try to connect to them and not speak anything on that connection.

This change adds a ping message to the liveness check on routing table refreshes.