### PR TITLE
Add RoutingDHT that implements the routing.Routing interface

### DIFF
--- a/v2/internal/coord/coordinator.go
+++ b/v2/internal/coord/coordinator.go
@@ -383,7 +383,7 @@ func (c *Coordinator) QueryMessage(ctx context.Context, msg *pb.Message, fn coor
 	ctx, span := c.tele.Tracer.Start(ctx, "Coordinator.QueryMessage")
 	defer span.End()
 	if msg == nil {
-		return coordt.QueryStats{}, fmt.Errorf("no message supplied for query")
+		return nil, coordt.QueryStats{}, fmt.Errorf("no message supplied for query")
 	}
 	c.cfg.Logger.Debug("starting query with message", tele.LogAttrKey(msg.Target()), slog.String("type", msg.Type.String()))
 

--- a/v2/query_test.go
+++ b/v2/query_test.go
@@ -29,7 +29,7 @@ func TestRTAdditionOnSuccessfulQuery(t *testing.T) {
 	require.ErrorIs(t, err, coordt.ErrNodeNotFound)
 
 	// // but when d3 queries d2, d1 and d3 discover each other
-	_, _ = d3.FindPeer(ctx, "something")
+	_, _ = NewRouting(d3).FindPeer(ctx, "something")
 	// ignore the error
 
 	// d3 should update its routing table to include d1 during the query
@@ -74,7 +74,7 @@ func TestRTEvictionOnFailedQuery(t *testing.T) {
 	require.NoError(t, err)
 
 	// failed queries should remove the queried peers from the routing table
-	_, _ = d1.FindPeer(ctx, "test")
+	_, _ = NewRouting(d1).FindPeer(ctx, "test")
 
 	// d1 should update its routing table to remove d2 because of the failure
 	_, err = top.ExpectRoutingRemoved(ctx, d1, d2.host.ID())


### PR DESCRIPTION
Not sure I like that. It would also be good to point to the concerns that people have with the routing.Routing interface. This makes the tests look a little less nice unless we let the topology solely operate on `RoutingDHT`'s.

fixes #929