### PR TITLE
fix: flaky test by skipping connectivity checks

### DIFF
--- a/v2/config.go
+++ b/v2/config.go
@@ -395,16 +395,21 @@ type QueryConfig struct {
 	// operation. A DefaultQuorum of 0 means that we search the network until
 	// we have exhausted the keyspace.
 	DefaultQuorum int
+
+	// SkipConnectivityCheck defines whether we do a connectivity check before
+	// we add peers to the routing table.
+	SkipConnectivityCheck bool
 }
 
 // DefaultQueryConfig returns the default query configuration options for a DHT.
 func DefaultQueryConfig() *QueryConfig {
 	return &QueryConfig{
-		Concurrency:        3,               // MAGIC
-		Timeout:            5 * time.Minute, // MAGIC
-		RequestConcurrency: 3,               // MAGIC
-		RequestTimeout:     time.Minute,     // MAGIC
-		DefaultQuorum:      0,               // MAGIC
+		Concurrency:           3,               // MAGIC
+		Timeout:               5 * time.Minute, // MAGIC
+		RequestConcurrency:    3,               // MAGIC
+		RequestTimeout:        time.Minute,     // MAGIC
+		DefaultQuorum:         0,               // MAGIC
+		SkipConnectivityCheck: false,
 	}
 }
 

--- a/v2/dht.go
+++ b/v2/dht.go
@@ -128,6 +128,7 @@ func New(h host.Host, cfg *Config) (*DHT, error) {
 	coordCfg.Routing.Logger = cfg.Logger.With("behaviour", "routing")
 	coordCfg.Routing.Tracer = cfg.TracerProvider.Tracer(tele.TracerName)
 	coordCfg.Routing.Meter = cfg.MeterProvider.Meter(tele.MeterName)
+	coordCfg.Routing.IncludeSkipCheck = cfg.Query.SkipConnectivityCheck
 
 	rtr := &router{
 		host:       h,

--- a/v2/routing_test.go
+++ b/v2/routing_test.go
@@ -682,6 +682,8 @@ func (suite *SearchValueQuorumTestSuite) SetupTest() {
 
 	cfg := DefaultConfig()
 	cfg.Clock = clk
+	cfg.Query.SkipConnectivityCheck = true
+
 	top := NewTopology(t)
 
 	// init privileged DHT server


### PR DESCRIPTION
By skipping connectivity checks we reduce the chances of simultaneously opening a stream that will block connection establishment.

Context: https://github.com/libp2p/go-libp2p/issues/2589