### PR TITLE
Specified CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,15 @@
+# CODEOWNERS
+
+# default owner is the libp2p team
+*.go @libp2p/go-libp2p-maintainers @guillaumemichel
+/pb/ @libp2p/go-libp2p-maintainers @guillaumemichel
+
+# dual is an application for IPFS
+/dual/ @ipfs/kubo-maintainers @guillaumemichel
+# fullrt is IPFS specific
+/fullrt/ @ipfs/kubo-maintainers @guillaumemichel
+# providers describe the IPFS specific providers
+/providers/ @ipfs/kubo-maintainers @guillaumemichel
+# records are IPFS specific
+/records.go @ipfs/kubo-maintainers @guillaumemichel
+/records_test.go @ipfs/kubo-maintainers @guillaumemichel

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,11 +5,11 @@
 /pb/ @libp2p/go-libp2p-maintainers @guillaumemichel
 
 # dual is an application for IPFS
-/dual/ @ipfs/kubo-maintainers @guillaumemichel
+/dual/ @libp2p/kubo-maintainers @guillaumemichel
 # fullrt is IPFS specific
-/fullrt/ @ipfs/kubo-maintainers @guillaumemichel
+/fullrt/ @libp2p/kubo-maintainers @guillaumemichel
 # providers describe the IPFS specific providers
-/providers/ @ipfs/kubo-maintainers @guillaumemichel
+/providers/ @libp2p/kubo-maintainers @guillaumemichel
 # records are IPFS specific
-/records.go @ipfs/kubo-maintainers @guillaumemichel
-/records_test.go @ipfs/kubo-maintainers @guillaumemichel
+/records.go @libp2p/kubo-maintainers @guillaumemichel
+/records_test.go @libp2p/kubo-maintainers @guillaumemichel

--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ Check out our [contributing document](https://github.com/libp2p/community/blob/m
 
 <!-- Small note: If editing the README, please conform to the [standard-readme](https://github.com/RichardLitt/standard-readme) specification. -->
 
+## Maintainers
+
+- [@ipfs/kubo-maintainers](https://github.com/orgs/ipfs/teams/kubo-maintainers)
+- [@libp2p/go-libp2p-maintainers](https://github.com/orgs/libp2p/teams/go-libp2p-maintainers)
+- [@guillaumemichel](https://github.com/guillaumemichel)
+
+See [CODEOWNERS](./CODEOWNERS).
+
 ## License
 
 [MIT](LICENSE) © Protocol Labs Inc.

--- a/README.md
+++ b/README.md
@@ -33,13 +33,6 @@ Check out our [contributing document](https://github.com/libp2p/community/blob/m
 
 <!-- Small note: If editing the README, please conform to the [standard-readme](https://github.com/RichardLitt/standard-readme) specification. -->
 
-## Maintainers
-
-- [@ipfs/kubo-maintainers](https://github.com/orgs/ipfs/teams/kubo-maintainers)
-- [@libp2p/go-libp2p-maintainers](https://github.com/orgs/libp2p/teams/go-libp2p-maintainers)
-- [@guillaumemichel](https://github.com/guillaumemichel)
-
-
 ## License
 
 [MIT](LICENSE) © Protocol Labs Inc.


### PR DESCRIPTION
I tried to split code ownership between go-libp2p and kubo maintainers. Please let me know your thoughts

https://github.com/libp2p/go-libp2p-kad-dht/issues/825