### PR TITLE
Provider interface

### DIFF
--- a/reprovider/interface.md
+++ b/reprovider/interface.md
@@ -10,18 +10,20 @@ type Provider interface {
   // deletes the keys.
   StartProviding(...mh.Multihash)
 
+  // ForceStartProviding is similar to StartProviding, but it sends provider
+  // records out to the DHT regardless of whether the keys were already provided
+  // in the past. It keeps reproviding the keys until StopProviding is called
+  // for these keys.
+  ForceStartProviding(context.Context, ...mh.Multihash) error
+
   // StopProviding stops reproviding the given keys to the DHT swarm. The node
   // stops being referred as a provider when the provider records in the DHT
   // swarm expire.
   StopProviding(...mh.Multihash)
 
-  // InstantProvide only sends provider records for the given keys out to the DHT
-  // swarm. It does NOT take the responsibility to reprovide these keys.
-  InstantProvide(context.Context, ...mh.Multihash) error
-
-  // ForceProvide is similar to StartProviding, but it sends provider records out
-  // to the DHT even if the keys were already provided in the past.
-  ForceProvide(context.Context, ...mh.Multihash) error
+  // ProvideOnce sends provider records for the specified keys to the DHT swarm
+  // only once. It does not automatically reprovide those keys afterward.
+  ProvideOnce(context.Context, ...mh.Multihash) error
 }
 ```
 

--- a/reprovider/interface.md
+++ b/reprovider/interface.md
@@ -1,6 +1,6 @@
 # Provider Interface
 
-## Suggested `SweepingReprovider` interface
+## Suggested `DHTProvider` interface
 
 ```go
 // DHTProvider is an interface for providing keys to a DHT swarm. It holds a

