### PR TITLE
fix: netsize warning

### DIFF
--- a/lookup_optim.go
+++ b/lookup_optim.go
@@ -169,7 +169,11 @@ func (dht *IpfsDHT) optimisticProvide(outerCtx context.Context, keyMH multihash.
 
 	// tracking lookup results for network size estimator as "completed" is true
 	if err = dht.nsEstimator.Track(key, lookupRes.closest); err != nil {
-		logger.Warnf("network size estimator track peers: %s", err)
+		if err != netsize.ErrWrongNumOfPeers || dht.routingTable.Size() > dht.bucketSize {
+			// Don't warn if we have a wrong number of peers and the routing table is
+			// small because the network may simply not have enough peers.
+			logger.Warnf("network size estimator track peers: %s", err)
+		}
 	}
 
 	if ns, err := dht.nsEstimator.NetworkSize(); err == nil {


### PR DESCRIPTION
The network size estimator is emitting a warning if it doesn't get exactly `bucketSize` peers in the `Track()` method.

If the network doesn't contain `bucketSize` peers altogether, the warning will constantly be emitted, which is undesirable and corrected in this PR.

See [this post](https://discuss.ipfs.tech/t/understanding-reprovider-behavior-with-go-ds-crdt/19279).