### PR TITLE
feat: rework fullrt to use a caching routing table

### DIFF
--- a/cachert/rt.go
+++ b/cachert/rt.go
@@ -1,0 +1,145 @@
+package cachert
+
+import (
+	"time"
+
+	"github.com/emirpasic/gods/v2/trees/avltree"
+)
+
+type Key = string
+
+type KeySearchRange struct {
+	KeyLower Key
+	KeyUpper Key
+	Time     time.Time
+}
+
+type RT struct {
+	at     *avltree.Tree[Key, *KeySearchRange]
+	ranges map[*KeySearchRange]struct{}
+}
+
+func NewRT() *RT {
+	return &RT{
+		at:     avltree.New[Key, *KeySearchRange](),
+		ranges: make(map[*KeySearchRange]struct{}),
+	}
+}
+
+func (t *RT) GetRanges() []KeySearchRange {
+	ranges := make([]KeySearchRange, 0, len(t.ranges))
+	for k := range t.ranges {
+		if k.KeyLower > k.KeyUpper {
+			panic("lower key must be less than upper key")
+		}
+		ranges = append(ranges, KeySearchRange{
+			KeyLower: k.KeyLower,
+			KeyUpper: k.KeyUpper,
+			Time:     k.Time,
+		})
+	}
+	return ranges
+}
+
+func (t *RT) InsertRange(lower, upper Key, expiration time.Time) {
+	if lower > upper {
+		panic("lower key must be less than upper key")
+	}
+	if len([]byte(lower)) != len([]byte(upper)) && len([]byte(lower)) != 32 {
+		panic("lower and upper keys must be 32 bytes")
+	}
+
+	r := &KeySearchRange{lower, upper, expiration}
+
+	// Find the range that starts the latest, but before the start of this range
+	f, ok := t.at.Floor(r.KeyLower)
+	// If there are no nodes that start before this one
+	type rr struct {
+		k Key
+		r *KeySearchRange
+	}
+
+	var rangesToReplace []rr
+
+	if !ok {
+		f = t.at.Left()
+	} else {
+		if f.Value.KeyUpper > r.KeyLower {
+			// Truncate the previous range to stop where this one starts
+			f.Value.KeyUpper = r.KeyLower
+			rangesToReplace = append(rangesToReplace, rr{k: f.Key, r: f.Value})
+		}
+	}
+	// Insert this one
+	t.at.Put(r.KeyLower, r)
+	t.ranges[r] = struct{}{}
+
+	// Continue through subsequent ranges seeing if any get clobbered by this one
+	for f := f.Next(); f != nil; f = f.Next() {
+		if f.Value == r {
+			// This is the same range, so we can skip it
+			continue
+		}
+		if f.Value.KeyLower < r.KeyUpper {
+			if f.Value.KeyUpper <= r.KeyUpper {
+				rangesToReplace = append(rangesToReplace, rr{k: f.Key, r: nil})
+				delete(t.ranges, f.Value)
+			} else {
+				f.Value.KeyUpper = r.KeyUpper
+				rangesToReplace = append(rangesToReplace, rr{k: f.Key, r: f.Value})
+			}
+		} else {
+			break
+		}
+	}
+
+	for _, rng := range rangesToReplace {
+		t.at.Remove(rng.k)
+		if rng.r == nil {
+			continue
+		}
+		if rng.r.KeyLower == rng.r.KeyUpper {
+			// If the range is empty, we don't want to keep it
+			delete(t.ranges, rng.r)
+		} else {
+			t.at.Put(rng.r.KeyLower, rng.r)
+		}
+	}
+}
+
+func (t *RT) RangeIsCovered(lower, upper Key) bool {
+	if lower > upper {
+		panic("lower key must be less than upper key")
+	}
+	if len([]byte(lower)) != len([]byte(upper)) && len([]byte(lower)) != 32 {
+		panic("lower and upper keys must be 32 bytes")
+	}
+
+	lowest := lower
+	f, ok := t.at.Floor(lowest)
+	if !ok {
+		return false
+	}
+
+	for ; f != nil; f = f.Next() {
+		if f.Value.KeyLower > lowest {
+			return false
+		}
+
+		if f.Value.KeyUpper >= upper {
+			return true
+		}
+
+		lowest = f.Value.KeyUpper
+	}
+	return false
+}
+
+func (t *RT) CollectGarbage(ti time.Time) {
+	for r, _ := range t.ranges {
+		if r.Time.Before(ti) {
+			t.at.Remove(r.KeyLower)
+			delete(t.ranges, r)
+		}
+	}
+}

