### PR TITLE
fix: don't copy message to OnRequestHook

### DIFF
--- a/dht.go
+++ b/dht.go
@@ -40,8 +40,10 @@ import (
 	"go.uber.org/zap"
 )
 
-const tracer = tracing.Tracer("go-libp2p-kad-dht")
-const dhtName = "IpfsDHT"
+const (
+	tracer  = tracing.Tracer("go-libp2p-kad-dht")
+	dhtName = "IpfsDHT"
+)
 
 var (
 	logger     = logging.Logger("dht")
@@ -164,7 +166,7 @@ type IpfsDHT struct {
 	// Mostly used to filter out localhost and local addresses.
 	addrFilter func([]ma.Multiaddr) []ma.Multiaddr
 
-	onRequestHook func(ctx context.Context, s network.Stream, req pb.Message)
+	onRequestHook func(ctx context.Context, s network.Stream, req *pb.Message)
 }
 
 // Assert that IPFS assumptions about interfaces aren't broken. These aren't a
@@ -420,7 +422,6 @@ func makeRoutingTable(dht *IpfsDHT, cfg dhtcfg.Config, maxLastSuccessfulOutbound
 		df, err := peerdiversity.NewFilter(dht.rtPeerDiversityFilter, "rt/diversity", func(p peer.ID) int {
 			return kb.CommonPrefixLen(dht.selfKey, kb.ConvertPeerID(p))
 		})
-
 		if err != nil {
 			return nil, fmt.Errorf("failed to construct peer diversity filter: %w", err)
 		}

--- a/dht_net.go
+++ b/dht_net.go
@@ -101,7 +101,7 @@ func (dht *IpfsDHT) handleNewMessage(s network.Stream) bool {
 		)
 
 		if dht.onRequestHook != nil {
-			dht.onRequestHook(ctx, s, req)
+			dht.onRequestHook(ctx, s, &req)
 		}
 
 		handler := dht.handlerForMsgType(req.GetType())

--- a/dht_options.go
+++ b/dht_options.go
@@ -375,7 +375,7 @@ func WithCustomMessageSender(messageSenderBuilder func(h host.Host, protos []pro
 // incoming DHT protocol message.
 // Note: Ensure that the callback executes efficiently, as it will block the
 // entire message handler.
-func OnRequestHook(f func(ctx context.Context, s network.Stream, req pb.Message)) Option {
+func OnRequestHook(f func(ctx context.Context, s network.Stream, req *pb.Message)) Option {
 	return func(c *dhtcfg.Config) error {
 		c.OnRequestHook = f
 		return nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -65,7 +65,7 @@ type Config struct {
 
 	BootstrapPeers func() []peer.AddrInfo
 	AddressFilter  func([]ma.Multiaddr) []ma.Multiaddr
-	OnRequestHook  func(ctx context.Context, s network.Stream, req pb.Message)
+	OnRequestHook  func(ctx context.Context, s network.Stream, req *pb.Message)
 
 	// test specific Config options
 	DisableFixLowPeers          bool


### PR DESCRIPTION
Fix to https://github.com/libp2p/go-libp2p-kad-dht/pull/1011

[`go vet` isn't happy](https://github.com/libp2p/go-libp2p-kad-dht/actions/runs/12931140233/job/36064318036?pr=975) about copying `pb.Message` since it contains a lock.