--- a/reprovider/interface.md
+++ b/reprovider/interface.md
@@ -1,0 +1,53 @@
+# Provider Interface
+
+## Suggested `SweepingReprovider` interface
+
+```go
+type Provider interface {
+  // StartProviding provides the given keys to the DHT swarm unless they were
+  // already provided in the past. The keys will be periodically reprovided until
+  // StopProviding is called for the same keys or user defined garbage collection
+  // deletes the keys.
+  StartProviding(...mh.Multihash)
+
+  // StopProviding stops reproviding the given keys to the DHT swarm. The node
+  // stops being referred as a provider when the provider records in the DHT
+  // swarm expire.
+  StopProviding(...mh.Multihash)
+
+  // InstantProvide only sends provider records for the given keys out to the DHT
+  // swarm. It does NOT take the responsibility to reprovide these keys.
+  InstantProvide(context.Context, ...mh.Multihash) error
+
+  // ForceProvide is similar to StartProviding, but it sends provider records out
+  // to the DHT even if the keys were already provided in the past.
+  ForceProvide(context.Context, ...mh.Multihash) error
+}
+```
+
+## Old `boxo/provider` interface
+
+```go
+// Provider announces blocks to the network
+type Provider interface {
+  // Provide takes a cid and makes an attempt to announce it to the network
+  Provide(context.Context, cid.Cid, bool) error
+}
+
+// Reprovider reannounces blocks to the network
+type Reprovider interface {
+  // Reprovide starts a new reprovide if one isn't running already.
+  Reprovide(context.Context) error
+}
+
+// System defines the interface for interacting with the value
+// provider system
+type System interface {
+  Close() error
+  Stat() (ReproviderStats, error)
+  Provider
+  Reprovider
+}
+```
+
+[source](https://github.com/ipfs/boxo/blob/44137d7d622ade477c6efc190ec2d5414fa3fcf8/provider/provider.go#L22-L41)

--- a/reprovider/interface.md
+++ b/reprovider/interface.md
@@ -10,36 +10,32 @@
 type DHTProvider interface {
   // StartProviding ensures keys are periodically advertised to the DHT swarm.
   //
-  // If the keys aren't currently being reprovided, they are immediately
-  // provided to the DHT swarm, and scheduled to be reprovided periodically. If
-  // `force` is set to true, all keys are immediately provided to the DHT
-  // swarm, regardless of whether they were already being provided in the past.
-  // `keys` keep being reprovided until `StopProviding` is called.
+  // If the `keys` aren't currently being reprovided, they are added to the
+  // queue to be provided to the DHT swarm as soon as possible, and scheduled
+  // to be reprovided periodically. If `force` is set to true, all keys are
+  // provided to the DHT swarm, regardless of whether they were already being
+  // reprovided in the past. `keys` keep being reprovided until `StopProviding`
+  // is called.
   //
-  // This call blocks until the initial provide completes (or fails), at
-  // which point it returns any error related to the initial provide.
-  //
-  // Cancelling the context cancels only the immediate provide, but not the
-  // reproviding of keys which is still done at some point the future. Call
-  // `StopProviding` to stop reproviding the specified keys.
-  StartProviding(ctx context.Context, force bool, keys ...mh.Multihash) error
-
-  // StartProvidingAsync is similar to `StartProviding`, but it does not block
-  // until the initial provide operation completes or fails. The supplied keys
-  // will eventually be provided and reprovided to the DHT swarm until
-  // `StopProviding` is called.
-  StartProvidingAsync(force bool, keys ...mh.Multihash)
+  // This operation is asynchronous, it returns as soon as the `keys` are added
+  // to the provide queue, and provides happens asynchronously.
+  StartProviding(force bool, keys ...mh.Multihash)
 
   // StopProviding stops reproviding the given keys to the DHT swarm. The node
   // stops being referred as a provider when the provider records in the DHT
   // swarm expire.
-  StopProviding(...mh.Multihash)
+  //
+  // Remove the `keys` from the schedule and return immediately. Valid records
+  // can remain in the DHT swarm up to the provider record TTL after calling
+  // `StopProviding`.
+  StopProviding(keys ...mh.Multihash)
 
   // ProvideOnce sends provider records for the specified keys to the DHT swarm
   // only once. It does not automatically reprovide those keys afterward.
   //
-  // Canceling the context cancels the immediate provide of the keys.
-  ProvideOnce(context.Context, ...mh.Multihash) error
+  // Add the supplied multihashes to the provide queue, and return immediately.
+  // The provide operation happens asynchronously.
+  ProvideOnce(keys ...mh.Multihash)
 }
 ```
 

--- a/reprovider/interface.md
+++ b/reprovider/interface.md
@@ -3,18 +3,32 @@
 ## Suggested `SweepingReprovider` interface
 
 ```go
-type Provider interface {
-  // StartProviding provides the given keys to the DHT swarm unless they were
-  // already provided in the past. The keys will be periodically reprovided until
-  // StopProviding is called for the same keys or user defined garbage collection
-  // deletes the keys.
-  StartProviding(...mh.Multihash)
+// DHTProvider is an interface for providing keys to a DHT swarm. It holds a
+// state of keys to be advertised, and is responsible for periodically
+// publishing provider records for these keys to the DHT swarm before the
+// records expire.
+type DHTProvider interface {
+  // StartProviding ensures keys are periodically advertised to the DHT swarm.
+  //
+  // If the keys aren't currently being reprovided, they are immediately
+  // provided to the DHT swarm, and scheduled to be reprovided periodically. If
+  // `force` is set to true, all keys are immediately provided to the DHT
+  // swarm, regardless of whether they were already being provided in the past.
+  // `keys` keep being reprovided until `StopProviding` is called.
+  //
+  // This call blocks until the initial provide completes (or fails), at
+  // which point it returns any error related to the initial provide.
+  //
+  // Cancelling the context cancels only the immediate provide, but not the
+  // reproviding of keys which is still done at some point the future. Call
+  // `StopProviding` to stop reproviding the specified keys.
+  StartProviding(ctx context.Context, force bool, keys ...mh.Multihash) error
 
-  // ForceStartProviding is similar to StartProviding, but it sends provider
-  // records out to the DHT regardless of whether the keys were already provided
-  // in the past. It keeps reproviding the keys until StopProviding is called
-  // for these keys.
-  ForceStartProviding(context.Context, ...mh.Multihash) error
+  // StartProvidingAsync is similar to `StartProviding`, but it does not block
+  // until the initial provide operation completes or fails. The supplied keys
+  // will eventually be provided and reprovided to the DHT swarm until
+  // `StopProviding` is called.
+  StartProvidingAsync(force bool, keys ...mh.Multihash)
 
   // StopProviding stops reproviding the given keys to the DHT swarm. The node
   // stops being referred as a provider when the provider records in the DHT
@@ -23,6 +37,8 @@ type Provider interface {
 
   // ProvideOnce sends provider records for the specified keys to the DHT swarm
   // only once. It does not automatically reprovide those keys afterward.
+  //
+  // Canceling the context cancels the immediate provide of the keys.
   ProvideOnce(context.Context, ...mh.Multihash) error
 }
 ```


### PR DESCRIPTION
This PR is just a place to discuss the interface, it doesn't contain actual code.

## DHT Provider Interface

Here is the suggested Provider interface for the `SweepingReprovider`, to be used in kubo to replace `boxo/provider` `System`/`Provider` [interface](https://github.com/ipfs/boxo/blob/44137d7d622ade477c6efc190ec2d5414fa3fcf8/provider/provider.go#L22-L41).

Note that the interface would also be implemented by a dual DHT Sweeping Provider.

We can extend the interface as needed (e.g `Stats()`).

---

## Kubo integration

If we want both Provide systems (`go-libp2p-kad-dht:Provider` and `boxo:Provider`) to be swappable in kubo (at least for a transition period), it would be convenient to have a common interface for both systems.

IMO it is easier to wrap `boxo:Provider` around `go-libp2p-kad-dht:Provider` than the other way around, since `go-libp2p-kad-dht:Provider` is "richer".

However, `go-libp2p-kad-dht:Provider` doesn't have a concept of `Reprovide` to trigger a general reprovide of all keys, which is required by `boxo:Provider`. AFAIK only the `ipfs routing reprovide` command is using `boxo:Provider.Reprovide`, so it should be easy enough to cast and if the provide system in use in kubo is `boxo:Provider`, the reprovide command happens as it used to, otherwise mark it as deprecated with the new provide system.

If `boxo:Provider` is wrapped in the `go-libp2p-kad-dht:Provider` interface, `StartProviding()` and `ProvideOnce()` could  both be mapped to `boxo:Provider.Provide()`, and `StopProviding()` would be a noop. 

---

@lidel @hsanjuan @gammazero WDYT? We can still change the interface easily at this point.