--- a/cachert/rt_test.go
+++ b/cachert/rt_test.go
@@ -1,0 +1,91 @@
+package cachert
+
+import (
+	"bytes"
+	"testing"
+	"time"
+)
+
+func TestRT_InsertRangeAndGetRanges(t *testing.T) {
+	rt := NewRT()
+
+	// Valid 32-byte keys
+	key1 := bytes.Repeat([]byte("a"), 32)
+	key2 := bytes.Repeat([]byte("b"), 32)
+	key3 := bytes.Repeat([]byte("c"), 32)
+	key4 := bytes.Repeat([]byte("d"), 32)
+
+	// Insert non-overlapping range
+	rt.InsertRange(string(key1), string(key2), time.Now().Add(1*time.Hour))
+	ranges := rt.GetRanges()
+	if len(ranges) != 1 {
+		t.Fatalf("expected 1 range, got %d", len(ranges))
+	}
+
+	// Insert overlapping range
+	rt.InsertRange(string(key2), string(key3), time.Now().Add(2*time.Hour))
+	ranges = rt.GetRanges()
+	if len(ranges) != 2 {
+		t.Fatalf("expected 2 ranges, got %d", len(ranges))
+	}
+
+	// Insert range that merges with existing ranges
+	rt.InsertRange(string(key1), string(key4), time.Now().Add(3*time.Hour))
+	ranges = rt.GetRanges()
+	if len(ranges) != 1 {
+		t.Fatalf("expected 1 merged range, got %d", len(ranges))
+	}
+	if ranges[0].KeyLower != string(key1) || ranges[0].KeyUpper != string(key4) {
+		t.Fatalf("merged range has incorrect bounds: %+v", ranges[0])
+	}
+}
+
+func TestRT_RangeIsCovered(t *testing.T) {
+	rt := NewRT()
+
+	// Valid 32-byte keys
+	key1 := bytes.Repeat([]byte("a"), 32)
+	key2 := bytes.Repeat([]byte("b"), 32)
+	key3 := bytes.Repeat([]byte("c"), 32)
+	key4 := bytes.Repeat([]byte("d"), 32)
+
+	// Insert ranges
+	rt.InsertRange(string(key1), string(key2), time.Now().Add(1*time.Hour))
+	rt.InsertRange(string(key2), string(key3), time.Now().Add(2*time.Hour))
+
+	// Check covered range
+	if !rt.RangeIsCovered(string(key1), string(key3)) {
+		t.Fatalf("expected range [%s, %s] to be covered", key1, key3)
+	}
+
+	// Check partially covered range
+	if rt.RangeIsCovered(string(key1), string(key4)) {
+		t.Fatalf("expected range [%s, %s] to not be fully covered", key1, key4)
+	}
+
+	// Check uncovered range
+	if rt.RangeIsCovered(string(key3), string(key4)) {
+		t.Fatalf("expected range [%s, %s] to not be covered", key3, key4)
+	}
+}
+
+func TestRT_CollectGarbage(t *testing.T) {
+	rt := NewRT()
+
+	// Valid 32-byte keys
+	key1 := bytes.Repeat([]byte("a"), 32)
+	key2 := bytes.Repeat([]byte("b"), 32)
+
+	// Insert range with expiration
+	expiredTime := time.Now().Add(-1 * time.Hour)
+	rt.InsertRange(string(key1), string(key2), expiredTime)
+
+	// Collect garbage
+	rt.CollectGarbage(time.Now())
+
+	// Validate range is removed
+	ranges := rt.GetRanges()
+	if len(ranges) != 0 {
+		t.Fatalf("expected 0 ranges after garbage collection, got %d", len(ranges))
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,9 @@ toolchain go1.22.1
 retract v0.24.3 // this includes a breaking change and should have been released as v0.25.0
 
 require (
+	github.com/emirpasic/gods/v2 v2.0.0-alpha
 	github.com/gogo/protobuf v1.3.2
+	github.com/google/btree v1.1.3
 	github.com/google/gopacket v1.1.19
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-multierror v1.1.1
@@ -31,6 +33,7 @@ require (
 	github.com/multiformats/go-multibase v0.2.0
 	github.com/multiformats/go-multihash v0.2.3
 	github.com/multiformats/go-multistream v0.5.0
+	github.com/probe-lab/go-kademlia v0.0.0-20240823125516-aed94cdc2c2f
 	github.com/stretchr/testify v1.9.0
 	github.com/whyrusleeping/go-keyspace v0.0.0-20160322163242-5b898ac5add1
 	go.opencensus.io v0.24.0

--- a/go.sum
+++ b/go.sum
@@ -71,6 +71,8 @@ github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25Kn
 github.com/elastic/gosigar v0.12.0/go.mod h1:iXRIGg2tLnu7LBdpqzyQfGDEidKCfWcCMS0WKyPWoMs=
 github.com/elastic/gosigar v0.14.3 h1:xwkKwPia+hSfg9GqrCUKYdId102m9qTJIIr7egmK/uo=
 github.com/elastic/gosigar v0.14.3/go.mod h1:iXRIGg2tLnu7LBdpqzyQfGDEidKCfWcCMS0WKyPWoMs=
+github.com/emirpasic/gods/v2 v2.0.0-alpha h1:dwFlh8pBg1VMOXWGipNMRt8v96dKAIvBehtCt6OtunU=
+github.com/emirpasic/gods/v2 v2.0.0-alpha/go.mod h1:W0y4M2dtBB9U5z3YlghmpuUhiaZT2h6yoeE+C1sCp6A=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
@@ -125,6 +127,8 @@ github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QD
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
+github.com/google/btree v1.1.3 h1:CVpQJjYgC4VbzxeGVHfvZrv1ctoYCAI8vbl07Fcxlyg=
+github.com/google/btree v1.1.3/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
@@ -422,6 +426,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/polydawn/refmt v0.89.0 h1:ADJTApkvkeBZsN0tBTx8QjpD9JkmxbKp0cxfr9qszm4=
 github.com/polydawn/refmt v0.89.0/go.mod h1:/zvteZs/GwLtCgZ4BL6CBsk9IKIlexP43ObX9AxTqTw=
+github.com/probe-lab/go-kademlia v0.0.0-20240823125516-aed94cdc2c2f h1:RRo6TuvMKIiTiKjQHEYrakdCExb/lPG9rNelr4tZadk=
+github.com/probe-lab/go-kademlia v0.0.0-20240823125516-aed94cdc2c2f/go.mod h1:FHBJfMug9mTo5BDBC6i9PbfYPImNCjeGC+oBJxNGsJQ=
 github.com/prometheus/client_golang v0.8.0/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v1.20.5 h1:cxppBPuYhUnsO6yo/aoRol4L7q7UFfdm+bR9r+8l63Y=
 github.com/prometheus/client_golang v1.20.5/go.mod h1:PIEt8X02hGcP8JWbeHyeZ53Y/jReSnHgO035n//V5WE=

--- a/internal/net/message_manager.go
+++ b/internal/net/message_manager.go
@@ -74,6 +74,8 @@ func (m *messageSenderImpl) OnDisconnect(ctx context.Context, p peer.ID) {
 // measure the RTT for latency measurements.
 func (m *messageSenderImpl) SendRequest(ctx context.Context, p peer.ID, pmes *pb.Message) (*pb.Message, error) {
 	ctx, _ = tag.New(ctx, metrics.UpsertMessageType(pmes))
+	ctx, cancel := context.WithTimeout(ctx, dhtReadMessageTimeout)
+	defer cancel()
 
 	ms, err := m.messageSenderForPeer(ctx, p)
 	if err != nil {
@@ -109,6 +111,8 @@ func (m *messageSenderImpl) SendRequest(ctx context.Context, p peer.ID, pmes *pb
 // SendMessage sends out a message
 func (m *messageSenderImpl) SendMessage(ctx context.Context, p peer.ID, pmes *pb.Message) error {
 	ctx, _ = tag.New(ctx, metrics.UpsertMessageType(pmes))
+	ctx, cancel := context.WithTimeout(ctx, dhtReadMessageTimeout)
+	defer cancel()
 
 	ms, err := m.messageSenderForPeer(ctx, p)
 	if err != nil {

--- a/lookup.go
+++ b/lookup.go
@@ -34,12 +34,12 @@ func (dht *IpfsDHT) GetClosestPeers(ctx context.Context, key string) ([]peer.ID,
 		return nil, err
 	}
 
-	if err := ctx.Err(); err != nil || !lookupRes.completed {
-		return lookupRes.peers, err
+	if err := ctx.Err(); err != nil || !lookupRes.Completed {
+		return lookupRes.Peers, err
 	}
 
 	// tracking lookup results for network size estimator
-	if err = dht.nsEstimator.Track(key, lookupRes.closest); err != nil {
+	if err = dht.nsEstimator.Track(key, lookupRes.Closest); err != nil {
 		logger.Warnf("network size estimator track peers: %s", err)
 	}
 
@@ -50,7 +50,7 @@ func (dht *IpfsDHT) GetClosestPeers(ctx context.Context, key string) ([]peer.ID,
 	// refresh the cpl for this key as the query was successful
 	dht.routingTable.ResetCplRefreshedAtForID(kb.ConvertKey(key), time.Now())
 
-	return lookupRes.peers, nil
+	return lookupRes.Peers, nil
 }
 
 // pmGetClosestPeers is the protocol messenger version of the GetClosestPeer queryFn.

--- a/lookup_optim.go
+++ b/lookup_optim.go
@@ -150,7 +150,7 @@ func (dht *IpfsDHT) optimisticProvide(outerCtx context.Context, keyMH multihash.
 
 	// Store the provider records with all the closest peers we haven't already contacted/scheduled interaction with.
 	es.peerStatesLk.Lock()
-	for _, p := range lookupRes.peers {
+	for _, p := range lookupRes.Peers {
 		if _, found := es.peerStates[p]; found {
 			continue
 		}
@@ -163,12 +163,12 @@ func (dht *IpfsDHT) optimisticProvide(outerCtx context.Context, keyMH multihash.
 	// wait until a threshold number of RPCs have completed
 	es.waitForRPCs()
 
-	if err := outerCtx.Err(); err != nil || !lookupRes.completed { // likely the "completed" field is false but that's not a given
+	if err := outerCtx.Err(); err != nil || !lookupRes.Completed { // likely the "completed" field is false but that's not a given
 		return err
 	}
 
 	// tracking lookup results for network size estimator as "completed" is true
-	if err = dht.nsEstimator.Track(key, lookupRes.closest); err != nil {
+	if err = dht.nsEstimator.Track(key, lookupRes.Closest); err != nil {
 		logger.Warnf("network size estimator track peers: %s", err)
 	}
 

--- a/routing.go
+++ b/routing.go
@@ -179,7 +179,7 @@ func (dht *IpfsDHT) SearchValue(ctx context.Context, key string, opts ...routing
 				return
 			}
 
-			for _, p := range l.peers {
+			for _, p := range l.Peers {
 				if _, ok := peersWithBest[p]; !ok {
 					updatePeers = append(updatePeers, p)
 				}
@@ -281,9 +281,9 @@ func (dht *IpfsDHT) updatePeerValues(ctx context.Context, key string, val []byte
 	}
 }
 
-func (dht *IpfsDHT) getValues(ctx context.Context, key string, stopQuery chan struct{}) (<-chan recvdVal, <-chan *lookupWithFollowupResult) {
+func (dht *IpfsDHT) getValues(ctx context.Context, key string, stopQuery chan struct{}) (<-chan recvdVal, <-chan *LookupWithFollowupResult) {
 	valCh := make(chan recvdVal, 1)
-	lookupResCh := make(chan *lookupWithFollowupResult, 1)
+	lookupResCh := make(chan *LookupWithFollowupResult, 1)
 
 	logger.Debugw("finding value", "key", internal.LoggableRecordKeyString(key))
 
@@ -371,8 +371,8 @@ func (dht *IpfsDHT) getValues(ctx context.Context, key string, stopQuery chan st
 	return valCh, lookupResCh
 }
 
-func (dht *IpfsDHT) refreshRTIfNoShortcut(key kb.ID, lookupRes *lookupWithFollowupResult) {
-	if lookupRes.completed {
+func (dht *IpfsDHT) refreshRTIfNoShortcut(key kb.ID, lookupRes *LookupWithFollowupResult) {
+	if lookupRes.Completed {
 		// refresh the cpl for this key as the query was successful
 		dht.routingTable.ResetCplRefreshedAtForID(key, time.Now())
 	}
@@ -672,12 +672,12 @@ func (dht *IpfsDHT) FindPeer(ctx context.Context, id peer.ID) (pi peer.AddrInfo,
 	}
 
 	dialedPeerDuringQuery := false
-	for i, p := range lookupRes.peers {
+	for i, p := range lookupRes.Peers {
 		if p == id {
 			// Note: we consider PeerUnreachable to be a valid state because the peer may not support the DHT protocol
 			// and therefore the peer would fail the query. The fact that a peer that is returned can be a non-DHT
 			// server peer and is not identified as such is a bug.
-			dialedPeerDuringQuery = (lookupRes.state[i] == qpeerset.PeerQueried || lookupRes.state[i] == qpeerset.PeerUnreachable || lookupRes.state[i] == qpeerset.PeerWaiting)
+			dialedPeerDuringQuery = (lookupRes.State[i] == qpeerset.PeerQueried || lookupRes.State[i] == qpeerset.PeerUnreachable || lookupRes.State[i] == qpeerset.PeerWaiting)
 			break
 		}
 	}


### PR DESCRIPTION
cc @guillaumemichel this should be complimentary or may help with #1082. It operates by reworking the fullrt client to not actually be a full routing table, but have a caching routing table.

Feel free to change/rewrite anything here 😅.