### PR TITLE
fix: flaky TestFindPeerWithQueryFilter

### DIFF
--- a/dht_test.go
+++ b/dht_test.go
@@ -1315,7 +1315,7 @@ func TestFindPeerWithQueryFilter(t *testing.T) {
 
 	require.Eventually(t, func() bool {
 		return len(dhts[2].host.Network().ConnsToPeer(filteredPeer.ID())) > 0
-	}, 5*time.Millisecond, time.Millisecond, "failed to connect to peer")
+	}, 30*time.Millisecond, time.Millisecond, "failed to connect to peer")
 
 	ctxT, cancel := context.WithTimeout(ctx, time.Second)
 	defer cancel()


### PR DESCRIPTION
Fixes https://github.com/libp2p/go-libp2p-kad-dht/issues/1033

* Unable to reproduce failure locally
* Increased deadline from `5ms` to `30ms`