### PR TITLE
Give dht and coordinator their own telemetry instances

### DIFF
--- a/v2/backend_provider.go
+++ b/v2/backend_provider.go
@@ -92,7 +92,7 @@ type ProvidersBackendConfig struct {
 
 	// Tele holds a reference to the telemetry struct to capture metrics and
 	// traces.
-	Tele *tele.Telemetry
+	Tele *Telemetry
 
 	// AddressFilter is a filter function that any addresses that we attempt to
 	// store or fetch from the peerstore's address book need to pass through.
@@ -106,7 +106,7 @@ type ProvidersBackendConfig struct {
 // configuration is passed to [NewBackendProvider], this default configuration
 // here is used.
 func DefaultProviderBackendConfig() (*ProvidersBackendConfig, error) {
-	telemetry, err := tele.NewWithGlobalProviders()
+	telemetry, err := NewWithGlobalProviders()
 	if err != nil {
 		return nil, fmt.Errorf("new telemetry: %w", err)
 	}

--- a/v2/backend_record.go
+++ b/v2/backend_record.go
@@ -11,8 +11,6 @@ import (
 	record "github.com/libp2p/go-libp2p-record"
 	recpb "github.com/libp2p/go-libp2p-record/pb"
 	"golang.org/x/exp/slog"
-
-	"github.com/libp2p/go-libp2p-kad-dht/v2/tele"
 )
 
 type RecordBackend struct {
@@ -29,11 +27,11 @@ type RecordBackendConfig struct {
 	clk          clock.Clock
 	MaxRecordAge time.Duration
 	Logger       *slog.Logger
-	Tele         *tele.Telemetry
+	Tele         *Telemetry
 }
 
 func DefaultRecordBackendConfig() (*RecordBackendConfig, error) {
-	telemetry, err := tele.NewWithGlobalProviders()
+	telemetry, err := NewWithGlobalProviders()
 	if err != nil {
 		return nil, fmt.Errorf("new telemetry: %w", err)
 	}

--- a/v2/config.go
+++ b/v2/config.go
@@ -11,7 +11,6 @@ import (
 	"github.com/libp2p/go-libp2p/core/protocol"
 	ma "github.com/multiformats/go-multiaddr"
 	manet "github.com/multiformats/go-multiaddr/net"
-	"github.com/plprobelab/go-kademlia/coord"
 	"github.com/plprobelab/go-kademlia/kad"
 	"github.com/plprobelab/go-kademlia/key"
 	"github.com/plprobelab/go-kademlia/routing"
@@ -21,6 +20,8 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap/exp/zapslog"
 	"golang.org/x/exp/slog"
+
+	"github.com/libp2p/go-libp2p-kad-dht/v2/coord"
 )
 
 // ServiceName is used to scope incoming streams for the resource manager.
@@ -112,7 +113,7 @@ type Config struct {
 	Mode ModeOpt
 
 	// Kademlia holds the configuration of the underlying Kademlia implementation.
-	Kademlia *coord.Config
+	Kademlia *coord.CoordinatorConfig
 
 	// BucketSize determines the number of closer peers to return
 	BucketSize int
@@ -182,7 +183,7 @@ func DefaultConfig() *Config {
 	return &Config{
 		Clock:             clock.New(),
 		Mode:              ModeOptAutoClient,
-		Kademlia:          coord.DefaultConfig(),
+		Kademlia:          coord.DefaultCoordinatorConfig(),
 		BucketSize:        20, // MAGIC
 		ProtocolID:        ProtocolIPFS,
 		RoutingTable:      nil,                  // nil because a routing table requires information about the local node. triert.TrieRT will be used if this field is nil.

--- a/v2/coord/telemetry.go
+++ b/v2/coord/telemetry.go
@@ -1,0 +1,28 @@
+package coord
+
+import (
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/libp2p/go-libp2p-kad-dht/v2/tele"
+)
+
+// Telemetry is the struct that holds a reference to all metrics and the tracer used
+// by the coordinator and its components.
+// Make sure to also register the [MeterProviderOpts] with your custom or the global
+// [metric.MeterProvider].
+type Telemetry struct {
+	Tracer trace.Tracer
+	// TODO: define metrics produced by coordinator
+}
+
+// NewTelemetry initializes a Telemetry struct with the given meter and tracer providers.
+func NewTelemetry(meterProvider metric.MeterProvider, tracerProvider trace.TracerProvider) (*Telemetry, error) {
+	t := &Telemetry{
+		Tracer: tracerProvider.Tracer(tele.TracerName),
+	}
+
+	// TODO: Initalize metrics produced by the coordinator
+
+	return t, nil
+}

--- a/v2/dht.go
+++ b/v2/dht.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/libp2p/go-libp2p-kad-dht/v2/coord"
 	"github.com/libp2p/go-libp2p-kad-dht/v2/kadt"
-	"github.com/libp2p/go-libp2p-kad-dht/v2/tele"
 )
 
 // DHT is an implementation of Kademlia with S/Kademlia modifications.
@@ -58,7 +57,7 @@ type DHT struct {
 	sub event.Subscription
 
 	// tele holds a reference to a telemetry struct
-	tele *tele.Telemetry
+	tele *Telemetry
 }
 
 // New constructs a new [DHT] for the given underlying host and with the given
@@ -88,7 +87,7 @@ func New(h host.Host, cfg *Config) (*DHT, error) {
 	}
 
 	// initialize a new telemetry struct
-	d.tele, err = tele.New(cfg.MeterProvider, cfg.TracerProvider)
+	d.tele, err = NewTelemetry(cfg.MeterProvider, cfg.TracerProvider)
 	if err != nil {
 		return nil, fmt.Errorf("init telemetry: %w", err)
 	}
@@ -152,11 +151,9 @@ func New(h host.Host, cfg *Config) (*DHT, error) {
 	}
 
 	// instantiate a new Kademlia DHT coordinator.
-	coordCfg, err := coord.DefaultCoordinatorConfig()
-	if err != nil {
-		return nil, fmt.Errorf("new coordinator config: %w", err)
-	}
-	coordCfg.Tele = d.tele
+	coordCfg := coord.DefaultCoordinatorConfig()
+	coordCfg.MeterProvider = cfg.MeterProvider
+	coordCfg.TracerProvider = cfg.TracerProvider
 
 	d.kad, err = coord.NewCoordinator(d.host.ID(), &Router{host: h}, d.rt, coordCfg)
 	if err != nil {

--- a/v2/tele/tele.go
+++ b/v2/tele/tele.go
@@ -2,141 +2,24 @@ package tele
 
 import (
 	"context"
-	"fmt"
 
-	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/sdk/instrumentation"
 	motel "go.opentelemetry.io/otel/sdk/metric"
-	"go.opentelemetry.io/otel/trace"
 )
 
 // ctxKey is an unexported type alias for the value of a context key. This is
 // used to attach metric values to a context and get them out of a context.
 type ctxKey struct{}
 
-var (
-	meterName  = "github.com/libp2p/go-libp2p-kad-dht/v2"
-	tracerName = "go-libp2p-kad-dht"
-
-	// attrsCtxKey is the actual context key value that's used as a key for
-	// metric values that are attached to a context.
-	attrsCtxKey = ctxKey{}
+const (
+	MeterName  = "github.com/libp2p/go-libp2p-kad-dht/v2"
+	TracerName = "go-libp2p-kad-dht"
 )
 
-// Telemetry is the struct that holds a reference to all metrics and the tracer.
-// Initialize this struct with [New] or [NewWithGlobalProviders]. Make sure
-// to also register the [MeterProviderOpts] with your custom or the global
-// [metric.MeterProvider].
-//
-// To see the documentation for each metric below, check out [New] and the
-// metric.WithDescription() calls when initializing each metric.
-type Telemetry struct {
-	Tracer                 trace.Tracer
-	ReceivedMessages       metric.Int64Counter
-	ReceivedMessageErrors  metric.Int64Counter
-	ReceivedBytes          metric.Int64Histogram
-	InboundRequestLatency  metric.Float64Histogram
-	OutboundRequestLatency metric.Float64Histogram
-	SentMessages           metric.Int64Counter
-	SentMessageErrors      metric.Int64Counter
-	SentRequests           metric.Int64Counter
-	SentRequestErrors      metric.Int64Counter
-	SentBytes              metric.Int64Histogram
-	LRUCache               metric.Int64Counter
-	NetworkSize            metric.Int64Counter
-}
-
-// NewWithGlobalProviders uses the global meter and tracer providers from
-// opentelemetry. Check out the documentation of [MeterProviderOpts] for
-// implications of using this constructor.
-func NewWithGlobalProviders() (*Telemetry, error) {
-	return New(otel.GetMeterProvider(), otel.GetTracerProvider())
-}
-
-// New initializes a Telemetry struct with the given meter and tracer providers.
-// It constructs the different metric counters and histograms. The histograms
-// have custom boundaries. Therefore, the given [metric.MeterProvider] should
-// have the custom view registered that [MeterProviderOpts] returns.
-func New(meterProvider metric.MeterProvider, tracerProvider trace.TracerProvider) (*Telemetry, error) {
-	var err error
-
-	if meterProvider == nil {
-		meterProvider = otel.GetMeterProvider()
-	}
-
-	if tracerProvider == nil {
-		tracerProvider = otel.GetTracerProvider()
-	}
-
-	t := &Telemetry{
-		Tracer: tracerProvider.Tracer(tracerName),
-	}
-
-	meter := meterProvider.Meter(meterName)
-	t.ReceivedMessages, err = meter.Int64Counter("received_messages", metric.WithDescription("Total number of messages received per RPC"), metric.WithUnit("1"))
-	if err != nil {
-		return nil, fmt.Errorf("received_messages counter: %w", err)
-	}
-
-	t.ReceivedMessageErrors, err = meter.Int64Counter("received_message_errors", metric.WithDescription("Total number of errors for messages received per RPC"), metric.WithUnit("1"))
-	if err != nil {
-		return nil, fmt.Errorf("received_message_errors counter: %w", err)
-	}
-
-	t.ReceivedBytes, err = meter.Int64Histogram("received_bytes", metric.WithDescription("Total received bytes per RPC"), metric.WithUnit("By"))
-	if err != nil {
-		return nil, fmt.Errorf("received_bytes histogram: %w", err)
-	}
-
-	t.InboundRequestLatency, err = meter.Float64Histogram("inbound_request_latency", metric.WithDescription("Latency per RPC"), metric.WithUnit("ms"))
-	if err != nil {
-		return nil, fmt.Errorf("inbound_request_latency histogram: %w", err)
-	}
-
-	t.OutboundRequestLatency, err = meter.Float64Histogram("outbound_request_latency", metric.WithDescription("Latency per RPC"), metric.WithUnit("ms"))
-	if err != nil {
-		return nil, fmt.Errorf("outbound_request_latency histogram: %w", err)
-	}
-
-	t.SentMessages, err = meter.Int64Counter("sent_messages", metric.WithDescription("Total number of messages sent per RPC"), metric.WithUnit("1"))
-	if err != nil {
-		return nil, fmt.Errorf("sent_messages counter: %w", err)
-	}
-
-	t.SentMessageErrors, err = meter.Int64Counter("sent_message_errors", metric.WithDescription("Total number of errors for messages sent per RPC"), metric.WithUnit("1"))
-	if err != nil {
-		return nil, fmt.Errorf("sent_message_errors counter: %w", err)
-	}
-
-	t.SentRequests, err = meter.Int64Counter("sent_requests", metric.WithDescription("Total number of requests sent per RPC"), metric.WithUnit("1"))
-	if err != nil {
-		return nil, fmt.Errorf("sent_requests counter: %w", err)
-	}
-
-	t.SentRequestErrors, err = meter.Int64Counter("sent_request_errors", metric.WithDescription("Total number of errors for requests sent per RPC"), metric.WithUnit("1"))
-	if err != nil {
-		return nil, fmt.Errorf("sent_request_errors counter: %w", err)
-	}
-
-	t.SentBytes, err = meter.Int64Histogram("sent_bytes", metric.WithDescription("Total sent bytes per RPC"), metric.WithUnit("By"))
-	if err != nil {
-		return nil, fmt.Errorf("sent_bytes histogram: %w", err)
-	}
-
-	t.LRUCache, err = meter.Int64Counter("lru_cache", metric.WithDescription("Cache hit or miss counter"), metric.WithUnit("1"))
-	if err != nil {
-		return nil, fmt.Errorf("lru_cache counter: %w", err)
-	}
-
-	t.NetworkSize, err = meter.Int64Counter("network_size", metric.WithDescription("Network size estimation"), metric.WithUnit("1"))
-	if err != nil {
-		return nil, fmt.Errorf("network_size counter: %w", err)
-	}
-
-	return t, nil
-}
+// attrsCtxKey is the actual context key value that's used as a key for
+// metric values that are attached to a context.
+var attrsCtxKey = ctxKey{}
 
 // MeterProviderOpts is a method that returns metric options. Make sure
 // to register these options to your [metric.MeterProvider]. Unfortunately,
@@ -157,7 +40,7 @@ func New(meterProvider metric.MeterProvider, tracerProvider trace.TracerProvider
 // go-libp2p-kad-dht.
 var MeterProviderOpts = []motel.Option{
 	motel.WithView(motel.NewView(
-		motel.Instrument{Name: "*_bytes", Scope: instrumentation.Scope{Name: meterName}},
+		motel.Instrument{Name: "*_bytes", Scope: instrumentation.Scope{Name: MeterName}},
 		motel.Stream{
 			Aggregation: motel.AggregationExplicitBucketHistogram{
 				Boundaries: []float64{1024, 2048, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216, 67108864, 268435456, 1073741824, 4294967296},
@@ -165,7 +48,7 @@ var MeterProviderOpts = []motel.Option{
 		},
 	)),
 	motel.WithView(motel.NewView(
-		motel.Instrument{Name: "*_request_latency", Scope: instrumentation.Scope{Name: meterName}},
+		motel.Instrument{Name: "*_request_latency", Scope: instrumentation.Scope{Name: MeterName}},
 		motel.Stream{
 			Aggregation: motel.AggregationExplicitBucketHistogram{
 				Boundaries: []float64{0.01, 0.05, 0.1, 0.3, 0.6, 0.8, 1, 2, 3, 4, 5, 6, 8, 10, 13, 16, 20, 25, 30, 40, 50, 65, 80, 100, 130, 160, 200, 250, 300, 400, 500, 650, 800, 1000, 2000, 5000, 10000, 20000, 50000, 100000},

--- a/v2/telemetry.go
+++ b/v2/telemetry.go
@@ -1,0 +1,120 @@
+package dht
+
+import (
+	"fmt"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/libp2p/go-libp2p-kad-dht/v2/tele"
+)
+
+// Telemetry is the struct that holds a reference to all metrics and the tracer.
+// Initialize this struct with [NewTelemetry]. Make sure
+// to also register the [MeterProviderOpts] with your custom or the global
+// [metric.MeterProvider].
+//
+// To see the documentation for each metric below, check out [NewTelemetry] and the
+// metric.WithDescription() calls when initializing each metric.
+type Telemetry struct {
+	Tracer                 trace.Tracer
+	ReceivedMessages       metric.Int64Counter
+	ReceivedMessageErrors  metric.Int64Counter
+	ReceivedBytes          metric.Int64Histogram
+	InboundRequestLatency  metric.Float64Histogram
+	OutboundRequestLatency metric.Float64Histogram
+	SentMessages           metric.Int64Counter
+	SentMessageErrors      metric.Int64Counter
+	SentRequests           metric.Int64Counter
+	SentRequestErrors      metric.Int64Counter
+	SentBytes              metric.Int64Histogram
+	LRUCache               metric.Int64Counter
+	NetworkSize            metric.Int64Counter
+}
+
+// NewTelemetry initializes a Telemetry struct with the given meter and tracer providers.
+// It constructs the different metric counters and histograms. The histograms
+// have custom boundaries. Therefore, the given [metric.MeterProvider] should
+// have the custom view registered that [MeterProviderOpts] returns.
+func NewTelemetry(meterProvider metric.MeterProvider, tracerProvider trace.TracerProvider) (*Telemetry, error) {
+	var err error
+
+	if meterProvider == nil {
+		meterProvider = otel.GetMeterProvider()
+	}
+
+	if tracerProvider == nil {
+		tracerProvider = otel.GetTracerProvider()
+	}
+
+	t := &Telemetry{
+		Tracer: tracerProvider.Tracer(tele.TracerName),
+	}
+
+	meter := meterProvider.Meter(tele.MeterName)
+
+	// Initalize metrics for the DHT
+
+	t.ReceivedMessages, err = meter.Int64Counter("received_messages", metric.WithDescription("Total number of messages received per RPC"), metric.WithUnit("1"))
+	if err != nil {
+		return nil, fmt.Errorf("received_messages counter: %w", err)
+	}
+
+	t.ReceivedMessageErrors, err = meter.Int64Counter("received_message_errors", metric.WithDescription("Total number of errors for messages received per RPC"), metric.WithUnit("1"))
+	if err != nil {
+		return nil, fmt.Errorf("received_message_errors counter: %w", err)
+	}
+
+	t.ReceivedBytes, err = meter.Int64Histogram("received_bytes", metric.WithDescription("Total received bytes per RPC"), metric.WithUnit("By"))
+	if err != nil {
+		return nil, fmt.Errorf("received_bytes histogram: %w", err)
+	}
+
+	t.InboundRequestLatency, err = meter.Float64Histogram("inbound_request_latency", metric.WithDescription("Latency per RPC"), metric.WithUnit("ms"))
+	if err != nil {
+		return nil, fmt.Errorf("inbound_request_latency histogram: %w", err)
+	}
+
+	t.OutboundRequestLatency, err = meter.Float64Histogram("outbound_request_latency", metric.WithDescription("Latency per RPC"), metric.WithUnit("ms"))
+	if err != nil {
+		return nil, fmt.Errorf("outbound_request_latency histogram: %w", err)
+	}
+
+	t.SentMessages, err = meter.Int64Counter("sent_messages", metric.WithDescription("Total number of messages sent per RPC"), metric.WithUnit("1"))
+	if err != nil {
+		return nil, fmt.Errorf("sent_messages counter: %w", err)
+	}
+
+	t.SentMessageErrors, err = meter.Int64Counter("sent_message_errors", metric.WithDescription("Total number of errors for messages sent per RPC"), metric.WithUnit("1"))
+	if err != nil {
+		return nil, fmt.Errorf("sent_message_errors counter: %w", err)
+	}
+
+	t.SentRequests, err = meter.Int64Counter("sent_requests", metric.WithDescription("Total number of requests sent per RPC"), metric.WithUnit("1"))
+	if err != nil {
+		return nil, fmt.Errorf("sent_requests counter: %w", err)
+	}
+
+	t.SentRequestErrors, err = meter.Int64Counter("sent_request_errors", metric.WithDescription("Total number of errors for requests sent per RPC"), metric.WithUnit("1"))
+	if err != nil {
+		return nil, fmt.Errorf("sent_request_errors counter: %w", err)
+	}
+
+	t.SentBytes, err = meter.Int64Histogram("sent_bytes", metric.WithDescription("Total sent bytes per RPC"), metric.WithUnit("By"))
+	if err != nil {
+		return nil, fmt.Errorf("sent_bytes histogram: %w", err)
+	}
+
+	t.LRUCache, err = meter.Int64Counter("lru_cache", metric.WithDescription("Cache hit or miss counter"), metric.WithUnit("1"))
+	if err != nil {
+		return nil, fmt.Errorf("lru_cache counter: %w", err)
+	}
+
+	t.NetworkSize, err = meter.Int64Counter("network_size", metric.WithDescription("Network size estimation"), metric.WithUnit("1"))
+	if err != nil {
+		return nil, fmt.Errorf("network_size counter: %w", err)
+	}
+
+	return t, nil
+}

--- a/v2/telemetry.go
+++ b/v2/telemetry.go
@@ -33,6 +33,13 @@ type Telemetry struct {
 	NetworkSize            metric.Int64Counter
 }
 
+// NewWithGlobalProviders uses the global meter and tracer providers from
+// opentelemetry. Check out the documentation of [MeterProviderOpts] for
+// implications of using this constructor.
+func NewWithGlobalProviders() (*Telemetry, error) {
+	return NewTelemetry(otel.GetMeterProvider(), otel.GetTracerProvider())
+}
+
 // NewTelemetry initializes a Telemetry struct with the given meter and tracer providers.
 // It constructs the different metric counters and histograms. The histograms
 // have custom boundaries. Therefore, the given [metric.MeterProvider] should


### PR DESCRIPTION
Decouple dht and coordinator metrics so we separate responsibilities cleanly. Both components will use the same meter and tracer providers by default.

This also removes the error return from DefaultCoordinatorConfig() which was only needed because it was initializing a Telemetry struct with metrics that it does not touch.