### PR TITLE
fix(tests): cleanup of skipped tests

### DIFF
--- a/dht_test.go
+++ b/dht_test.go
@@ -521,7 +521,6 @@ func TestValueGetInvalid(t *testing.T) {
 }
 
 func TestProvides(t *testing.T) {
-	// t.Skip("skipping test to debug another")
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -695,7 +694,6 @@ func TestHandleAddProviderAddressFilter(t *testing.T) {
 }
 
 func TestLocalProvides(t *testing.T) {
-	// t.Skip("skipping test to debug another")
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -731,7 +729,6 @@ func TestLocalProvides(t *testing.T) {
 }
 
 func TestAddressFilterProvide(t *testing.T) {
-	// t.Skip("skipping test to debug another")
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -1130,7 +1127,6 @@ func TestProvidesMany(t *testing.T) {
 }
 
 func TestProvidesAsync(t *testing.T) {
-	// t.Skip("skipping test to debug another")
 	if testing.Short() {
 		t.SkipNow()
 	}
@@ -1247,7 +1243,6 @@ func TestUnfindablePeer(t *testing.T) {
 }
 
 func TestFindPeer(t *testing.T) {
-	// t.Skip("skipping test to debug another")
 	if testing.Short() {
 		t.SkipNow()
 	}
@@ -1284,7 +1279,6 @@ func TestFindPeer(t *testing.T) {
 }
 
 func TestFindPeerWithQueryFilter(t *testing.T) {
-	// t.Skip("skipping test to debug another")
 	if testing.Short() {
 		t.SkipNow()
 	}

--- a/records_test.go
+++ b/records_test.go
@@ -2,7 +2,6 @@ package dht
 
 import (
 	"context"
-	"crypto/rand"
 	"fmt"
 	"testing"
 	"time"
@@ -17,33 +16,6 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/routing"
 )
-
-// Check that GetPublicKey() correctly extracts a public key
-func TestPubkeyExtract(t *testing.T) {
-	t.Skip("public key extraction for ed25519 keys has been disabled. See https://github.com/libp2p/specs/issues/111")
-	ctx := context.Background()
-	dht := setupDHT(ctx, t, false)
-	defer dht.Close()
-
-	_, pk, err := ci.GenerateEd25519Key(rand.Reader)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	pid, err := peer.IDFromPublicKey(pk)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	pkOut, err := dht.GetPublicKey(context.Background(), pid)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if !pkOut.Equals(pk) {
-		t.Fatal("got incorrect public key out")
-	}
-}
 
 // Check that GetPublicKey() correctly retrieves a public key from the peerstore
 func TestPubkeyPeerstore(t *testing.T) {


### PR DESCRIPTION
Removing skipped and deprecated `TestPubkeyExtract`, and well as some `t.Skip()` commented out.