### PR TITLE
fix: use correct message type attribute in metrics

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -119,9 +119,9 @@ func RecordMessageRecvErr(ctx context.Context, messageType string, msgLen int64)
 	attrSetOpt := metric.WithAttributeSet(ctxAttrSet)
 	attrOpt := metric.WithAttributes(attribute.Key(KeyMessageType).String("UNKNOWN"))
 
-	receivedMessages.Add(ctx, 1, attrSetOpt, attrOpt)
-	receivedMessageErrors.Add(ctx, 1, attrSetOpt, attrOpt)
-	receivedBytes.Record(ctx, msgLen, attrSetOpt, attrOpt)
+	receivedMessages.Add(ctx, 1, attrOpt, attrSetOpt)
+	receivedMessageErrors.Add(ctx, 1, attrOpt, attrSetOpt)
+	receivedBytes.Record(ctx, msgLen, attrOpt, attrSetOpt)
 }
 
 func RecordMessageHandleErr(ctx context.Context) {
@@ -149,11 +149,10 @@ func RecordRequestSendErr(ctx context.Context) {
 func RecordRequestSendOK(ctx context.Context, sentBytesLen int64, latencyMs float64) {
 	ctxAttrSet := AttributesFromContext(ctx)
 	attrSetOpt := metric.WithAttributeSet(ctxAttrSet)
-	attrOpt := metric.WithAttributes(attribute.Key(KeyMessageType).String("UNKNOWN"))
 
-	sentRequests.Add(ctx, 1, attrSetOpt, attrOpt)
-	sentBytes.Record(ctx, 1, attrSetOpt, attrOpt)
-	outboundRequestLatency.Record(ctx, latencyMs, attrSetOpt, attrOpt)
+	sentRequests.Add(ctx, 1, attrSetOpt)
+	sentBytes.Record(ctx, 1, attrSetOpt)
+	outboundRequestLatency.Record(ctx, latencyMs, attrSetOpt)
 }
 
 func RecordMessageSendOK(ctx context.Context, sentBytesLen int64) {


### PR DESCRIPTION
The message type attribute was being overwritten with "UNKNOWN" because `attrOpt` was given after `attrSetOpt` (which contained the message type from the context) in the varargs.
I removed the message type "UNKOWN" from `RecordRequestSendOK` since its only called once and the context that is passed in has the message type attribute set.

The images bellow show the problem with an example query in victoria metrics.
![message-type-pre](https://github.com/user-attachments/assets/5c62875e-101d-4506-a690-ba57447ee8e4)
![message-type-post](https://github.com/user-attachments/assets/75eaac6b-2e9e-4947-8271-05a133a0edb2)