### PR TITLE
fix: replace deprecated Boxo function

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/ipfs/go-datastore v0.6.0
 	github.com/ipfs/go-detect-race v0.0.1
 	github.com/ipfs/go-log/v2 v2.5.1
+	github.com/ipfs/go-test v0.0.4
 	github.com/libp2p/go-libp2p v0.36.2
 	github.com/libp2p/go-libp2p-kbucket v0.6.4
 	github.com/libp2p/go-libp2p-record v0.2.0
@@ -60,6 +61,8 @@ require (
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/huin/goupnp v1.3.0 // indirect
+	github.com/ipfs/go-block-format v0.2.0 // indirect
+	github.com/ipfs/go-ipfs-util v0.0.3 // indirect
 	github.com/ipfs/go-log v1.0.5 // indirect
 	github.com/ipld/go-ipld-prime v0.21.0 // indirect
 	github.com/jackpal/go-nat-pmp v1.0.2 // indirect

--- a/records_test.go
+++ b/records_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/test"
 
 	u "github.com/ipfs/boxo/util"
+	"github.com/ipfs/go-test/random"
 	record "github.com/libp2p/go-libp2p-record"
 	tnet "github.com/libp2p/go-libp2p-testing/net"
 	ci "github.com/libp2p/go-libp2p/core/crypto"
@@ -151,7 +152,7 @@ func TestPubkeyNotFound(t *testing.T) {
 
 	connect(t, ctx, dhtA, dhtB)
 
-	r := u.NewSeededRand(15) // generate deterministic keypair
+	r := random.NewSeededRand(15) // generate deterministic keypair
 	_, pubk, err := ci.GenerateKeyPairWithReader(ci.RSA, 2048, r)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
`NewSeededRand` migrated from [boxo](https://github.com/ipfs/boxo) to [go-test](https://github.com/ipfs/go-test)