### PR TITLE
fix addrsSoFar comparison

### DIFF
--- a/fullrt/dht.go
+++ b/fullrt/dht.go
@@ -1389,7 +1389,7 @@ func (dht *FullRT) FindPeer(ctx context.Context, id peer.ID) (pi peer.AddrInfo, 
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		addrsSoFar := make(map[multiaddr.Multiaddr]struct{})
+		addrsSoFar := make(map[string]struct{})
 		for {
 			select {
 			case ai, ok := <-addrsCh:
@@ -1398,10 +1398,10 @@ func (dht *FullRT) FindPeer(ctx context.Context, id peer.ID) (pi peer.AddrInfo, 
 				}
 
 				for _, a := range ai.Addrs {
-					_, found := addrsSoFar[a]
+					_, found := addrsSoFar[string(a.Bytes())]
 					if !found {
 						newAddrs = append(newAddrs, a)
-						addrsSoFar[a] = struct{}{}
+						addrsSoFar[string(a.Bytes())] = struct{}{}
 					}
 				}
 			case <-ctx.Done():


### PR DESCRIPTION
I don't think there was any guarantee that the you'd get back the same pointer for this interface check to work. And this won't work in go-multiaddr v0.15. 

By changing this and possibly backporting this fix users can use go-multiaddr v0.15 without having to also deal with breaking changes in kad-dht and boxo.