### PR TITLE
refactor: use errors.New when no formatting required

### DIFF
--- a/dht_options.go
+++ b/dht_options.go
@@ -2,7 +2,7 @@ package dht
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"testing"
 	"time"
 
@@ -129,7 +129,7 @@ func NamespacedValidator(ns string, v record.Validator) Option {
 	return func(c *dhtcfg.Config) error {
 		nsval, ok := c.Validator.(record.NamespacedValidator)
 		if !ok {
-			return fmt.Errorf("can only add namespaced validators to a NamespacedValidator")
+			return errors.New("can only add namespaced validators to a NamespacedValidator")
 		}
 		nsval[ns] = v
 		return nil

--- a/fullrt/dht.go
+++ b/fullrt/dht.go
@@ -261,7 +261,7 @@ func (dht *FullRT) TriggerRefresh(ctx context.Context) error {
 	case dht.triggerRefresh <- struct{}{}:
 		return nil
 	case <-dht.ctx.Done():
-		return fmt.Errorf("dht is closed")
+		return errors.New("dht is closed")
 	}
 }
 
@@ -520,7 +520,7 @@ func (dht *FullRT) PutValue(ctx context.Context, key string, value []byte, opts 
 			return err
 		}
 		if i != 0 {
-			return fmt.Errorf("can't replace a newer value with an older value")
+			return errors.New("can't replace a newer value with an older value")
 		}
 	}
 
@@ -546,7 +546,7 @@ func (dht *FullRT) PutValue(ctx context.Context, key string, value []byte, opts 
 	}, peers, true)
 
 	if successes == 0 {
-		return fmt.Errorf("failed to complete put")
+		return errors.New("failed to complete put")
 	}
 
 	return nil
