### PR TITLE
chore: fix connectedness

### DIFF
--- a/dht.go
+++ b/dht.go
@@ -737,8 +737,7 @@ func (dht *IpfsDHT) FindLocal(ctx context.Context, id peer.ID) peer.AddrInfo {
 	_, span := internal.StartSpan(ctx, "IpfsDHT.FindLocal", trace.WithAttributes(attribute.Stringer("PeerID", id)))
 	defer span.End()
 
-	connectedness := dht.host.Network().Connectedness(id)
-	if connectedness == network.Connected || connectedness == network.Limited {
+	if HasValidConnectedness(dht.host, id) {
 		return dht.peerstore.PeerInfo(id)
 	}
 	return peer.AddrInfo{}
@@ -927,8 +926,7 @@ func (dht *IpfsDHT) newContextWithLocalTags(ctx context.Context, extraTags ...ta
 
 func (dht *IpfsDHT) maybeAddAddrs(p peer.ID, addrs []ma.Multiaddr, ttl time.Duration) {
 	// Don't add addresses for self or our connected peers. We have better ones.
-	connectedness := dht.host.Network().Connectedness(p)
-	if p == dht.self || connectedness == network.Connected || connectedness == network.Limited {
+	if p == dht.self || HasValidConnectedness(dht.host, p) {
 		return
 	}
 	dht.peerstore.AddAddrs(p, dht.filterAddrs(addrs), ttl)

--- a/dht.go
+++ b/dht.go
@@ -737,7 +737,8 @@ func (dht *IpfsDHT) FindLocal(ctx context.Context, id peer.ID) peer.AddrInfo {
 	_, span := internal.StartSpan(ctx, "IpfsDHT.FindLocal", trace.WithAttributes(attribute.Stringer("PeerID", id)))
 	defer span.End()
 
-	if dht.host.Network().Connectedness(id) == network.Connected {
+	connectedness := dht.host.Network().Connectedness(id)
+	if connectedness == network.Connected || connectedness == network.Limited {
 		return dht.peerstore.PeerInfo(id)
 	}
 	return peer.AddrInfo{}
@@ -926,7 +927,8 @@ func (dht *IpfsDHT) newContextWithLocalTags(ctx context.Context, extraTags ...ta
 
 func (dht *IpfsDHT) maybeAddAddrs(p peer.ID, addrs []ma.Multiaddr, ttl time.Duration) {
 	// Don't add addresses for self or our connected peers. We have better ones.
-	if p == dht.self || dht.host.Network().Connectedness(p) == network.Connected {
+	connectedness := dht.host.Network().Connectedness(p)
+	if p == dht.self || connectedness == network.Connected || connectedness == network.Limited {
 		return
 	}
 	dht.peerstore.AddAddrs(p, dht.filterAddrs(addrs), ttl)

--- a/dht_filters.go
+++ b/dht_filters.go
@@ -238,3 +238,8 @@ func inAddrRange(ip net.IP, ipnets []*net.IPNet) bool {
 
 	return false
 }
+
+func HasValidConnectedness(host host.Host, id peer.ID) bool {
+	connectedness := host.Network().Connectedness(id)
+	return connectedness == network.Connected || connectedness == network.Limited
+}

--- a/fullrt/dht.go
+++ b/fullrt/dht.go
@@ -1460,7 +1460,7 @@ func (dht *FullRT) FindPeer(ctx context.Context, id peer.ID) (pi peer.AddrInfo, 
 	// Return peer information if we tried to dial the peer during the query or we are (or recently were) connected
 	// to the peer.
 	connectedness := dht.h.Network().Connectedness(id)
-	if connectedness == network.Connected {
+	if connectedness == network.Connected || connectedness == network.Limited {
 		return dht.h.Peerstore().PeerInfo(id), nil
 	}
 
@@ -1538,7 +1538,8 @@ func (dht *FullRT) getRecordFromDatastore(ctx context.Context, dskey ds.Key) (*r
 
 // FindLocal looks for a peer with a given ID connected to this dht and returns the peer and the table it was found in.
 func (dht *FullRT) FindLocal(id peer.ID) peer.AddrInfo {
-	if dht.h.Network().Connectedness(id) == network.Connected {
+	connectedness := dht.h.Network().Connectedness(id)
+	if connectedness == network.Connected || connectedness == network.Limited {
 		return dht.h.Peerstore().PeerInfo(id)
 	}
 	return peer.AddrInfo{}
@@ -1546,7 +1547,8 @@ func (dht *FullRT) FindLocal(id peer.ID) peer.AddrInfo {
 
 func (dht *FullRT) maybeAddAddrs(p peer.ID, addrs []multiaddr.Multiaddr, ttl time.Duration) {
 	// Don't add addresses for self or our connected peers. We have better ones.
-	if p == dht.h.ID() || dht.h.Network().Connectedness(p) == network.Connected {
+	connectedness := dht.h.Network().Connectedness(p)
+	if p == dht.h.ID() || connectedness == network.Connected || connectedness == network.Limited {
 		return
 	}
 	dht.h.Peerstore().AddAddrs(p, addrs, ttl)

--- a/fullrt/dht.go
+++ b/fullrt/dht.go
@@ -1459,8 +1459,7 @@ func (dht *FullRT) FindPeer(ctx context.Context, id peer.ID) (pi peer.AddrInfo, 
 
 	// Return peer information if we tried to dial the peer during the query or we are (or recently were) connected
 	// to the peer.
-	connectedness := dht.h.Network().Connectedness(id)
-	if connectedness == network.Connected || connectedness == network.Limited {
+	if kaddht.HasValidConnectedness(dht.h, id) {
 		return dht.h.Peerstore().PeerInfo(id), nil
 	}
 
@@ -1538,8 +1537,7 @@ func (dht *FullRT) getRecordFromDatastore(ctx context.Context, dskey ds.Key) (*r
 
 // FindLocal looks for a peer with a given ID connected to this dht and returns the peer and the table it was found in.
 func (dht *FullRT) FindLocal(id peer.ID) peer.AddrInfo {
-	connectedness := dht.h.Network().Connectedness(id)
-	if connectedness == network.Connected || connectedness == network.Limited {
+	if kaddht.HasValidConnectedness(dht.h, id) {
 		return dht.h.Peerstore().PeerInfo(id)
 	}
 	return peer.AddrInfo{}
@@ -1547,8 +1545,7 @@ func (dht *FullRT) FindLocal(id peer.ID) peer.AddrInfo {
 
 func (dht *FullRT) maybeAddAddrs(p peer.ID, addrs []multiaddr.Multiaddr, ttl time.Duration) {
 	// Don't add addresses for self or our connected peers. We have better ones.
-	connectedness := dht.h.Network().Connectedness(p)
-	if p == dht.h.ID() || connectedness == network.Connected || connectedness == network.Limited {
+	if p == dht.h.ID() || kaddht.HasValidConnectedness(dht.h, p) {
 		return
 	}
 	dht.h.Peerstore().AddAddrs(p, addrs, ttl)

--- a/query.go
+++ b/query.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	pstore "github.com/libp2p/go-libp2p/core/peerstore"
 	"github.com/libp2p/go-libp2p/core/routing"
@@ -530,7 +529,7 @@ func (dht *IpfsDHT) dialPeer(ctx context.Context, p peer.ID) error {
 	defer span.End()
 
 	// short-circuit if we're already connected.
-	if dht.host.Network().Connectedness(p) == network.Connected {
+	if HasValidConnectedness(dht.host, p) {
 		return nil
 	}
 

--- a/query.go
+++ b/query.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	pstore "github.com/libp2p/go-libp2p/core/peerstore"
 	"github.com/libp2p/go-libp2p/core/routing"
@@ -529,7 +530,7 @@ func (dht *IpfsDHT) dialPeer(ctx context.Context, p peer.ID) error {
 	defer span.End()
 
 	// short-circuit if we're already connected.
-	if HasValidConnectedness(dht.host, p) {
+	if dht.host.Network().Connectedness(p) == network.Connected {
 		return nil
 	}
 

--- a/query_test.go
+++ b/query_test.go
@@ -34,18 +34,18 @@ func TestRTEvictionOnFailedQuery(t *testing.T) {
 	// peers should be in the RT because of fixLowPeers
 	require.NoError(t, tu.WaitFor(ctx, func() error {
 		if !checkRoutingTable(d1, d2) {
-			return fmt.Errorf("should have routes 0")
+			return fmt.Errorf("should have routes")
 		}
 		return nil
 	}))
 
-	// close both hosts so query fails
-	require.NoError(t, d1.host.Close())
-	require.NoError(t, d2.host.Close())
-	// peers will still be in the RT because we have decoupled membership from connectivity
+	// clear the addresses of the peers so that the next queries fail
+	d1.host.Peerstore().ClearAddrs(d2.self)
+	d2.host.Peerstore().ClearAddrs(d1.self)
+	// peers will still be in the RT because RT is decoupled with the host and peerstore
 	require.NoError(t, tu.WaitFor(ctx, func() error {
 		if !checkRoutingTable(d1, d2) {
-			return fmt.Errorf("should have routes 1")
+			return fmt.Errorf("should have routes")
 		}
 		return nil
 	}))
@@ -59,7 +59,7 @@ func TestRTEvictionOnFailedQuery(t *testing.T) {
 
 	require.NoError(t, tu.WaitFor(ctx, func() error {
 		if checkRoutingTable(d1, d2) {
-			return fmt.Errorf("should not have routes 2")
+			return fmt.Errorf("should not have routes")
 		}
 		return nil
 	}))

--- a/routing.go
+++ b/routing.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/peerstore"
 	"github.com/libp2p/go-libp2p/core/routing"
@@ -664,8 +663,7 @@ func (dht *IpfsDHT) FindPeer(ctx context.Context, id peer.ID) (pi peer.AddrInfo,
 			return peers, err
 		},
 		func(*qpeerset.QueryPeerset) bool {
-			connectedness := dht.host.Network().Connectedness(id)
-			return connectedness == network.Connected || connectedness == network.Limited
+			return HasValidConnectedness(dht.host, id)
 		},
 	)
 
@@ -686,8 +684,7 @@ func (dht *IpfsDHT) FindPeer(ctx context.Context, id peer.ID) (pi peer.AddrInfo,
 
 	// Return peer information if we tried to dial the peer during the query or we are (or recently were) connected
 	// to the peer.
-	connectedness := dht.host.Network().Connectedness(id)
-	if dialedPeerDuringQuery || connectedness == network.Connected || connectedness == network.Limited {
+	if dialedPeerDuringQuery || HasValidConnectedness(dht.host, id) {
 		return dht.peerstore.PeerInfo(id), nil
 	}
 

--- a/routing.go
+++ b/routing.go
@@ -664,7 +664,8 @@ func (dht *IpfsDHT) FindPeer(ctx context.Context, id peer.ID) (pi peer.AddrInfo,
 			return peers, err
 		},
 		func(*qpeerset.QueryPeerset) bool {
-			return dht.host.Network().Connectedness(id) == network.Connected
+			connectedness := dht.host.Network().Connectedness(id)
+			return connectedness == network.Connected || connectedness == network.Limited
 		},
 	)
 
@@ -686,7 +687,7 @@ func (dht *IpfsDHT) FindPeer(ctx context.Context, id peer.ID) (pi peer.AddrInfo,
 	// Return peer information if we tried to dial the peer during the query or we are (or recently were) connected
 	// to the peer.
 	connectedness := dht.host.Network().Connectedness(id)
-	if dialedPeerDuringQuery || connectedness == network.Connected {
+	if dialedPeerDuringQuery || connectedness == network.Connected || connectedness == network.Limited {
 		return dht.peerstore.PeerInfo(id), nil
 	}
 


### PR DESCRIPTION
This PR builds on #974 and fixes a bug whereby `FindPeer` won't return results for peers behind NAT which only have `p2p-circuit` multiaddrs.


This fixes the regression [starting from v0.34 of go-libp2p](https://github.com/libp2p/go-libp2p/releases/tag/v0.34.0):

> Peers connected to the host via relayed or any other limited connection now report their connectivity state as Limited.
> NOTE: This changes the behavior of the `Connected` Connectedness state. Previously it included all limited connections and now it doesn't. To keep existing behavior in your code you can replace checks connectedness == network.Connected with connectedness != network.NotConnected
