### PR TITLE
add ctx canceled err check

### DIFF
--- a/internal/net/message_manager.go
+++ b/internal/net/message_manager.go
@@ -295,11 +295,12 @@ func (ms *peerMessageSender) SendRequest(ctx context.Context, pmes *pb.Message) 
 
 		mes := new(pb.Message)
 		if err := ms.ctxReadMsg(ctx, mes); err != nil {
-			if err == context.Canceled {
-				return nil, err
-			}
 			_ = ms.s.Reset()
 			ms.s = nil
+			if err == context.Canceled {
+				// retry would be same error
+				return nil, err
+			}
 			if retry {
 				logger.Debugw("error reading message", "error", err)
 				return nil, err

--- a/internal/net/message_manager.go
+++ b/internal/net/message_manager.go
@@ -295,8 +295,10 @@ func (ms *peerMessageSender) SendRequest(ctx context.Context, pmes *pb.Message) 
 
 		mes := new(pb.Message)
 		if err := ms.ctxReadMsg(ctx, mes); err != nil {
-			_ = ms.s.Reset()
-			ms.s = nil
+			if err != context.Canceled {
+				_ = ms.s.Reset()
+				ms.s = nil
+			}
 
 			if retry {
 				logger.Debugw("error reading message", "error", err)

--- a/internal/net/message_manager.go
+++ b/internal/net/message_manager.go
@@ -295,11 +295,11 @@ func (ms *peerMessageSender) SendRequest(ctx context.Context, pmes *pb.Message) 
 
 		mes := new(pb.Message)
 		if err := ms.ctxReadMsg(ctx, mes); err != nil {
-			if err != context.Canceled {
-				_ = ms.s.Reset()
-				ms.s = nil
+			if err == context.Canceled {
+				return nil, err
 			}
-
+			_ = ms.s.Reset()
+			ms.s = nil
 			if retry {
 				logger.Debugw("error reading message", "error", err)
 				return nil, err


### PR DESCRIPTION
ISSUE: https://github.com/libp2p/go-libp2p-kad-dht/issues/958
There is no need to re-establish the connection for context canceled error, otherwise a lot of memory will be generated when calling GetValue in large numbers.

**Looking forward to someone reviewing the code.**