### PR TITLE
fix: flaky TestInvalidServer

### DIFF
--- a/dht_test.go
+++ b/dht_test.go
@@ -1559,8 +1559,9 @@ func TestInvalidServer(t *testing.T) {
 		t.Fatal("DHT server should have been added to the misbehaving server routing table")
 	}
 
-	// connect s0 to both s1 and m1
+	// connect s0 to s1 first and then m1
 	connectNoSync(t, ctx, s0, s1)
+	wait(t, ctx, s0, s1)
 	connectNoSync(t, ctx, s0, m1)
 
 	// s1 should be added to s0's routing table. Then, because s0's routing table


### PR DESCRIPTION
Fixes https://github.com/libp2p/go-libp2p-kad-dht/issues/1023

On the CI, it has happened that `s0` connected to `m1` before `s1` resulting in both `m1` and `s1` being added to the routing table. This fix makes sure `s0` connects to `s1` first before trying to connect to `m1`.