### PR TITLE
fix(crawler): remove peerstore no-op

### DIFF
--- a/crawler/crawler.go
+++ b/crawler/crawler.go
@@ -32,12 +32,11 @@ type (
 	}
 	// DefaultCrawler provides a default implementation of Crawler.
 	DefaultCrawler struct {
-		parallelism          int
-		connectTimeout       time.Duration
-		queryTimeout         time.Duration
-		host                 host.Host
-		dhtRPC               *pb.ProtocolMessenger
-		dialAddressExtendDur time.Duration
+		parallelism    int
+		connectTimeout time.Duration
+		queryTimeout   time.Duration
+		host           host.Host
+		dhtRPC         *pb.ProtocolMessenger
 	}
 )
 
@@ -59,12 +58,11 @@ func NewDefaultCrawler(host host.Host, opts ...Option) (*DefaultCrawler, error) 
 	}
 
 	return &DefaultCrawler{
-		parallelism:          o.parallelism,
-		connectTimeout:       o.connectTimeout,
-		queryTimeout:         3 * o.connectTimeout,
-		host:                 host,
-		dhtRPC:               pm,
-		dialAddressExtendDur: o.dialAddressExtendDur,
+		parallelism:    o.parallelism,
+		connectTimeout: o.connectTimeout,
+		queryTimeout:   3 * o.connectTimeout,
+		host:           host,
+		dhtRPC:         pm,
 	}, nil
 }
 
@@ -300,11 +298,6 @@ func (c *DefaultCrawler) queryPeer(ctx context.Context, nextPeer peer.AddrInfo) 
 		logger.Debugf("could not connect to peer %v: %v", nextPeer.ID, err)
 		return &queryResult{nextPeer.ID, nil, err}
 	}
-	// Extend peerstore address ttl for addresses whose ttl is below
-	// c.dialAddressExtendDur. By now identify has already cleaned up addresses
-	// provided to Connect above and only kept the listen addresses advertised by
-	// the remote peer
-	c.host.Peerstore().AddAddrs(nextPeer.ID, c.host.Peerstore().Addrs(nextPeer.ID), c.dialAddressExtendDur)
 
 	localPeers := make(map[peer.ID]*peer.AddrInfo)
 	var retErr error

--- a/crawler/options.go
+++ b/crawler/options.go
@@ -11,11 +11,10 @@ import (
 type Option func(*options) error
 
 type options struct {
-	protocols            []protocol.ID
-	parallelism          int
-	connectTimeout       time.Duration
-	perMsgTimeout        time.Duration
-	dialAddressExtendDur time.Duration
+	protocols      []protocol.ID
+	parallelism    int
+	connectTimeout time.Duration
+	perMsgTimeout  time.Duration
 }
 
 // defaults are the default crawler options. This option will be automatically
@@ -25,7 +24,6 @@ var defaults = func(o *options) error {
 	o.parallelism = 1000
 	o.connectTimeout = time.Second * 5
 	o.perMsgTimeout = time.Second * 5
-	o.dialAddressExtendDur = time.Minute * 30
 
 	return nil
 }
@@ -58,16 +56,6 @@ func WithMsgTimeout(timeout time.Duration) Option {
 func WithConnectTimeout(timeout time.Duration) Option {
 	return func(o *options) error {
 		o.connectTimeout = timeout
-		return nil
-	}
-}
-
-// WithDialAddrExtendDuration sets the duration by which the TTL of dialed address in peer store are
-// extended.
-// Defaults to 30 minutes if unset.
-func WithDialAddrExtendDuration(ext time.Duration) Option {
-	return func(o *options) error {
-		o.dialAddressExtendDur = ext
 		return nil
 	}
 }

--- a/fullrt/dht.go
+++ b/fullrt/dht.go
@@ -163,7 +163,7 @@ func NewFullRT(h host.Host, protocolPrefix protocol.ID, options ...Option) (*Ful
 	}
 
 	if fullrtcfg.crawler == nil {
-		fullrtcfg.crawler, err = crawler.NewDefaultCrawler(h, crawler.WithParallelism(200), crawler.WithDialAddrExtendDuration(fullrtcfg.crawlInterval))
+		fullrtcfg.crawler, err = crawler.NewDefaultCrawler(h, crawler.WithParallelism(200))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Extending the TTL in the host's peerstore right after connecting is a no-op, since it is effective only [if the provided TTL is higher than the current one](https://github.com/libp2p/go-libp2p/blob/5e6f217d847e7c1c3f98197a54c9503d0303a7bb/p2p/host/peerstore/pstoremem/addr_book.go#L374-L377), and a remote peer that is `Connected` has a a [much higher](https://github.com/libp2p/go-libp2p/blob/5e6f217d847e7c1c3f98197a54c9503d0303a7bb/core/peerstore/peerstore.go#L48) TTL.

Hence we can fully remove the `dialAddressExtendDur`.

See https://github.com/libp2p/go-libp2p-kad-dht/issues/1061#issuecomment-2704316209 and https://github.com/libp2p/go-libp2p-kad-dht/pull/1053

Note that this is a breaking change.