### PR TITLE
fix(query): reverting changes on TestRTEvictionOnFailedQuery

### DIFF
--- a/query_test.go
+++ b/query_test.go
@@ -39,10 +39,10 @@ func TestRTEvictionOnFailedQuery(t *testing.T) {
 		return nil
 	}))
 
-	// clear the addresses of the peers so that the next queries fail
-	d1.host.Peerstore().ClearAddrs(d2.self)
-	d2.host.Peerstore().ClearAddrs(d1.self)
-	// peers will still be in the RT because RT is decoupled with the host and peerstore
+	// close both hosts so query fails
+	require.NoError(t, d1.host.Close())
+	require.NoError(t, d2.host.Close())
+	// peers will still be in the RT because we have decoupled membership from connectivity
 	require.NoError(t, tu.WaitFor(ctx, func() error {
 		if !checkRoutingTable(d1, d2) {
 			return fmt.Errorf("should have routes")


### PR DESCRIPTION
Reverting changes on `TestRTEvictionOnFailedQuery` introduced in https://github.com/libp2p/go-libp2p-kad-dht/pull/980, fixed in https://github.com/libp2p/go-libp2p/pull/2916.

This change was removed in https://github.com/libp2p/go-libp2p-kad-dht/commit/4667e81182cce3d559d3d784a289309311129376 in https://github.com/libp2p/go-libp2p-kad-dht/pull/976, but the commit was [overwritten](https://github.com/libp2p/go-libp2p-kad-dht/compare/4667e81182cce3d559d3d784a289309311129376..5669815d0188dd9f71d08d69daff9740ea777077) (by accident?). 

The commit was initially [removed](https://github.com/libp2p/go-libp2p-kad-dht/pull/974#issuecomment-2298578461) in https://github.com/libp2p/go-libp2p-kad-dht/pull/974 but not in https://github.com/libp2p/go-libp2p-kad-dht/pull/976.

No need to make a new release for this.