### PR TITLE
add WithAllowLimitedConn for SendRequest

### DIFF
--- a/internal/net/message_manager.go
+++ b/internal/net/message_manager.go
@@ -74,7 +74,7 @@ func (m *messageSenderImpl) OnDisconnect(ctx context.Context, p peer.ID) {
 // measure the RTT for latency measurements.
 func (m *messageSenderImpl) SendRequest(ctx context.Context, p peer.ID, pmes *pb.Message) (*pb.Message, error) {
 	ctx, _ = tag.New(ctx, metrics.UpsertMessageType(pmes))
-
+	ctx = network.WithAllowLimitedConn(ctx, "sendrequest")
 	ms, err := m.messageSenderForPeer(ctx, p)
 	if err != nil {
 		stats.Record(ctx,


### PR DESCRIPTION
In case two nodes are both in private network, Relay service is required for them to communicate between each other, but currently such communication cannot be achieved because that the connection based on Relay is "limited", so "SendRequest" should be granted with the permission of  "AllowLimitedConn" .