### PR TITLE
Fix test flakes that wait for routing events

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -94,7 +94,7 @@ jobs:
         with:
           run: |
             export "PATH=$PATH_386:$PATH"
-            go test -count 100 -failfast ./...
+            go test -count 20 -failfast ./...
           working-directory: ./v2
       - name: Run tests with race detector
         # speed things up. Windows and OSX VMs are slow

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -94,7 +94,7 @@ jobs:
         with:
           run: |
             export "PATH=$PATH_386:$PATH"
-            go test -count 20 -failfast ./...
+            go test ./...
           working-directory: ./v2
       - name: Run tests with race detector
         # speed things up. Windows and OSX VMs are slow

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -94,7 +94,7 @@ jobs:
         with:
           run: |
             export "PATH=$PATH_386:$PATH"
-            go test -count 100 ./...
+            go test -count 100 -failfast ./...
           working-directory: ./v2
       - name: Run tests with race detector
         # speed things up. Windows and OSX VMs are slow

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -94,7 +94,7 @@ jobs:
         with:
           run: |
             export "PATH=$PATH_386:$PATH"
-            go test ./...
+            go test -count 100 ./...
           working-directory: ./v2
       - name: Run tests with race detector
         # speed things up. Windows and OSX VMs are slow

--- a/v2/dht.go
+++ b/v2/dht.go
@@ -150,7 +150,7 @@ func New(h host.Host, cfg *Config) (*DHT, error) {
 	}
 
 	// instantiate a new Kademlia DHT coordinator.
-	coordCfg := coord.DefaultCoordinatorConfig()
+	coordCfg := cfg.Kademlia
 	coordCfg.Clock = cfg.Clock
 	coordCfg.MeterProvider = cfg.MeterProvider
 	coordCfg.TracerProvider = cfg.TracerProvider

--- a/v2/dht_test.go
+++ b/v2/dht_test.go
@@ -1,9 +1,6 @@
 package dht
 
 import (
-	"context"
-	"fmt"
-	"reflect"
 	"testing"
 	"time"
 
@@ -73,22 +70,6 @@ func TestNew(t *testing.T) {
 
 			assert.Equal(t, want.mode, got.mode)
 		})
-	}
-}
-
-// expectEventType selects on the event channel until an event of the expected type is sent.
-func expectEventType(t *testing.T, ctx context.Context, events <-chan coord.RoutingNotification, expected coord.RoutingNotification) (coord.RoutingNotification, error) {
-	t.Helper()
-	for {
-		select {
-		case ev := <-events:
-			t.Logf("saw event: %T\n", ev)
-			if reflect.TypeOf(ev) == reflect.TypeOf(expected) {
-				return ev, nil
-			}
-		case <-ctx.Done():
-			return nil, fmt.Errorf("test deadline exceeded while waiting for event %T", expected)
-		}
 	}
 }
 

--- a/v2/dht_test.go
+++ b/v2/dht_test.go
@@ -96,6 +96,8 @@ func TestAddAddresses(t *testing.T) {
 	ctx := kadtest.CtxShort(t)
 
 	localCfg := DefaultConfig()
+	rn := coord.NewBufferedRoutingNotifier()
+	localCfg.Kademlia.RoutingNotifier = rn
 
 	local := newClientDht(t, localCfg)
 
@@ -120,7 +122,7 @@ func TestAddAddresses(t *testing.T) {
 	require.NoError(t, err)
 
 	// the include state machine runs in the background and eventually should add the node to routing table
-	_, err = expectEventType(t, ctx, local.kad.RoutingNotifications(), &coord.EventRoutingUpdated{})
+	_, err = rn.Expect(ctx, &coord.EventRoutingUpdated{})
 	require.NoError(t, err)
 
 	// the routing table should now contain the node

--- a/v2/internal/kadtest/context.go
+++ b/v2/internal/kadtest/context.go
@@ -2,6 +2,7 @@ package kadtest
 
 import (
 	"context"
+	"runtime"
 	"testing"
 	"time"
 )
@@ -13,7 +14,13 @@ import (
 func CtxShort(t *testing.T) context.Context {
 	t.Helper()
 
-	timeout := 10 * time.Second
+	var timeout time.Duration
+	// Increase the timeout for 32-bit Windows
+	if runtime.GOOS == "windows" && runtime.GOARCH == "386" {
+		timeout = 60 * time.Second
+	} else {
+		timeout = 10 * time.Second
+	}
 	goal := time.Now().Add(timeout)
 
 	deadline, ok := t.Deadline()

--- a/v2/notifee_test.go
+++ b/v2/notifee_test.go
@@ -4,7 +4,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/libp2p/go-libp2p-kad-dht/v2/coord"
 	"github.com/libp2p/go-libp2p-kad-dht/v2/internal/kadtest"
+	"github.com/libp2p/go-libp2p-kad-dht/v2/kadt"
 	"github.com/libp2p/go-libp2p/core/network"
 
 	"github.com/libp2p/go-libp2p/core/event"
@@ -72,7 +74,11 @@ func TestDHT_consumeNetworkEvents_onEvtLocalReachabilityChanged(t *testing.T) {
 func TestDHT_consumeNetworkEvents_onEvtPeerIdentificationCompleted(t *testing.T) {
 	ctx := kadtest.CtxShort(t)
 
-	d1 := newServerDht(t, nil)
+	cfg1 := DefaultConfig()
+	rn1 := coord.NewBufferedRoutingNotifier()
+	cfg1.Kademlia.RoutingNotifier = rn1
+	d1 := newServerDht(t, cfg1)
+
 	d2 := newServerDht(t, nil)
 
 	// make sure d1 has the address of d2 in its peerstore
@@ -83,6 +89,6 @@ func TestDHT_consumeNetworkEvents_onEvtPeerIdentificationCompleted(t *testing.T)
 		Peer: d2.host.ID(),
 	})
 
-	_, err := expectRoutingUpdated(t, ctx, d1.kad.RoutingNotifications(), d2.host.ID())
+	_, err := rn1.ExpectRoutingUpdated(ctx, kadt.PeerID(d2.host.ID()))
 	require.NoError(t, err)
 }


### PR DESCRIPTION
Replaces the routing notification channel with a type that is passed in by the consumer. This allows tests waiting for routing notifications to deterministically buffer and inspect the entire set of notifications.

Tests in DHT package are a little more awkward to write since they have to pass in a RoutingNotifier but we need to do a pass over the test helpers anyway and should clean all of it up with some helper functions.