### PR TITLE
Test query interactions with routing table

### DIFF
--- a/v2/coord/coordinator.go
+++ b/v2/coord/coordinator.go
@@ -451,3 +451,32 @@ func (c *Coordinator) Bootstrap(ctx context.Context, seeds []peer.ID) error {
 
 	return nil
 }
+
+// NotifyConnectivity notifies the coordinator that a peer has passed a connectivity check
+// which means it is connected and supports finding closer nodes
+func (c *Coordinator) NotifyConnectivity(ctx context.Context, id peer.ID) error {
+	ctx, span := c.cfg.Tele.Tracer.Start(ctx, "Coordinator.NotifyConnectivity")
+	defer span.End()
+
+	ai := peer.AddrInfo{
+		ID: id,
+	}
+	c.routingBehaviour.Notify(ctx, &EventNotifyConnectivity{
+		NodeInfo: ai,
+	})
+
+	return nil
+}
+
+// NotifyNonConnectivity notifies the coordinator that a peer has failed a connectivity check
+// which means it is not connected and/or it doesn't support finding closer nodes
+func (c *Coordinator) NotifyNonConnectivity(ctx context.Context, id peer.ID) error {
+	ctx, span := c.cfg.Tele.Tracer.Start(ctx, "Coordinator.NotifyConnectivity")
+	defer span.End()
+
+	c.routingBehaviour.Notify(ctx, &EventNotifyNonConnectivity{
+		NodeID: id,
+	})
+
+	return nil
+}

