### PR TITLE
Enhance handleNewMessage Server Mode Logging: Convert Error Logs to Debug Level

### DIFF
--- a/dht_net.go
+++ b/dht_net.go
@@ -44,7 +44,7 @@ func (dht *IpfsDHT) handleNewMessage(s network.Stream) bool {
 
 	for {
 		if dht.getMode() != modeServer {
-			logger.Errorf("ignoring incoming dht message while not in server mode")
+			logger.Debugf("ignoring incoming dht message while not in server mode")
 			return false
 		}
 


### PR DESCRIPTION
The current implementation of the **handleNewMessage** function exclusively processes messages in server mode, generating error logs and returning false for non-server mode cases. This leads to a repetitive logging of this error message whenever the node isn't in server mode:
`ignoring incoming dht message while not in server mode`
This PR enhances the function by elevating the error log to the debug level.