### PR TITLE
fix: flaky TestSkipRefreshOnGapCpls

### DIFF
--- a/rtrefresh/rt_refresh_manager_test.go
+++ b/rtrefresh/rt_refresh_manager_test.go
@@ -15,8 +15,6 @@ import (
 )
 
 func TestSkipRefreshOnGapCpls(t *testing.T) {
-	t.Skip("This test is flaky, see https://github.com/libp2p/go-libp2p-kad-dht/issues/722.")
-
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	local := test.RandPeerIDFatal(t)
@@ -40,6 +38,10 @@ func TestSkipRefreshOnGapCpls(t *testing.T) {
 
 			p, err := rt.GenRandPeerID(uint(u))
 			require.NoError(t, err)
+			for rt.Find(p) != "" {
+				p, err = rt.GenRandPeerID(uint(u))
+				require.NoError(t, err)
+			}
 			b, err := rt.TryAddPeer(p, true, false)
 			require.NoError(t, err)
 			require.True(t, b)


### PR DESCRIPTION
Fixes https://github.com/libp2p/go-libp2p-kad-dht/issues/722

`GenRandPeerID` doesn't actually generate a random peer ID, but it select one matching the CPL from the [preimage list](https://github.com/libp2p/go-libp2p-kbucket/blob/master/bucket_prefixmap.go).

The test was failing when the same peer was "randomly generated" twice and added to the routing table.