### PR TITLE
fix: flaky TestFindPeerQueryMinimal

### DIFF
--- a/dht_test.go
+++ b/dht_test.go
@@ -1606,7 +1606,7 @@ func minInt(a, b int) int {
 }
 
 func TestFindPeerQueryMinimal(t *testing.T) {
-	testFindPeerQuery(t, 2, 22, 1)
+	testFindPeerQuery(t, 1, 22, 1)
 }
 
 func TestFindPeerQuery(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/libp2p/go-libp2p-kad-dht/issues/791

Using `testFindPeerQuery` with 2 `bootstrappers` but only a single `bootstrapConns` leads to partitioning. Basically each node connects to one of the two bootstrappers at random. Bootstrappers aren't connected to each other. The only bridge between the 2 partitions is `guy`, which is connected to all bootstrappers.

While not critical, it may require nodes to perform a high number of routing table refreshes to converge to a stable state. The test is sometimes failing because nodes in both partitions may not know each other.

Using a single bootstrapper for the _minimal_ test doesn't seem crazy, and solves the partitions issue.