--- a/v2/coord/event.go
+++ b/v2/coord/event.go
@@ -86,6 +86,8 @@ type EventStopQuery struct {
 func (*EventStopQuery) behaviourEvent() {}
 func (*EventStopQuery) queryCommand()   {}
 
+// EventAddAddrInfo notifies the routing behaviour of a potential new peer or of additional addresses for
+// an existing peer.
 type EventAddAddrInfo struct {
 	NodeInfo peer.AddrInfo
 	TTL      time.Duration
@@ -94,9 +96,11 @@ type EventAddAddrInfo struct {
 func (*EventAddAddrInfo) behaviourEvent() {}
 func (*EventAddAddrInfo) routingCommand() {}
 
+// EventGetCloserNodesSuccess notifies a behaviour that a GetCloserNodes request, initiated by an
+// [EventOutboundGetCloserNodes] event has produced a successful response.
 type EventGetCloserNodesSuccess struct {
 	QueryID     query.QueryID
-	To          peer.AddrInfo
+	To          peer.AddrInfo // To is the peer address that the GetCloserNodes request was sent to.
 	Target      KadKey
 	CloserNodes []peer.AddrInfo
 }
@@ -104,9 +108,11 @@ type EventGetCloserNodesSuccess struct {
 func (*EventGetCloserNodesSuccess) behaviourEvent()      {}
 func (*EventGetCloserNodesSuccess) nodeHandlerResponse() {}
 
+// EventGetCloserNodesFailure notifies a behaviour that a GetCloserNodes request, initiated by an
+// [EventOutboundGetCloserNodes] event has failed to produce a valid response.
 type EventGetCloserNodesFailure struct {
 	QueryID query.QueryID
-	To      peer.AddrInfo
+	To      peer.AddrInfo // To is the peer address that the GetCloserNodes request was sent to.
 	Target  KadKey
 	Err     error
 }
@@ -142,6 +148,14 @@ type EventRoutingUpdated struct {
 func (*EventRoutingUpdated) behaviourEvent()      {}
 func (*EventRoutingUpdated) routingNotification() {}
 
+// EventRoutingRemoved is emitted by the coordinator when new node has been removed from the routing table.
+type EventRoutingRemoved struct {
+	NodeID peer.ID
+}
+
+func (*EventRoutingRemoved) behaviourEvent()      {}
+func (*EventRoutingRemoved) routingNotification() {}
+
 // EventBootstrapFinished is emitted by the coordinator when a bootstrap has finished, either through
 // running to completion or by being canceled.
 type EventBootstrapFinished struct {
@@ -150,3 +164,23 @@ type EventBootstrapFinished struct {
 
 func (*EventBootstrapFinished) behaviourEvent()      {}
 func (*EventBootstrapFinished) routingNotification() {}
+
+// EventNotifyConnectivity notifies a behaviour that a peer's connectivity and support for finding closer nodes
+// has been confirmed such as from a successful query response or an inbound query. This should not be used for
+// general connections to the host but only when it is confirmed that the peer responds to requests for closer
+// nodes.
+type EventNotifyConnectivity struct {
+	NodeInfo peer.AddrInfo
+}
+
+func (*EventNotifyConnectivity) behaviourEvent()      {}
+func (*EventNotifyConnectivity) routingNotification() {}
+
+// EventNotifyNonConnectivity notifies a behaviour that a peer does not have connectivity and/or does not support
+// finding closer nodes is known.
+type EventNotifyNonConnectivity struct {
+	NodeID peer.ID
+}
+
+func (*EventNotifyNonConnectivity) behaviourEvent() {}
+func (*EventNotifyNonConnectivity) routingCommand() {}

--- a/v2/coord/query.go
+++ b/v2/coord/query.go
@@ -83,6 +83,11 @@ func (p *PooledQueryBehaviour) Notify(ctx context.Context, ev BehaviourEvent) {
 			Response: CloserNodesResponse(ev.Target, ev.CloserNodes),
 		}
 	case *EventGetCloserNodesFailure:
+		// queue an event that will notify the routing behaviour of a failed node
+		p.pending = append(p.pending, &EventNotifyNonConnectivity{
+			ev.To.ID,
+		})
+
 		cmd = &query.EventPoolMessageFailure[KadKey]{
 			NodeID:  kadt.PeerID(ev.To.ID),
 			QueryID: ev.QueryID,

--- a/v2/handlers.go
+++ b/v2/handlers.go
@@ -25,6 +25,9 @@ func (d *DHT) handleFindPeer(ctx context.Context, remote peer.ID, req *pb.Messag
 		return nil, fmt.Errorf("handleFindPeer with empty key")
 	}
 
+	// tell the coordinator that this peer supports finding closer nodes
+	d.kad.NotifyConnectivity(ctx, remote)
+
 	// "parse" requested peer ID from the key field
 	target := peer.ID(req.GetKey())
 

--- a/v2/notifee.go
+++ b/v2/notifee.go
@@ -1,10 +1,13 @@
 package dht
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/libp2p/go-libp2p/core/event"
 	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/peerstore"
 )
 
 // networkEventsSubscription registers a subscription on the libp2p event bus
@@ -49,6 +52,7 @@ func (d *DHT) consumeNetworkEvents(sub event.Subscription) {
 		case event.EvtLocalAddressesUpdated:
 		case event.EvtPeerProtocolsUpdated:
 		case event.EvtPeerIdentificationCompleted:
+			d.onEvtPeerIdentificationCompleted(evt)
 		case event.EvtPeerConnectednessChanged:
 		default:
 			d.log.Warn("unknown libp2p event", "type", fmt.Sprintf("%T", evt))
@@ -83,4 +87,11 @@ func (d *DHT) onEvtLocalReachabilityChanged(evt event.EvtLocalReachabilityChange
 	default:
 		d.log.With("reachability", evt.Reachability).Warn("unknown reachability type")
 	}
+}
+
+func (d *DHT) onEvtPeerIdentificationCompleted(evt event.EvtPeerIdentificationCompleted) {
+	// tell the coordinator about a new candidate for inclusion in the routing table
+	d.kad.AddNodes(context.Background(), []peer.AddrInfo{
+		{ID: evt.Peer},
+	}, peerstore.RecentlyConnectedAddrTTL)
 }

--- a/v2/query_test.go
+++ b/v2/query_test.go
@@ -1,10 +1,16 @@
 package dht
 
 import (
+	"context"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/libp2p/go-libp2p"
+	"github.com/libp2p/go-libp2p-kad-dht/v2/coord"
+	"github.com/libp2p/go-libp2p-kad-dht/v2/internal/kadtest"
 	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/stretchr/testify/require"
 )
 
@@ -47,6 +53,9 @@ func newServerDht(t testing.TB, cfg *Config) *DHT {
 	d, err := New(h, cfg)
 	require.NoError(t, err)
 
+	// add at least 1 entry in the routing table so the server will pass connectivity checks
+	fillRoutingTable(t, d, 1)
+
 	t.Cleanup(func() {
 		if err = d.Close(); err != nil {
 			t.Logf("unexpected error when closing dht: %s", err)
@@ -71,4 +80,139 @@ func newClientDht(t testing.TB, cfg *Config) *DHT {
 		}
 	})
 	return d
+}
+
+// expectRoutingUpdated selects on the event channel until an EventRoutingUpdated event is seen for the specified peer id
+func expectRoutingUpdated(t *testing.T, ctx context.Context, events <-chan coord.RoutingNotification, id peer.ID) (*coord.EventRoutingUpdated, error) {
+	t.Helper()
+	for {
+		select {
+		case ev := <-events:
+			if tev, ok := ev.(*coord.EventRoutingUpdated); ok {
+				if tev.NodeInfo.ID == id {
+					return tev, nil
+				}
+				t.Logf("saw routing update for %s", tev.NodeInfo.ID)
+			}
+		case <-ctx.Done():
+			return nil, fmt.Errorf("test deadline exceeded while waiting for routing update event")
+		}
+	}
+}
+
+// expectRoutingUpdated selects on the event channel until an EventRoutingUpdated event is seen for the specified peer id
+func expectRoutingRemoved(t *testing.T, ctx context.Context, events <-chan coord.RoutingNotification, id peer.ID) (*coord.EventRoutingRemoved, error) {
+	t.Helper()
+	for {
+		select {
+		case ev := <-events:
+			if tev, ok := ev.(*coord.EventRoutingRemoved); ok {
+				if tev.NodeID == id {
+					return tev, nil
+				}
+				t.Logf("saw routing removed for %s", tev.NodeID)
+			}
+		case <-ctx.Done():
+			return nil, fmt.Errorf("test deadline exceeded while waiting for routing removed event")
+		}
+	}
+}
+
+func connect(t *testing.T, ctx context.Context, a, b *DHT) {
+	t.Helper()
+
+	remoteAddrInfo := peer.AddrInfo{
+		ID:    b.host.ID(),
+		Addrs: b.host.Addrs(),
+	}
+
+	// Add b's addresss to a
+	err := a.AddAddresses(ctx, []peer.AddrInfo{remoteAddrInfo}, time.Minute)
+	require.NoError(t, err)
+
+	// the include state machine runs in the background for a and eventually should add the node to routing table
+	_, err = expectRoutingUpdated(t, ctx, a.kad.RoutingNotifications(), b.host.ID())
+	require.NoError(t, err)
+
+	// the routing table should now contain the node
+	_, err = a.kad.GetNode(ctx, b.host.ID())
+	require.NoError(t, err)
+}
+
+// connectLinearChain connects the dhts together in a linear chain.
+// The dhts are configured with routing tables that contain immediate neighbours.
+func connectLinearChain(t *testing.T, ctx context.Context, dhts ...*DHT) {
+	for i := 1; i < len(dhts); i++ {
+		connect(t, ctx, dhts[i-1], dhts[i])
+		connect(t, ctx, dhts[i], dhts[i-1])
+	}
+}
+
+func TestRTAdditionOnSuccessfulQuery(t *testing.T) {
+	ctx := kadtest.CtxShort(t)
+
+	d1 := newServerDht(t, nil)
+	d2 := newServerDht(t, nil)
+	d3 := newServerDht(t, nil)
+
+	connectLinearChain(t, ctx, d1, d2, d3)
+
+	// d3 does not know about d1
+	_, err := d3.kad.GetNode(ctx, d1.host.ID())
+	require.ErrorIs(t, err, coord.ErrNodeNotFound)
+
+	// d1 does not know about d3
+	_, err = d1.kad.GetNode(ctx, d3.host.ID())
+	require.ErrorIs(t, err, coord.ErrNodeNotFound)
+
+	// // but when d3 queries d2, d1 and d3 discover each other
+	_, _ = d3.FindPeer(ctx, "something")
+	// ignore the error
+
+	// d3 should update its routing table to include d1 during the query
+	_, err = expectRoutingUpdated(t, ctx, d3.kad.RoutingNotifications(), d1.host.ID())
+	require.NoError(t, err)
+
+	// d3 now has d1 in its routing table
+	_, err = d3.kad.GetNode(ctx, d1.host.ID())
+	require.NoError(t, err)
+
+	// d1 should update its routing table to include d3 during the query
+	_, err = expectRoutingUpdated(t, ctx, d1.kad.RoutingNotifications(), d3.host.ID())
+	require.NoError(t, err)
+
+	// d1 now has d3 in its routing table
+	_, err = d1.kad.GetNode(ctx, d3.host.ID())
+	require.NoError(t, err)
+}
+
+func TestRTEvictionOnFailedQuery(t *testing.T) {
+	ctx := kadtest.CtxShort(t)
+
+	d1 := newServerDht(t, nil)
+	d2 := newServerDht(t, nil)
+	connect(t, ctx, d1, d2)
+	connect(t, ctx, d2, d1)
+
+	// close both hosts so query fails
+	require.NoError(t, d1.host.Close())
+	require.NoError(t, d2.host.Close())
+
+	// peers will still be in the RT because time is paused and
+	// no scheduled probes will have taken place
+
+	// d1 still has d2 in the routing table
+	_, err := d1.kad.GetNode(ctx, d2.host.ID())
+	require.NoError(t, err)
+
+	// d2 still has d1 in the routing table
+	_, err = d2.kad.GetNode(ctx, d1.host.ID())
+	require.NoError(t, err)
+
+	// failed queries should remove the queried peers from the routing table
+	_, _ = d1.FindPeer(ctx, "test")
+
+	// d1 should update its routing table to remove d2 because of the failure
+	_, err = expectRoutingRemoved(t, ctx, d1.kad.RoutingNotifications(), d2.host.ID())
+	require.NoError(t, err)
 }


### PR DESCRIPTION
This change ports two tests from v1: TestRTAdditionOnSuccessfulQuery and TestRTEvictionOnFailedQuery

Note: this is dependent on a fix in go-kademlia which recently updated to go 1.21 so doesn't build with this version of go-libp2p-kad-dht
