### PR TITLE
fix: don't skip TestContextShutDown

### DIFF
--- a/dht_test.go
+++ b/dht_test.go
@@ -392,7 +392,6 @@ func TestValueSetInvalid(t *testing.T) {
 }
 
 func TestContextShutDown(t *testing.T) {
-	t.Skip("This test is flaky, see https://github.com/libp2p/go-libp2p-kad-dht/issues/724.")
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 


### PR DESCRIPTION
Fixes https://github.com/libp2p/go-libp2p-kad-dht/issues/724

Test doesn't appear to be flaky anymore, I wasn't able to reproduce locally. Let's not skip it