### PR TITLE
fix: increase timeout in TestProvidesMany

### DIFF
--- a/dht_test.go
+++ b/dht_test.go
@@ -1085,7 +1085,7 @@ func TestProvidesMany(t *testing.T) {
 
 	errchan := make(chan error)
 
-	ctxT, cancel = context.WithTimeout(ctx, 5*time.Second)
+	ctxT, cancel = context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
 
 	var wg sync.WaitGroup


### PR DESCRIPTION
Fixes https://github.com/libp2p/go-libp2p-kad-dht/issues/726

Test seems to fail because timeout value was too low. 