### PR TITLE
fix: error on no valid provs

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -341,9 +341,9 @@ func (dht *IpfsDHT) handleGetProviders(ctx context.Context, p peer.ID, pmes *pb.
 func (dht *IpfsDHT) handleAddProvider(ctx context.Context, p peer.ID, pmes *pb.Message) (_ *pb.Message, _err error) {
 	key := pmes.GetKey()
 	if len(key) > 80 {
-		return nil, fmt.Errorf("handleAddProvider key size too large")
+		return nil, errors.New("handleAddProvider key size too large")
 	} else if len(key) == 0 {
-		return nil, fmt.Errorf("handleAddProvider key is empty")
+		return nil, errors.New("handleAddProvider key is empty")
 	}
 
 	logger.Debugw("adding provider", "from", p, "key", internal.LoggableProviderRecordBytes(key))
@@ -372,7 +372,7 @@ func (dht *IpfsDHT) handleAddProvider(ctx context.Context, p peer.ID, pmes *pb.M
 		success = true
 	}
 	if !success {
-		return nil, fmt.Errorf("handleAddProvider no valid provider")
+		return nil, errors.New("handleAddProvider no valid provider")
 	}
 
 	return nil, nil

--- a/handlers.go
+++ b/handlers.go
@@ -350,6 +350,7 @@ func (dht *IpfsDHT) handleAddProvider(ctx context.Context, p peer.ID, pmes *pb.M
 
 	// add provider should use the address given in the message
 	pinfos := pb.PBPeersToPeerInfos(pmes.GetProviderPeers())
+	success := false
 	for _, pi := range pinfos {
 		if pi.ID != p {
 			// we should ignore this provider record! not from originator.
@@ -368,6 +369,10 @@ func (dht *IpfsDHT) handleAddProvider(ctx context.Context, p peer.ID, pmes *pb.M
 		// announcement go through.
 		addrs := dht.filterAddrs(pi.Addrs)
 		dht.providerStore.AddProvider(ctx, key, peer.AddrInfo{ID: pi.ID, Addrs: addrs})
+		success = true
+	}
+	if !success {
+		return nil, fmt.Errorf("handleAddProvider no valid provider")
 	}
 
 	return nil, nil


### PR DESCRIPTION
Until now, when a client sends an `ADD_PROVIDE` with no valid provider (either not matching the client's peer id, or missing addresses), the DHT Server will behave as if the operation was successful.

This change makes the DHT Server error when no valid providers are provided, which will close the stream (same behavior as other errors).