### PR TITLE
fix: flaky TestClientModeConnect

### DIFF
--- a/dht_test.go
+++ b/dht_test.go
@@ -1459,9 +1459,14 @@ func TestClientModeConnect(t *testing.T) {
 	a.ProviderStore().AddProvider(ctx, c.Hash(), peer.AddrInfo{ID: p})
 	time.Sleep(time.Millisecond * 5) // just in case...
 
-	provs, err := b.FindProviders(ctx, c)
-	if err != nil {
-		t.Fatal(err)
+	maxRetries := 3
+	var provs []peer.AddrInfo
+	var err error
+	for i := 0; i < maxRetries && len(provs) == 0; i++ {
+		provs, err = b.FindProviders(ctx, c)
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	if len(provs) == 0 {


### PR DESCRIPTION
Fixes https://github.com/libp2p/go-libp2p-kad-dht/issues/1026

Test is flaky because of timing issues. The provider record is probably not added in the provider store by the time the FindProviders request hits `a`.

If prov isn't found at first try again. Retrying seems better than sleeping more.