### PR TITLE
findnode(self) should return multiple peers

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -262,29 +262,25 @@ func (dht *IpfsDHT) handleFindPeer(ctx context.Context, from peer.ID, pmes *pb.M
 
 	// if looking for self... special case where we send it on CloserPeers.
 	targetPid := peer.ID(pmes.GetKey())
-	if targetPid == dht.self {
-		closest = []peer.ID{dht.self}
-	} else {
-		closest = dht.betterPeersToQuery(pmes, from, dht.bucketSize)
+	closest = dht.betterPeersToQuery(pmes, from, dht.bucketSize)
 
-		// Never tell a peer about itself.
-		if targetPid != from {
-			// Add the target peer to the set of closest peers if
-			// not already present in our routing table.
-			//
-			// Later, when we lookup known addresses for all peers
-			// in this set, we'll prune this peer if we don't
-			// _actually_ know where it is.
-			found := false
-			for _, p := range closest {
-				if targetPid == p {
-					found = true
-					break
-				}
+	// Never tell a peer about itself.
+	if targetPid != from {
+		// Add the target peer to the set of closest peers if
+		// not already present in our routing table.
+		//
+		// Later, when we lookup known addresses for all peers
+		// in this set, we'll prune this peer if we don't
+		// _actually_ know where it is.
+		found := false
+		for _, p := range closest {
+			if targetPid == p {
+				found = true
+				break
 			}
-			if !found {
-				closest = append(closest, targetPid)
-			}
+		}
+		if !found {
+			closest = append(closest, targetPid)
 		}
 	}
 


### PR DESCRIPTION
When receiving a kademlia `FIND_NODE` request for its own peer id, a go-libp2p-kad-dht node will respond with its own peer record only. According to libp2p kademlia [spec](https://github.com/libp2p/specs/blob/master/kad-dht/README.md), it should reply with the `k` closest nodes.

> The libp2p Kademlia DHT offers the following types of operations:
> * Peer routing
>     * Finding the closest nodes to a given key via FIND_NODE.

> 3. Upon a response:
>     1. If successful the response will contain the k closest nodes the peer knows to the key Key. Add them to the candidate list Pn, except for those that have already been queried.

Depending on https://github.com/libp2p/specs/pull/609, nodes shouldn't even include their own peer records in the response (already known to the requester). This will be implemented in a future PR.