### PR TITLE
Introduce options to parameterize config of the accelerated DHT client

### DIFF
--- a/fullrt/dht.go
+++ b/fullrt/dht.go
@@ -105,7 +105,12 @@ type FullRT struct {
 //
 // Not all of the standard DHT options are supported in this DHT.
 func NewFullRT(h host.Host, protocolPrefix protocol.ID, options ...Option) (*FullRT, error) {
-	var fullrtcfg config
+	fullrtcfg := config{
+		crawlInterval:       time.Hour,
+		bulkSendParallelism: 20,
+		waitFrac:            0.3,
+		timeoutPerOp:        5 * time.Second,
+	}
 	if err := fullrtcfg.apply(options...); err != nil {
 		return nil, err
 	}
@@ -179,12 +184,12 @@ func NewFullRT(h host.Host, protocolPrefix protocol.ID, options ...Option) (*Ful
 
 		triggerRefresh: make(chan struct{}),
 
-		waitFrac:     0.3,
-		timeoutPerOp: 5 * time.Second,
+		waitFrac:     fullrtcfg.waitFrac,
+		timeoutPerOp: fullrtcfg.timeoutPerOp,
 
-		crawlerInterval: time.Minute * 60,
+		crawlerInterval: fullrtcfg.crawlInterval,
 
-		bulkSendParallelism: 20,
+		bulkSendParallelism: fullrtcfg.bulkSendParallelism,
 	}
 
 	rt.wg.Add(1)

--- a/fullrt/options.go
+++ b/fullrt/options.go
@@ -2,12 +2,18 @@ package fullrt
 
 import (
 	"fmt"
+	"time"
 
 	kaddht "github.com/libp2p/go-libp2p-kad-dht"
 )
 
 type config struct {
 	dhtOpts []kaddht.Option
+
+	crawlInterval       time.Duration
+	waitFrac            float64
+	bulkSendParallelism int
+	timeoutPerOp        time.Duration
 }
 
 func (cfg *config) apply(opts ...Option) error {
@@ -24,6 +30,48 @@ type Option func(opt *config) error
 func DHTOption(opts ...kaddht.Option) Option {
 	return func(c *config) error {
 		c.dhtOpts = append(c.dhtOpts, opts...)
+		return nil
+	}
+}
+
+// WithCrawlInterval sets the interval at which the DHT is crawled to refresh peer store.
+// Defaults to 1 hour if unspecified.
+func WithCrawlInterval(i time.Duration) Option {
+	return func(opt *config) error {
+		opt.crawlInterval = i
+		return nil
+	}
+}
+
+// WithSuccessWaitFraction sets the fraction of peers to wait for before considering an operation a success defined as a number between (0, 1].
+// Defaults to 30% if unspecified.
+func WithSuccessWaitFraction(f float64) Option {
+	return func(opt *config) error {
+		if f <= 0 || f > 1 {
+			return fmt.Errorf("success wait fraction must be larger than 0 and smaller or equal to 1; got: %f", f)
+		}
+		opt.waitFrac = f
+		return nil
+	}
+}
+
+// WithBulkSendParallelism sets the maximum degree of parallelism at which messages are sent to other peers. It must be at least 1.
+// Defaults to 20 if unspecified.
+func WithBulkSendParallelism(b int) Option {
+	return func(opt *config) error {
+		if b < 1 {
+			return fmt.Errorf("bulk send parallelism must be at least 1; got: %d", b)
+		}
+		opt.bulkSendParallelism = b
+		return nil
+	}
+}
+
+// WithTimeoutPerOperation sets the timeout per operation, where operations include putting providers and querying the DHT.
+// Defaults to 5 seconds if unspecified.
+func WithTimeoutPerOperation(t time.Duration) Option {
+	return func(opt *config) error {
+		opt.timeoutPerOp = t
 		return nil
 	}
 }


### PR DESCRIPTION
Introduce new options such that the following can be configured, with fallback onto the existing hardcoded values:
 * network crawl interval
 * success wait fraction
 * bulk send parallelism
 * timeout per operation