@@ -834,7 +834,7 @@ func (dht *FullRT) Provide(ctx context.Context, key cid.Cid, brdcst bool) (err e
 	if !dht.enableProviders {
 		return routing.ErrNotSupported
 	} else if !key.Defined() {
-		return fmt.Errorf("invalid cid: undefined")
+		return errors.New("invalid cid: undefined")
 	}
 	keyMH := key.Hash()
 	logger.Debugw("providing", "cid", key, "mh", internal.LoggableProviderRecordBytes(keyMH))
@@ -895,7 +895,7 @@ func (dht *FullRT) Provide(ctx context.Context, key cid.Cid, brdcst bool) (err e
 	}
 
 	if successes == 0 {
-		return fmt.Errorf("failed to complete provide")
+		return errors.New("failed to complete provide")
 	}
 
 	return ctx.Err()
@@ -989,7 +989,7 @@ func (dht *FullRT) ProvideMany(ctx context.Context, keys []multihash.Multihash) 
 	// TODO: We may want to limit the type of addresses in our provider records
 	// For example, in a WAN-only DHT prohibit sharing non-WAN addresses (e.g. 192.168.0.100)
 	if len(pi.Addrs) < 1 {
-		return fmt.Errorf("no known addresses for self, cannot put provider")
+		return errors.New("no known addresses for self, cannot put provider")
 	}
 
 	fn := func(ctx context.Context, p, k peer.ID) error {
@@ -1016,7 +1016,7 @@ func (dht *FullRT) PutMany(ctx context.Context, keys []string, values [][]byte) 
 	}
 
 	if len(keys) != len(values) {
-		return fmt.Errorf("number of keys does not match the number of values")
+		return errors.New("number of keys does not match the number of values")
 	}
 
 	keysAsPeerIDs := make([]peer.ID, 0, len(keys))
@@ -1027,7 +1027,7 @@ func (dht *FullRT) PutMany(ctx context.Context, keys []string, values [][]byte) 
 	}
 
 	if len(keys) != len(keyRecMap) {
-		return fmt.Errorf("does not support duplicate keys")
+		return errors.New("does not support duplicate keys")
 	}
 
 	fn := func(ctx context.Context, p, k peer.ID) error {
@@ -1200,7 +1200,7 @@ func (dht *FullRT) bulkMessageSend(ctx context.Context, keys []peer.ID, fn func(
 
 	if numSendsSuccessful == 0 {
 		logger.Infof("bulk send failed")
-		return fmt.Errorf("failed to complete bulk sending")
+		return errors.New("failed to complete bulk sending")
 	}
 
 	logger.Infof("bulk send complete: %d keys, %d unique, %d successful, %d skipped peers, %d fails",
@@ -1244,7 +1244,7 @@ func (dht *FullRT) FindProviders(ctx context.Context, c cid.Cid) ([]peer.AddrInf
 	if !dht.enableProviders {
 		return nil, routing.ErrNotSupported
 	} else if !c.Defined() {
-		return nil, fmt.Errorf("invalid cid: undefined")
+		return nil, errors.New("invalid cid: undefined")
 	}
 
 	var providers []peer.AddrInfo

--- a/handlers.go
+++ b/handlers.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"fmt"
 	"time"
 
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -256,7 +255,7 @@ func (dht *IpfsDHT) handleFindPeer(ctx context.Context, from peer.ID, pmes *pb.M
 	var closest []peer.ID
 
 	if len(pmes.GetKey()) == 0 {
-		return nil, fmt.Errorf("handleFindPeer with empty key")
+		return nil, errors.New("handleFindPeer with empty key")
 	}
 
 	// if looking for self... special case where we send it on CloserPeers.
@@ -304,9 +303,9 @@ func (dht *IpfsDHT) handleFindPeer(ctx context.Context, from peer.ID, pmes *pb.M
 func (dht *IpfsDHT) handleGetProviders(ctx context.Context, p peer.ID, pmes *pb.Message) (_ *pb.Message, _err error) {
 	key := pmes.GetKey()
 	if len(key) > 80 {
-		return nil, fmt.Errorf("handleGetProviders key size too large")
+		return nil, errors.New("handleGetProviders key size too large")
 	} else if len(key) == 0 {
-		return nil, fmt.Errorf("handleGetProviders key is empty")
+		return nil, errors.New("handleGetProviders key is empty")
 	}
 
 	resp := pb.NewMessage(pmes.GetType(), pmes.GetKey(), pmes.GetClusterLevel())

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -101,7 +102,7 @@ func (c *Config) ApplyFallbacks(h host.Host) error {
 				nsval["ipns"] = ipns.Validator{KeyBook: h.Peerstore()}
 			}
 		} else {
-			return fmt.Errorf("the default Validator was changed without being marked as changed")
+			return errors.New("the default Validator was changed without being marked as changed")
 		}
 	}
 	return nil

--- a/internal/logging.go
+++ b/internal/logging.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -20,7 +21,7 @@ func multibaseB32Encode(k []byte) string {
 
 func tryFormatLoggableRecordKey(k string) (string, error) {
 	if len(k) == 0 {
-		return "", fmt.Errorf("LoggableRecordKey is empty")
+		return "", errors.New("LoggableRecordKey is empty")
 	}
 	var proto, cstr string
 	if k[0] == '/' {
@@ -73,7 +74,7 @@ func (lk LoggableProviderRecordBytes) String() string {
 
 func tryFormatLoggableProviderKey(k []byte) (string, error) {
 	if len(k) == 0 {
-		return "", fmt.Errorf("LoggableProviderKey is empty")
+		return "", errors.New("LoggableProviderKey is empty")
 	}
 
 	encodedKey := multibaseB32Encode(k)

--- a/internal/net/message_manager.go
+++ b/internal/net/message_manager.go
@@ -3,7 +3,7 @@ package net
 import (
 	"bufio"
 	"context"
-	"fmt"
+	"errors"
 	"io"
 	"sync"
 	"time"
@@ -26,7 +26,7 @@ import (
 var dhtReadMessageTimeout = 10 * time.Second
 
 // ErrReadTimeout is an error that occurs when no message is read within the timeout period.
-var ErrReadTimeout = fmt.Errorf("timed out reading response")
+var ErrReadTimeout = errors.New("timed out reading response")
 
 var logger = logging.Logger("dht")
 
@@ -197,7 +197,7 @@ func (ms *peerMessageSender) prepOrInvalidate(ctx context.Context) error {
 
 func (ms *peerMessageSender) prep(ctx context.Context) error {
 	if ms.invalid {
-		return fmt.Errorf("message sender has been invalidated")
+		return errors.New("message sender has been invalidated")
 	}
 	if ms.s != nil {
 		return nil

--- a/lookup.go
+++ b/lookup.go
@@ -2,7 +2,7 @@ package dht
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"time"
 
 	"github.com/libp2p/go-libp2p-kad-dht/internal"
@@ -24,7 +24,7 @@ func (dht *IpfsDHT) GetClosestPeers(ctx context.Context, key string) ([]peer.ID,
 	defer span.End()
 
 	if key == "" {
-		return nil, fmt.Errorf("can't lookup empty key")
+		return nil, errors.New("can't lookup empty key")
 	}
 
 	// TODO: I can break the interface! return []peer.ID

--- a/lookup_optim.go
+++ b/lookup_optim.go
@@ -2,7 +2,7 @@ package dht
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"math"
 	"sync"
 	"sync/atomic"
@@ -111,7 +111,7 @@ func (dht *IpfsDHT) optimisticProvide(outerCtx context.Context, keyMH multihash.
 	key := string(keyMH)
 
 	if key == "" {
-		return fmt.Errorf("can't lookup empty key")
+		return errors.New("can't lookup empty key")
 	}
 
 	// initialize new context for all putProvider operations.

--- a/netsize/netsize.go
+++ b/netsize/netsize.go
@@ -1,7 +1,7 @@
 package netsize
 
 import (
-	"fmt"
+	"errors"
 	"math"
 	"math/big"
 	"sort"
@@ -20,8 +20,8 @@ import (
 const invalidEstimate int32 = -1
 
 var (
-	ErrNotEnoughData   = fmt.Errorf("not enough data")
-	ErrWrongNumOfPeers = fmt.Errorf("expected bucket size number of peers")
+	ErrNotEnoughData   = errors.New("not enough data")
+	ErrWrongNumOfPeers = errors.New("expected bucket size number of peers")
 )
 
 var (
@@ -144,7 +144,6 @@ func (e *Estimator) Track(key string, peers []peer.ID) error {
 
 // NetworkSize instructs the Estimator to calculate the current network size estimate.
 func (e *Estimator) NetworkSize() (int32, error) {
-
 	// return cached calculation lock-free (fast path)
 	if estimate := atomic.LoadInt32(&e.netSizeCache); estimate != invalidEstimate {
 		logger.Debugw("Cached network size estimation", "estimate", estimate)
@@ -234,7 +233,6 @@ func (e *Estimator) NetworkSize() (int32, error) {
 // I actually thought this cannot happen as peers would have been added to the routing table before
 // the Track function gets called. But they seem sometimes not to be added.
 func (e *Estimator) calcWeight(key string, peers []peer.ID) float64 {
-
 	cpl := kbucket.CommonPrefixLen(kbucket.ConvertKey(key), e.localID)
 	bucketLevel := e.rt.NPeersForCpl(uint(cpl))
 

--- a/pb/protocol_messenger.go
+++ b/pb/protocol_messenger.go
@@ -193,7 +193,7 @@ func (pm *ProtocolMessenger) PutProviderAddrs(ctx context.Context, p peer.ID, ke
 	// TODO: We may want to limit the type of addresses in our provider records
 	// For example, in a WAN-only DHT prohibit sharing non-WAN addresses (e.g. 192.168.0.100)
 	if len(self.Addrs) < 1 {
-		return fmt.Errorf("no known addresses for self, cannot put provider")
+		return errors.New("no known addresses for self, cannot put provider")
 	}
 
 	pmes := NewMessage(Message_ADD_PROVIDER, key, 0)

--- a/providers/providers_manager.go
+++ b/providers/providers_manager.go
@@ -3,6 +3,7 @@ package providers
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -36,11 +37,13 @@ const (
 
 // ProvideValidity is the default time that a Provider Record should last on DHT
 // This value is also known as Provider Record Expiration Interval.
-var ProvideValidity = amino.DefaultProvideValidity
-var defaultCleanupInterval = time.Hour
-var lruCacheSize = 256
-var batchBufferSize = 256
-var log = logging.Logger("providers")
+var (
+	ProvideValidity        = amino.DefaultProvideValidity
+	defaultCleanupInterval = time.Hour
+	lruCacheSize           = 256
+	batchBufferSize        = 256
+	log                    = logging.Logger("providers")
+)
 
 // ProviderStore represents a store that associates peers and their addresses to keys.
 type ProviderStore interface {
@@ -403,7 +406,7 @@ func loadProviderSet(ctx context.Context, dstore ds.Datastore, k []byte) (*provi
 func readTimeValue(data []byte) (time.Time, error) {
 	nsec, n := binary.Varint(data)
 	if n <= 0 {
-		return time.Time{}, fmt.Errorf("failed to parse time")
+		return time.Time{}, errors.New("failed to parse time")
 	}
 
 	return time.Unix(0, nsec), nil

--- a/query_test.go
+++ b/query_test.go
@@ -2,7 +2,7 @@ package dht
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"testing"
 	"time"
 
@@ -34,7 +34,7 @@ func TestRTEvictionOnFailedQuery(t *testing.T) {
 	// peers should be in the RT because of fixLowPeers
 	require.NoError(t, tu.WaitFor(ctx, func() error {
 		if !checkRoutingTable(d1, d2) {
-			return fmt.Errorf("should have routes")
+			return errors.New("should have routes")
 		}
 		return nil
 	}))
@@ -45,7 +45,7 @@ func TestRTEvictionOnFailedQuery(t *testing.T) {
 	// peers will still be in the RT because we have decoupled membership from connectivity
 	require.NoError(t, tu.WaitFor(ctx, func() error {
 		if !checkRoutingTable(d1, d2) {
-			return fmt.Errorf("should have routes")
+			return errors.New("should have routes")
 		}
 		return nil
 	}))
@@ -59,7 +59,7 @@ func TestRTEvictionOnFailedQuery(t *testing.T) {
 
 	require.NoError(t, tu.WaitFor(ctx, func() error {
 		if checkRoutingTable(d1, d2) {
-			return fmt.Errorf("should not have routes")
+			return errors.New("should not have routes")
 		}
 		return nil
 	}))
@@ -80,14 +80,14 @@ func TestRTAdditionOnSuccessfulQuery(t *testing.T) {
 	// d1 has d2
 	require.NoError(t, tu.WaitFor(ctx, func() error {
 		if !checkRoutingTable(d1, d2) {
-			return fmt.Errorf("should  have routes")
+			return errors.New("should  have routes")
 		}
 		return nil
 	}))
 	// d2 has d3
 	require.NoError(t, tu.WaitFor(ctx, func() error {
 		if !checkRoutingTable(d2, d3) {
-			return fmt.Errorf("should  have routes")
+			return errors.New("should  have routes")
 		}
 		return nil
 	}))
@@ -95,7 +95,7 @@ func TestRTAdditionOnSuccessfulQuery(t *testing.T) {
 	// however, d1 does not know about d3
 	require.NoError(t, tu.WaitFor(ctx, func() error {
 		if checkRoutingTable(d1, d3) {
-			return fmt.Errorf("should not have routes")
+			return errors.New("should not have routes")
 		}
 		return nil
 	}))
@@ -105,7 +105,7 @@ func TestRTAdditionOnSuccessfulQuery(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, tu.WaitFor(ctx, func() error {
 		if !checkRoutingTable(d1, d3) {
-			return fmt.Errorf("should have routes")
+			return errors.New("should have routes")
 		}
 		return nil
 	}))

--- a/routing.go
+++ b/routing.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"fmt"
 	"sync"
 	"time"
 
@@ -59,7 +58,7 @@ func (dht *IpfsDHT) PutValue(ctx context.Context, key string, value []byte, opts
 			return err
 		}
 		if i != 0 {
-			return fmt.Errorf("can't replace a newer value with an older value")
+			return errors.New("can't replace a newer value with an older value")
 		}
 	}
 
@@ -390,7 +389,7 @@ func (dht *IpfsDHT) Provide(ctx context.Context, key cid.Cid, brdcst bool) (err 
 	if !dht.enableProviders {
 		return routing.ErrNotSupported
 	} else if !key.Defined() {
-		return fmt.Errorf("invalid cid: undefined")
+		return errors.New("invalid cid: undefined")
 	}
 	keyMH := key.Hash()
 	logger.Debugw("providing", "cid", key, "mh", internal.LoggableProviderRecordBytes(keyMH))
@@ -477,7 +476,7 @@ func (dht *IpfsDHT) FindProviders(ctx context.Context, c cid.Cid) ([]peer.AddrIn
 	if !dht.enableProviders {
 		return nil, routing.ErrNotSupported
 	} else if !c.Defined() {
-		return nil, fmt.Errorf("invalid cid: undefined")
+		return nil, errors.New("invalid cid: undefined")
 	}
 
 	var providers []peer.AddrInfo


### PR DESCRIPTION
When no special error formatting is required `errors.New` is more appropriate than `fmt.Errorf`. 