### PR TITLE
fix(crawler): separate timeout per query

### DIFF
--- a/crawler/crawler.go
+++ b/crawler/crawler.go
@@ -147,10 +147,10 @@ func (c *DefaultCrawler) Run(ctx context.Context, startingPeers []*peer.AddrInfo
 	for i := 0; i < c.parallelism; i++ {
 		go func() {
 			defer wg.Done()
-			ctx, cancel := context.WithTimeout(ctx, c.queryTimeout)
-			defer cancel()
 			for p := range jobs {
-				res := c.queryPeer(ctx, p)
+				qctx, cancel := context.WithTimeout(ctx, c.queryTimeout)
+				res := c.queryPeer(qctx, p)
+				cancel() // do not defer, cleanup after each job
 				results <- res
 			}
 		}()


### PR DESCRIPTION
This PR aims to correctly apply the fix from: 
- https://github.com/libp2p/go-libp2p-kad-dht/pull/996 (cc @MarcoPolo @guillaumemichel @ligustah)

### Problem

It did not work as expected because `context.WithTimeout`  was created once per goroutine but was used for multiple queries within the `for p := range jobs` loop.

This meant once the timeout expires for the first query, all subsequent queries in that worker would immediately fail since they're using the same expired context. The crawl ended in ~15s instead of few minutes.

Fix is to have new context per job.
