### PR TITLE
Fix: don't perform lookupCheck if not enough peers in routing table

### DIFF
--- a/dht.go
+++ b/dht.go
@@ -376,6 +376,10 @@ func makeDHT(h host.Host, cfg dhtcfg.Config) (*IpfsDHT, error) {
 // lookupCheck performs a lookup request to a remote peer.ID, verifying that it is able to
 // answer it correctly
 func (dht *IpfsDHT) lookupCheck(ctx context.Context, p peer.ID) error {
+	if dht.routingTable.Size() < dht.bucketSize {
+		// no need to be picky if we don't have enough peers
+		return nil
+	}
 	// lookup request to p requesting for its own peer.ID
 	peerids, err := dht.protoMessenger.GetClosestPeers(ctx, p, p)
 	// p should return at least its own peerid

--- a/dht.go
+++ b/dht.go
@@ -376,14 +376,12 @@ func makeDHT(h host.Host, cfg dhtcfg.Config) (*IpfsDHT, error) {
 // lookupCheck performs a lookup request to a remote peer.ID, verifying that it is able to
 // answer it correctly
 func (dht *IpfsDHT) lookupCheck(ctx context.Context, p peer.ID) error {
-	if dht.routingTable.Size() < dht.bucketSize {
-		// no need to be picky if we don't have enough peers
-		return nil
-	}
 	// lookup request to p requesting for its own peer.ID
 	peerids, err := dht.protoMessenger.GetClosestPeers(ctx, p, p)
-	// p should return at least its own peerid
-	if err == nil && len(peerids) == 0 {
+	// p is expected to return at least 1 peer id, unless our routing table has
+	// less than bucketSize peers, in which case we aren't picky about who we
+	// add to the routing table.
+	if err == nil && len(peerids) == 0 && dht.routingTable.Size() >= dht.bucketSize {
 		return fmt.Errorf("peer %s failed to return its closest peers, got %d", p, len(peerids))
 	}
 	return err

--- a/ext_test.go
+++ b/ext_test.go
@@ -42,7 +42,7 @@ func TestInvalidRemotePeers(t *testing.T) {
 
 	time.Sleep(100 * time.Millisecond)
 
-	// hosts[1] is added to the routing table even though is is not responding
-	// because d has no other peers in its routing table, hence it isn't
-	require.Equal(t, 1, d.routingTable.Size())
+	// hosts[1] isn't added to the routing table because it isn't responding to
+	// the DHT request
+	require.Equal(t, 0, d.routingTable.Size())
 }

--- a/ext_test.go
+++ b/ext_test.go
@@ -42,5 +42,7 @@ func TestInvalidRemotePeers(t *testing.T) {
 
 	time.Sleep(100 * time.Millisecond)
 
-	require.Equal(t, 0, d.routingTable.Size())
+	// hosts[1] is added to the routing table even though is is not responding
+	// because d has no other peers in its routing table, hence it isn't
+	require.Equal(t, 1, d.routingTable.Size())
 }


### PR DESCRIPTION
Currently, nodes will always perform a `lookupCheck` (`FIND_PEER` request where receiver should reply with at least 1 peer record) before a peer is added to the routing table, and when refreshing the routing table.

This check should be performed only if the routing table is well populated. Otherwise, it is tricky to bootstrap a new DHT network as the first peers start with an empty routing table, and are unable to provide peer to others when requested by the `lookupCheck`.

The check will be skipped if the routing table contains less than `bucketSize` peers, which means that no bucket can be full. It implies that unresponsive peers making it to the routing table because the check was skipped will get evicted once `bucketSize` peers are present in the routing table, and they won't prevent well behaving peers from replacing them in the routing table.