### PR TITLE
Using go-kademlia to schedule find peer request

### DIFF
--- a/dht_bootstrap.go
+++ b/dht_bootstrap.go
@@ -57,7 +57,7 @@ func GetDefaultBootstrapPeerAddrInfos() []peer.AddrInfo {
 
 // Bootstrap tells the DHT to get into a bootstrapped state satisfying the
 // IpfsRouter interface.
-func (dht *IpfsDHT) Bootstrap(ctx context.Context) error {
+func (dht *DHT) Bootstrap(ctx context.Context) error {
 	dht.fixRTIfNeeded()
 	dht.rtRefreshManager.RefreshNoWait()
 	return nil
@@ -67,7 +67,7 @@ func (dht *IpfsDHT) Bootstrap(ctx context.Context) error {
 //
 // The returned channel will block until the refresh finishes, then yield the
 // error and close. The channel is buffered and safe to ignore.
-func (dht *IpfsDHT) RefreshRoutingTable() <-chan error {
+func (dht *DHT) RefreshRoutingTable() <-chan error {
 	return dht.rtRefreshManager.Refresh(false)
 }
 
@@ -76,6 +76,6 @@ func (dht *IpfsDHT) RefreshRoutingTable() <-chan error {
 //
 // The returned channel will block until the refresh finishes, then yield the
 // error and close. The channel is buffered and safe to ignore.
-func (dht *IpfsDHT) ForceRefresh() <-chan error {
+func (dht *DHT) ForceRefresh() <-chan error {
 	return dht.rtRefreshManager.Refresh(true)
 }

--- a/dht_bootstrap_test.go
+++ b/dht_bootstrap_test.go
@@ -19,7 +19,7 @@ func TestSelfWalkOnAddressChange(t *testing.T) {
 	d2 := setupDHT(ctx, t, false, DisableAutoRefresh())
 	d3 := setupDHT(ctx, t, false, DisableAutoRefresh())
 
-	var connectedTo *IpfsDHT
+	var connectedTo *DHT
 	// connect d1 to whoever is "further"
 	if kb.CommonPrefixLen(kb.ConvertPeerID(d1.self), kb.ConvertPeerID(d2.self)) <=
 		kb.CommonPrefixLen(kb.ConvertPeerID(d1.self), kb.ConvertPeerID(d3.self)) {
@@ -34,14 +34,14 @@ func TestSelfWalkOnAddressChange(t *testing.T) {
 	connect(t, ctx, d2, d3)
 
 	// d1 should have ONLY 1 peer in it's RT
-	waitForWellFormedTables(t, []*IpfsDHT{d1}, 1, 1, 2*time.Second)
+	waitForWellFormedTables(t, []*DHT{d1}, 1, 1, 2*time.Second)
 	require.Equal(t, connectedTo.self, d1.routingTable.ListPeers()[0])
 
 	// now emit the address change event
 	em, err := d1.host.EventBus().Emitter(&event.EvtLocalAddressesUpdated{})
 	require.NoError(t, err)
 	require.NoError(t, em.Emit(event.EvtLocalAddressesUpdated{}))
-	waitForWellFormedTables(t, []*IpfsDHT{d1}, 2, 2, 2*time.Second)
+	waitForWellFormedTables(t, []*DHT{d1}, 2, 2, 2*time.Second)
 	// it should now have both peers in the RT
 	ps := d1.routingTable.ListPeers()
 	require.Contains(t, ps, d2.self)
@@ -80,8 +80,8 @@ func TestBootstrappersReplacable(t *testing.T) {
 	defer d.host.Close()
 	defer d.Close()
 
-	var d1 *IpfsDHT
-	var d2 *IpfsDHT
+	var d1 *DHT
+	var d2 *DHT
 
 	// d1 & d2 have a cpl of 0
 	for {
@@ -108,8 +108,8 @@ func TestBootstrappersReplacable(t *testing.T) {
 	require.Len(t, d.routingTable.ListPeers(), 2)
 
 	// d3 & d4 with cpl=0 will go in as d1 & d2 are replacable.
-	var d3 *IpfsDHT
-	var d4 *IpfsDHT
+	var d3 *DHT
+	var d4 *DHT
 
 	for {
 		d3 = setupDHT(ctx, t, false, disableFixLowPeersRoutine(t))
@@ -142,7 +142,7 @@ func TestBootstrappersReplacable(t *testing.T) {
 	time.Sleep(1 * time.Second)
 
 	// adding d5 fails because RT is frozen
-	var d5 *IpfsDHT
+	var d5 *DHT
 	for {
 		d5 = setupDHT(ctx, t, false, disableFixLowPeersRoutine(t))
 		if kb.CommonPrefixLen(d.selfKey, d5.selfKey) == 0 {

--- a/dht_net.go
+++ b/dht_net.go
@@ -22,7 +22,7 @@ var dhtStreamIdleTimeout = 1 * time.Minute
 var ErrReadTimeout = net.ErrReadTimeout
 
 // handleNewStream implements the network.StreamHandler
-func (dht *IpfsDHT) handleNewStream(s network.Stream) {
+func (dht *DHT) handleNewStream(s network.Stream) {
 	if dht.handleNewMessage(s) {
 		// If we exited without error, close gracefully.
 		_ = s.Close()
@@ -33,7 +33,7 @@ func (dht *IpfsDHT) handleNewStream(s network.Stream) {
 }
 
 // Returns true on orderly completion of writes (so we can Close the stream).
-func (dht *IpfsDHT) handleNewMessage(s network.Stream) bool {
+func (dht *DHT) handleNewMessage(s network.Stream) bool {
 	ctx := dht.ctx
 	r := msgio.NewVarintReaderSize(s, network.MessageSizeMax)
 

--- a/dual/dual.go
+++ b/dual/dual.go
@@ -27,8 +27,8 @@ import (
 // DHT implements the routing interface to provide two concrete DHT implementationts for use
 // in IPFS that are used to support both global network users and disjoint LAN usecases.
 type DHT struct {
-	WAN *dht.IpfsDHT
-	LAN *dht.IpfsDHT
+	WAN *dht.DHT
+	LAN *dht.DHT
 }
 
 // LanExtension is used to differentiate local protocol requests from those on the WAN DHT.
@@ -91,7 +91,7 @@ func DHTOption(opts ...dht.Option) Option {
 }
 
 // New creates a new DualDHT instance. Options provided are forwarded on to the two concrete
-// IpfsDHT internal constructions, modulo additional options used by the Dual DHT to enforce
+// DHT internal constructions, modulo additional options used by the Dual DHT to enforce
 // the LAN-vs-WAN distinction.
 // Note: query or routing table functional options provided as arguments to this function
 // will be overriden by this constructor.

--- a/dual/dual_test.go
+++ b/dual/dual_test.go
@@ -112,7 +112,7 @@ func setupDHT(ctx context.Context, t *testing.T, options ...dht.Option) *DHT {
 	return d
 }
 
-func connect(ctx context.Context, t *testing.T, a, b *dht.IpfsDHT) {
+func connect(ctx context.Context, t *testing.T, a, b *dht.DHT) {
 	t.Helper()
 	bid := b.PeerID()
 	baddr := b.Host().Peerstore().Addrs(bid)
@@ -126,7 +126,7 @@ func connect(ctx context.Context, t *testing.T, a, b *dht.IpfsDHT) {
 	wait(ctx, t, a, b)
 }
 
-func wait(ctx context.Context, t *testing.T, a, b *dht.IpfsDHT) {
+func wait(ctx context.Context, t *testing.T, a, b *dht.DHT) {
 	t.Helper()
 	for a.RoutingTable().Find(b.PeerID()) == "" {
 		// fmt.Fprintf(os.Stderr, "%v\n", a.RoutingTable().GetPeerInfos())
@@ -138,7 +138,7 @@ func wait(ctx context.Context, t *testing.T, a, b *dht.IpfsDHT) {
 	}
 }
 
-func setupTier(ctx context.Context, t *testing.T) (*DHT, *dht.IpfsDHT, *dht.IpfsDHT) {
+func setupTier(ctx context.Context, t *testing.T) (*DHT, *dht.DHT, *dht.DHT) {
 	t.Helper()
 	baseOpts := []dht.Option{
 		dht.NamespacedValidator("v", blankValidator{}),

--- a/handlers.go
+++ b/handlers.go
@@ -22,7 +22,7 @@ import (
 // dhthandler specifies the signature of functions that handle DHT messages.
 type dhtHandler func(context.Context, peer.ID, *pb.Message) (*pb.Message, error)
 
-func (dht *IpfsDHT) handlerForMsgType(t pb.Message_MessageType) dhtHandler {
+func (dht *DHT) handlerForMsgType(t pb.Message_MessageType) dhtHandler {
 	switch t {
 	case pb.Message_FIND_NODE:
 		return dht.handleFindPeer
@@ -51,7 +51,7 @@ func (dht *IpfsDHT) handlerForMsgType(t pb.Message_MessageType) dhtHandler {
 	return nil
 }
 
-func (dht *IpfsDHT) handleGetValue(ctx context.Context, p peer.ID, pmes *pb.Message) (_ *pb.Message, err error) {
+func (dht *DHT) handleGetValue(ctx context.Context, p peer.ID, pmes *pb.Message) (_ *pb.Message, err error) {
 	// first, is there even a key?
 	k := pmes.GetKey()
 	if len(k) == 0 {
@@ -89,7 +89,7 @@ func (dht *IpfsDHT) handleGetValue(ctx context.Context, p peer.ID, pmes *pb.Mess
 	return resp, nil
 }
 
-func (dht *IpfsDHT) checkLocalDatastore(ctx context.Context, k []byte) (*recpb.Record, error) {
+func (dht *DHT) checkLocalDatastore(ctx context.Context, k []byte) (*recpb.Record, error) {
 	logger.Debugf("%s handleGetValue looking into ds", dht.self)
 	dskey := convertToDsKey(k)
 	buf, err := dht.datastore.Get(ctx, dskey)
@@ -148,7 +148,7 @@ func cleanRecord(rec *recpb.Record) {
 }
 
 // Store a value in this peer local storage
-func (dht *IpfsDHT) handlePutValue(ctx context.Context, p peer.ID, pmes *pb.Message) (_ *pb.Message, err error) {
+func (dht *DHT) handlePutValue(ctx context.Context, p peer.ID, pmes *pb.Message) (_ *pb.Message, err error) {
 	if len(pmes.GetKey()) == 0 {
 		return nil, errors.New("handleGetValue but no key was provided")
 	}
@@ -219,7 +219,7 @@ func (dht *IpfsDHT) handlePutValue(ctx context.Context, p peer.ID, pmes *pb.Mess
 
 // returns nil, nil when either nothing is found or the value found doesn't properly validate.
 // returns nil, some_error when there's a *datastore* error (i.e., something goes very wrong)
-func (dht *IpfsDHT) getRecordFromDatastore(ctx context.Context, dskey ds.Key) (*recpb.Record, error) {
+func (dht *DHT) getRecordFromDatastore(ctx context.Context, dskey ds.Key) (*recpb.Record, error) {
 	buf, err := dht.datastore.Get(ctx, dskey)
 	if err == ds.ErrNotFound {
 		return nil, nil
@@ -247,12 +247,12 @@ func (dht *IpfsDHT) getRecordFromDatastore(ctx context.Context, dskey ds.Key) (*
 	return rec, nil
 }
 
-func (dht *IpfsDHT) handlePing(_ context.Context, p peer.ID, pmes *pb.Message) (*pb.Message, error) {
+func (dht *DHT) handlePing(_ context.Context, p peer.ID, pmes *pb.Message) (*pb.Message, error) {
 	logger.Debugf("%s Responding to ping from %s!\n", dht.self, p)
 	return pmes, nil
 }
 
-func (dht *IpfsDHT) handleFindPeer(ctx context.Context, from peer.ID, pmes *pb.Message) (_ *pb.Message, _err error) {
+func (dht *DHT) handleFindPeer(ctx context.Context, from peer.ID, pmes *pb.Message) (_ *pb.Message, _err error) {
 	resp := pb.NewMessage(pmes.GetType(), nil, pmes.GetClusterLevel())
 	var closest []peer.ID
 
@@ -306,7 +306,7 @@ func (dht *IpfsDHT) handleFindPeer(ctx context.Context, from peer.ID, pmes *pb.M
 	return resp, nil
 }
 
-func (dht *IpfsDHT) handleGetProviders(ctx context.Context, p peer.ID, pmes *pb.Message) (_ *pb.Message, _err error) {
+func (dht *DHT) handleGetProviders(ctx context.Context, p peer.ID, pmes *pb.Message) (_ *pb.Message, _err error) {
 	key := pmes.GetKey()
 	if len(key) > 80 {
 		return nil, fmt.Errorf("handleGetProviders key size too large")
@@ -334,7 +334,7 @@ func (dht *IpfsDHT) handleGetProviders(ctx context.Context, p peer.ID, pmes *pb.
 	return resp, nil
 }
 
-func (dht *IpfsDHT) handleAddProvider(ctx context.Context, p peer.ID, pmes *pb.Message) (_ *pb.Message, _err error) {
+func (dht *DHT) handleAddProvider(ctx context.Context, p peer.ID, pmes *pb.Message) (_ *pb.Message, _err error) {
 	key := pmes.GetKey()
 	if len(key) > 80 {
 		return nil, fmt.Errorf("handleAddProvider key size too large")

--- a/lookup.go
+++ b/lookup.go
@@ -21,8 +21,8 @@ import (
 //
 // If the context is canceled, this function will return the context error along
 // with the closest K peers it has found so far.
-func (dht *IpfsDHT) GetClosestPeers(ctx context.Context, key string) ([]peer.ID, error) {
-	ctx, span := internal.StartSpan(ctx, "IpfsDHT.GetClosestPeers", trace.WithAttributes(attribute.String("Key", key)))
+func (dht *DHT) GetClosestPeers(ctx context.Context, key string) ([]peer.ID, error) {
+	ctx, span := internal.StartSpan(ctx, "DHT.GetClosestPeers", trace.WithAttributes(attribute.String("Key", key)))
 	defer span.End()
 
 	if key == "" {
@@ -56,7 +56,7 @@ func (dht *IpfsDHT) GetClosestPeers(ctx context.Context, key string) ([]peer.ID,
 }
 
 // pmGetClosestPeers is the protocol messenger version of the GetClosestPeer queryFn.
-func (dht *IpfsDHT) pmGetClosestPeers(key string) queryFn {
+func (dht *DHT) pmGetClosestPeers(key string) queryFn {
 	return func(ctx context.Context, p peer.ID) ([]*peer.AddrInfo, error) {
 		// For DHT query command
 		routing.PublishQueryEvent(ctx, &routing.QueryEvent{

--- a/lookup_optim.go
+++ b/lookup_optim.go
@@ -47,7 +47,7 @@ type optimisticState struct {
 	putCtx context.Context
 
 	// reference to the DHT
-	dht *IpfsDHT
+	dht *DHT
 
 	// the most recent network size estimation
 	networkSize int32
@@ -81,7 +81,7 @@ type optimisticState struct {
 	putProvDone atomic.Int32
 }
 
-func (dht *IpfsDHT) newOptimisticState(ctx context.Context, key string) (*optimisticState, error) {
+func (dht *DHT) newOptimisticState(ctx context.Context, key string) (*optimisticState, error) {
 	// get network size and err out if there is no reasonable estimate
 	networkSize, err := dht.nsEstimator.NetworkSize()
 	if err != nil {
@@ -107,7 +107,7 @@ func (dht *IpfsDHT) newOptimisticState(ctx context.Context, key string) (*optimi
 	}, nil
 }
 
-func (dht *IpfsDHT) optimisticProvide(outerCtx context.Context, keyMH multihash.Multihash) error {
+func (dht *DHT) optimisticProvide(outerCtx context.Context, keyMH multihash.Multihash) error {
 	key := string(keyMH)
 
 	if key == "" {

--- a/query.go
+++ b/query.go
@@ -38,7 +38,7 @@ type query struct {
 	// the query context.
 	ctx context.Context
 
-	dht *IpfsDHT
+	dht *DHT
 
 	// seedPeers is the set of peers that seed the query
 	seedPeers []peer.ID
@@ -80,8 +80,8 @@ type lookupWithFollowupResult struct {
 //
 // After the lookup is complete the query function is run (unless stopped) against all of the top K peers from the
 // lookup that have not already been successfully queried.
-func (dht *IpfsDHT) runLookupWithFollowup(ctx context.Context, target string, queryFn queryFn, stopFn stopFn) (*lookupWithFollowupResult, error) {
-	ctx, span := internal.StartSpan(ctx, "IpfsDHT.RunLookupWithFollowup", trace.WithAttributes(attribute.String("Target", target)))
+func (dht *DHT) runLookupWithFollowup(ctx context.Context, target string, queryFn queryFn, stopFn stopFn) (*lookupWithFollowupResult, error) {
+	ctx, span := internal.StartSpan(ctx, "DHT.RunLookupWithFollowup", trace.WithAttributes(attribute.String("Target", target)))
 	defer span.End()
 
 	// run the query
@@ -152,8 +152,8 @@ processFollowUp:
 	return lookupRes, nil
 }
 
-func (dht *IpfsDHT) runQuery(ctx context.Context, target string, queryFn queryFn, stopFn stopFn) (*lookupWithFollowupResult, *qpeerset.QueryPeerset, error) {
-	ctx, span := internal.StartSpan(ctx, "IpfsDHT.RunQuery")
+func (dht *DHT) runQuery(ctx context.Context, target string, queryFn queryFn, stopFn stopFn) (*lookupWithFollowupResult, *qpeerset.QueryPeerset, error) {
+	ctx, span := internal.StartSpan(ctx, "DHT.RunQuery")
 	defer span.End()
 
 	// pick the K closest peers to the key in our Routing table.
@@ -272,7 +272,7 @@ type queryUpdate struct {
 }
 
 func (q *query) run() {
-	ctx, span := internal.StartSpan(q.ctx, "IpfsDHT.Query.Run")
+	ctx, span := internal.StartSpan(q.ctx, "DHT.Query.Run")
 	defer span.End()
 
 	pathCtx, cancelPath := context.WithCancel(ctx)
@@ -319,7 +319,7 @@ func (q *query) run() {
 
 // spawnQuery starts one query, if an available heard peer is found
 func (q *query) spawnQuery(ctx context.Context, cause peer.ID, queryPeer peer.ID, ch chan<- *queryUpdate) {
-	ctx, span := internal.StartSpan(ctx, "IpfsDHT.SpawnQuery", trace.WithAttributes(
+	ctx, span := internal.StartSpan(ctx, "DHT.SpawnQuery", trace.WithAttributes(
 		attribute.String("Cause", cause.String()),
 		attribute.String("QueryPeer", queryPeer.String()),
 	))
@@ -391,7 +391,7 @@ func (q *query) isStarvationTermination() bool {
 }
 
 func (q *query) terminate(ctx context.Context, cancel context.CancelFunc, reason LookupTerminationReason) {
-	ctx, span := internal.StartSpan(ctx, "IpfsDHT.Query.Terminate", trace.WithAttributes(attribute.Stringer("Reason", reason)))
+	ctx, span := internal.StartSpan(ctx, "DHT.Query.Terminate", trace.WithAttributes(attribute.Stringer("Reason", reason)))
 	defer span.End()
 
 	if q.terminated {
@@ -417,7 +417,7 @@ func (q *query) terminate(ctx context.Context, cancel context.CancelFunc, reason
 func (q *query) queryPeer(ctx context.Context, ch chan<- *queryUpdate, p peer.ID) {
 	defer q.waitGroup.Done()
 
-	ctx, span := internal.StartSpan(ctx, "IpfsDHT.QueryPeer")
+	ctx, span := internal.StartSpan(ctx, "DHT.QueryPeer")
 	defer span.End()
 
 	dialCtx, queryCtx := ctx, ctx
@@ -525,8 +525,8 @@ func (q *query) updateState(ctx context.Context, up *queryUpdate) {
 	}
 }
 
-func (dht *IpfsDHT) dialPeer(ctx context.Context, p peer.ID) error {
-	ctx, span := internal.StartSpan(ctx, "IpfsDHT.DialPeer", trace.WithAttributes(attribute.String("PeerID", p.String())))
+func (dht *DHT) dialPeer(ctx context.Context, p peer.ID) error {
+	ctx, span := internal.StartSpan(ctx, "DHT.DialPeer", trace.WithAttributes(attribute.String("PeerID", p.String())))
 	defer span.End()
 
 	// short-circuit if we're already connected.

--- a/query_test.go
+++ b/query_test.go
@@ -111,7 +111,7 @@ func TestRTAdditionOnSuccessfulQuery(t *testing.T) {
 	}))
 }
 
-func checkRoutingTable(a, b *IpfsDHT) bool {
+func checkRoutingTable(a, b *DHT) bool {
 	// loop until connection notification has been received.
 	// under high load, this may not happen as immediately as we would like.
 	return a.routingTable.Find(b.self) != "" && b.routingTable.Find(a.self) != ""

--- a/records.go
+++ b/records.go
@@ -19,8 +19,8 @@ type pubkrs struct {
 
 // GetPublicKey gets the public key when given a Peer ID. It will extract from
 // the Peer ID if inlined or ask the node it belongs to or ask the DHT.
-func (dht *IpfsDHT) GetPublicKey(ctx context.Context, p peer.ID) (ci.PubKey, error) {
-	ctx, span := internal.StartSpan(ctx, "IpfsDHT.GetPublicKey", trace.WithAttributes(attribute.Stringer("PeerID", p)))
+func (dht *DHT) GetPublicKey(ctx context.Context, p peer.ID) (ci.PubKey, error) {
+	ctx, span := internal.StartSpan(ctx, "DHT.GetPublicKey", trace.WithAttributes(attribute.Stringer("PeerID", p)))
 	defer span.End()
 
 	if !dht.enableValues {
@@ -77,7 +77,7 @@ func (dht *IpfsDHT) GetPublicKey(ctx context.Context, p peer.ID) (ci.PubKey, err
 	return nil, err
 }
 
-func (dht *IpfsDHT) getPublicKeyFromDHT(ctx context.Context, p peer.ID) (ci.PubKey, error) {
+func (dht *DHT) getPublicKeyFromDHT(ctx context.Context, p peer.ID) (ci.PubKey, error) {
 	// Only retrieve one value, because the public key is immutable
 	// so there's no need to retrieve multiple versions
 	pkkey := routing.KeyForPublicKey(p)
@@ -98,7 +98,7 @@ func (dht *IpfsDHT) getPublicKeyFromDHT(ctx context.Context, p peer.ID) (ci.PubK
 	return pubk, nil
 }
 
-func (dht *IpfsDHT) getPublicKeyFromNode(ctx context.Context, p peer.ID) (ci.PubKey, error) {
+func (dht *DHT) getPublicKeyFromNode(ctx context.Context, p peer.ID) (ci.PubKey, error) {
 	// check locally, just in case...
 	pk := dht.peerstore.PubKey(p)
 	if pk != nil {

--- a/rt_diversity_filter_test.go
+++ b/rt_diversity_filter_test.go
@@ -74,8 +74,8 @@ func TestRoutingTableEndToEndMaxPerCpl(t *testing.T) {
 	require.NoError(t, err)
 	defer d.Close()
 
-	var d2 *IpfsDHT
-	var d3 *IpfsDHT
+	var d2 *DHT
+	var d3 *DHT
 
 	for {
 		d2 = setupDHT(ctx, t, false)
@@ -137,15 +137,15 @@ func TestRoutingTableEndToEndMaxPerTable(t *testing.T) {
 	// only 3 peers per prefix for the table.
 	d2 := setupDHT(ctx, t, false, DisableAutoRefresh())
 	connect(t, ctx, d, d2)
-	waitForWellFormedTables(t, []*IpfsDHT{d}, 1, 1, 1*time.Second)
+	waitForWellFormedTables(t, []*DHT{d}, 1, 1, 1*time.Second)
 
 	d3 := setupDHT(ctx, t, false, DisableAutoRefresh())
 	connect(t, ctx, d, d3)
-	waitForWellFormedTables(t, []*IpfsDHT{d}, 2, 2, 1*time.Second)
+	waitForWellFormedTables(t, []*DHT{d}, 2, 2, 1*time.Second)
 
 	d4 := setupDHT(ctx, t, false, DisableAutoRefresh())
 	connect(t, ctx, d, d4)
-	waitForWellFormedTables(t, []*IpfsDHT{d}, 3, 3, 1*time.Second)
+	waitForWellFormedTables(t, []*DHT{d}, 3, 3, 1*time.Second)
 
 	d5 := setupDHT(ctx, t, false, DisableAutoRefresh())
 	connectNoSync(t, ctx, d, d5)

--- a/subscriber_notifee.go
+++ b/subscriber_notifee.go
@@ -9,7 +9,7 @@ import (
 	"github.com/libp2p/go-libp2p/p2p/host/eventbus"
 )
 
-func (dht *IpfsDHT) startNetworkSubscriber() error {
+func (dht *DHT) startNetworkSubscriber() error {
 	bufSize := eventbus.BufSize(256)
 
 	evts := []interface{}{
@@ -89,7 +89,7 @@ func (dht *IpfsDHT) startNetworkSubscriber() error {
 	return nil
 }
 
-func handlePeerChangeEvent(dht *IpfsDHT, p peer.ID) {
+func handlePeerChangeEvent(dht *DHT, p peer.ID) {
 	valid, err := dht.validRTPeer(p)
 	if err != nil {
 		logger.Errorf("could not check peerstore for protocol support: err: %s", err)
@@ -101,7 +101,7 @@ func handlePeerChangeEvent(dht *IpfsDHT, p peer.ID) {
 	}
 }
 
-func handleLocalReachabilityChangedEvent(dht *IpfsDHT, e event.EvtLocalReachabilityChanged) {
+func handleLocalReachabilityChangedEvent(dht *DHT, e event.EvtLocalReachabilityChanged) {
 	var target mode
 
 	switch e.Reachability {
@@ -131,7 +131,7 @@ func handleLocalReachabilityChangedEvent(dht *IpfsDHT, e event.EvtLocalReachabil
 // validRTPeer returns true if the peer supports the DHT protocol and false otherwise. Supporting the DHT protocol means
 // supporting the primary protocols, we do not want to add peers that are speaking obsolete secondary protocols to our
 // routing table
-func (dht *IpfsDHT) validRTPeer(p peer.ID) (bool, error) {
+func (dht *DHT) validRTPeer(p peer.ID) (bool, error) {
 	b, err := dht.peerstore.FirstSupportedProtocol(p, dht.protocols...)
 	if len(b) == 0 || err != nil {
 		return false, err


### PR DESCRIPTION
This is not compiling and should just showcase how go-kademlia could be used to start a findPeer query with the current implementation.

Interesting bits happen in routing.go and dht.go

cc @iand 