### PR TITLE
provider: keystore

### DIFF
--- a/amino/defaults.go
+++ b/amino/defaults.go
@@ -48,6 +48,11 @@ const (
 	// find the multiaddress associated with the returned peer id.
 	DefaultProviderAddrTTL = 24 * time.Hour
 
+	// DefaultReprovideInterval is the default interval at which the keys should
+	// be reprovided to the DHT swarm to ensure there are enough live records in
+	// the swarm.
+	DefaultReprovideInterval = 22 * time.Hour
+
 	// DefaultMaxPeersPerIPGroup is the maximal number of peers with addresses in
 	// the same IP group allowed in the routing table. Once this limit is
 	// reached, newly discovered peers with addresses in the same IP group will

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/multiformats/go-multibase v0.2.0
 	github.com/multiformats/go-multihash v0.2.3
 	github.com/multiformats/go-multistream v0.6.0
+	github.com/probe-lab/go-libdht v0.2.1-0.20250704053741-31e98600d9ec
 	github.com/stretchr/testify v1.10.0
 	github.com/whyrusleeping/go-keyspace v0.0.0-20160322163242-5b898ac5add1
 	go.opentelemetry.io/otel v1.35.0

--- a/go.sum
+++ b/go.sum
@@ -380,6 +380,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/polydawn/refmt v0.89.0 h1:ADJTApkvkeBZsN0tBTx8QjpD9JkmxbKp0cxfr9qszm4=
 github.com/polydawn/refmt v0.89.0/go.mod h1:/zvteZs/GwLtCgZ4BL6CBsk9IKIlexP43ObX9AxTqTw=
+github.com/probe-lab/go-libdht v0.2.1-0.20250704053741-31e98600d9ec h1:SHYUHNzEwackoRJ0yHw8Bx39kQYL2BtJ45qchJfbV0k=
+github.com/probe-lab/go-libdht v0.2.1-0.20250704053741-31e98600d9ec/go.mod h1:q+WlGiqs/UIRfdhw9Gmc+fPoAYlOim7VvXTjOI6KJmQ=
 github.com/prometheus/client_golang v0.8.0/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v1.22.0 h1:rb93p9lokFEsctTys46VnV1kLCDpVZ0a/Y92Vm0Zc6Q=
 github.com/prometheus/client_golang v1.22.0/go.mod h1:R7ljNsLXhuQXYZYtw6GAE9AZg8Y7vEW5scdCXrWRXC0=

--- a/provider/datastore/keystore.go
+++ b/provider/datastore/keystore.go
@@ -51,8 +51,8 @@ type KeyStore struct {
 }
 
 type keyStoreCfg struct {
-	base      string
-	prefixLen int
+	base       string
+	prefixBits int
 
 	gcFunc      KeyChanFunc
 	gcInterval  time.Duration
@@ -63,28 +63,28 @@ type keyStoreCfg struct {
 type KeyStoreOption func(*keyStoreCfg) error
 
 const (
-	DefaultKeyStorePrefixLen   = 10
+	DefaultKeyStorePrefixBits  = 10
 	DefaultKeyStoreBasePrefix  = "/reprovider/mhs"
 	DefaultKeyStoreGCInterval  = 2 * amino.DefaultReprovideInterval
 	DefaultKeyStoreGCBatchSize = 1 << 14
 )
 
 var KeyStoreDefaultCfg = func(cfg *keyStoreCfg) error {
-	cfg.prefixLen = DefaultKeyStorePrefixLen
+	cfg.prefixBits = DefaultKeyStorePrefixBits
 	cfg.base = DefaultKeyStoreBasePrefix
 	cfg.gcInterval = DefaultKeyStoreGCInterval
 	cfg.gcBatchSize = DefaultKeyStoreGCBatchSize
 	return nil
 }
 
-// WithPrefixLen sets the bit-length used to group multihashes when persisting
+// WithPrefixBits sets the bit-length used to group multihashes when persisting
 // them. The value must be positive and at most 256 bits.
-func WithPrefixLen(n int) KeyStoreOption {
+func WithPrefixBits(n int) KeyStoreOption {
 	return func(cfg *keyStoreCfg) error {
 		if n <= 0 || n > 256 {
 			return fmt.Errorf("invalid prefix length %d", n)
 		}
-		cfg.prefixLen = n
+		cfg.prefixBits = n
 		return nil
 	}
 }
@@ -155,7 +155,7 @@ func NewKeyStore(ctx context.Context, d ds.Batching, opts ...KeyStoreOption) (*K
 
 		ds:        d,
 		base:      ds.NewKey(cfg.base),
-		prefixLen: cfg.prefixLen,
+		prefixLen: cfg.prefixBits,
 
 		gcFunc:      cfg.gcFunc,
 		gcInterval:  cfg.gcInterval,

--- a/provider/datastore/keystore.go
+++ b/provider/datastore/keystore.go
@@ -1,0 +1,454 @@
+package datastore
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/ipfs/go-cid"
+	ds "github.com/ipfs/go-datastore"
+	query "github.com/ipfs/go-datastore/query"
+	logging "github.com/ipfs/go-log/v2"
+	"github.com/libp2p/go-libp2p-kad-dht/amino"
+	mh "github.com/multiformats/go-multihash"
+
+	"github.com/probe-lab/go-libdht/kad/key"
+	"github.com/probe-lab/go-libdht/kad/key/bit256"
+	"github.com/probe-lab/go-libdht/kad/key/bitstr"
+)
+
+var logger = logging.Logger("dht/SweepingReprovider/KeyStore")
+
+type KeyChanFunc = func(context.Context) (<-chan cid.Cid, error) // TODO: update to get mh.Multihash instead of cid.Cid
+
+// KeyStore maintains a collection of multihash keys, grouping them in a
+// datastore by their first `prefixLen` bits.
+//
+// Optionally, you can supply a garbage-collection callback that returns the
+// complete set of keys that should remain in the store. On a configurable
+// interval, the KeyStore will:
+//  1. Wipe its entire contents.
+//  2. Re-populate itself using only the keys provided by the callback.
+//
+// This automatic refresh keeps the KeyStore in sync with your source of truth
+// even if it’s difficult to know exactly when to call Remove() manually.
+type KeyStore struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+	lk     sync.Mutex
+
+	ds        ds.Batching
+	base      ds.Key
+	prefixLen int
+
+	gcFunc      KeyChanFunc // optional function to get keys for garbage collection
+	gcInterval  time.Duration
+	gcBatchSize int
+}
+
+type keyStoreCfg struct {
+	base      string
+	prefixLen int
+
+	gcFunc      KeyChanFunc
+	gcInterval  time.Duration
+	gcBatchSize int
+}
+
+// KeyStoreOption configures KeyStore behaviour.
+type KeyStoreOption func(*keyStoreCfg) error
+
+const (
+	DefaultKeyStorePrefixLen   = 10
+	DefaultKeyStoreBasePrefix  = "/reprovider/mhs"
+	DefaultKeyStoreGCInterval  = 2 * amino.DefaultReprovideInterval
+	DefaultKeyStoreGCBatchSize = 1 << 14
+)
+
+var KeyStoreDefaultCfg = func(cfg *keyStoreCfg) error {
+	cfg.prefixLen = DefaultKeyStorePrefixLen
+	cfg.base = DefaultKeyStoreBasePrefix
+	cfg.gcInterval = DefaultKeyStoreGCInterval
+	cfg.gcBatchSize = DefaultKeyStoreGCBatchSize
+	return nil
+}
+
+// WithPrefixLen sets the bit-length used to group multihashes when persisting
+// them. The value must be positive and at most 256 bits.
+func WithPrefixLen(n int) KeyStoreOption {
+	return func(cfg *keyStoreCfg) error {
+		if n <= 0 || n > 256 {
+			return fmt.Errorf("invalid prefix length %d", n)
+		}
+		cfg.prefixLen = n
+		return nil
+	}
+}
+
+// WithDatastorePrefix sets the datastore prefix under which multihashes are
+// stored.
+func WithDatastorePrefix(base string) KeyStoreOption {
+	return func(cfg *keyStoreCfg) error {
+		if base == "" {
+			return fmt.Errorf("datastore prefix cannot be empty")
+		}
+		cfg.base = base
+		return nil
+	}
+}
+
+// WithGCFunc sets the function periodically used to garbage collect keys that
+// shouldn't be provided anymore. During the garbage collection process, the
+// store is entirely purged, and is repopulated from the keys supplied by the
+// KeyChanFunc.
+func WithGCFunc(gcFunc KeyChanFunc) KeyStoreOption {
+	return func(cfg *keyStoreCfg) error {
+		cfg.gcFunc = gcFunc
+		return nil
+	}
+}
+
+// WithGCInterval defines the interval at which the KeyStore is garbage
+// collected. During the garbage collection process, the store is entirely
+// purged, and is repopulated from the keys supplied by the gcFunc.
+func WithGCInterval(interval time.Duration) KeyStoreOption {
+	return func(cfg *keyStoreCfg) error {
+		if interval <= 0 {
+			return fmt.Errorf("invalid garbage collection interval %s", interval)
+		}
+		cfg.gcInterval = interval
+		return nil
+	}
+}
+
+// WithGCBatchSize defines the number of keys per batch when repopulating the
+// KeyStore using the gcFunc. The gcFunc returns a chan cid.Cid, and the
+// repopulation process reads batches of gcBatchSize keys before writing them
+// to the KeyStore.
+func WithGCBatchSize(size int) KeyStoreOption {
+	return func(cfg *keyStoreCfg) error {
+		if size <= 0 {
+			return fmt.Errorf("invalid garbage collection batch size %d", size)
+		}
+		cfg.gcBatchSize = size
+		return nil
+	}
+}
+
+// NewKeyStore creates a new KeyStore backed by the provided datastore.
+func NewKeyStore(ctx context.Context, d ds.Batching, opts ...KeyStoreOption) (*KeyStore, error) {
+	var cfg keyStoreCfg
+	opts = append([]KeyStoreOption{KeyStoreDefaultCfg}, opts...)
+	for i, o := range opts {
+		if err := o(&cfg); err != nil {
+			return nil, fmt.Errorf("KeyStore option %d failed: %w", i, err)
+		}
+	}
+	keyStoreCtx, cancel := context.WithCancel(ctx)
+	keyStore := KeyStore{
+		ctx:    keyStoreCtx,
+		cancel: cancel,
+
+		ds:        d,
+		base:      ds.NewKey(cfg.base),
+		prefixLen: cfg.prefixLen,
+
+		gcFunc:      cfg.gcFunc,
+		gcInterval:  cfg.gcInterval,
+		gcBatchSize: cfg.gcBatchSize,
+	}
+	if cfg.gcFunc != nil && cfg.gcInterval > 0 {
+		go keyStore.runGC()
+	}
+	return &keyStore, nil
+}
+
+func (s *KeyStore) Close() error {
+	s.cancel()
+	s.wg.Wait()
+	return nil
+}
+
+// runGC periodically runs garbage collection.
+//
+// Garbage collection consists in totally purging the KeyStore, and
+// repopulating it with the keys supplied by the GC function. It basically
+// resets the state of the KeyStore to match the state returned by the GC
+// function.
+func (s *KeyStore) runGC() {
+	s.wg.Add(1)
+	defer s.wg.Done()
+	ticker := time.NewTicker(s.gcInterval)
+	for {
+		select {
+		case <-s.ctx.Done():
+			return
+		case <-ticker.C:
+			keysChan, err := s.gcFunc(s.ctx)
+			if err != nil {
+				logger.Errorf("garbage collection failed: %v", err)
+				continue
+			}
+			err = s.ResetCids(s.ctx, keysChan)
+			if err != nil {
+				logger.Errorf("reset failed: %v", err)
+			}
+		}
+	}
+}
+
+// ResetCids purges the KeyStore and repopulates it with the provided cids.
+func (s *KeyStore) ResetCids(ctx context.Context, keysChan <-chan cid.Cid) error {
+	err := s.Empty(ctx)
+	if err != nil {
+		return fmt.Errorf("KeyStore empty failed during reset: %w", err)
+	}
+	keys := make([]mh.Multihash, s.gcBatchSize)
+	i := 0
+	for c := range keysChan {
+		keys[i] = c.Hash()
+		i++
+		if i == s.gcBatchSize {
+			_, err = s.Put(ctx, keys...)
+			if err != nil {
+				return fmt.Errorf("KeyStore put failed during reset: %w", err)
+			}
+			i = 0
+			keys = keys[:0]
+		}
+	}
+	_, err = s.Put(ctx, keys...)
+	if err != nil {
+		return fmt.Errorf("KeyStore put failed during reset: %w", err)
+	}
+	return nil
+}
+
+func (s *KeyStore) dsKey(prefix bitstr.Key) ds.Key {
+	return s.base.ChildString(string(prefix))
+}
+
+// putLocked stores the provided keys while assuming s.lk is already held.
+func (s *KeyStore) putLocked(ctx context.Context, keys ...mh.Multihash) ([]mh.Multihash, error) {
+	groups := make(map[bitstr.Key][]mh.Multihash)
+	for _, h := range keys {
+		k := mhToBit256(h)
+		bs := bitstr.Key(key.BitString(k)[:s.prefixLen])
+		groups[bs] = append(groups[bs], h)
+	}
+
+	newKeys := make([]mh.Multihash, 0, len(keys))
+	for prefix, hs := range groups {
+		dsKey := s.dsKey(prefix)
+		var stored []mh.Multihash
+		data, err := s.ds.Get(ctx, dsKey)
+		if err != nil && err != ds.ErrNotFound {
+			return nil, err
+		}
+		if err == nil {
+			if err := json.Unmarshal(data, &stored); err != nil {
+				return nil, err
+			}
+		}
+
+		set := make(map[string]struct{}, len(stored))
+		for _, h := range stored {
+			set[string(h)] = struct{}{}
+		}
+
+		for _, h := range hs {
+			if _, ok := set[string(h)]; !ok {
+				stored = append(stored, h)
+				set[string(h)] = struct{}{}
+				newKeys = append(newKeys, h)
+			}
+		}
+
+		buf, err := json.Marshal(stored)
+		if err != nil {
+			return nil, err
+		}
+		if err := s.ds.Put(ctx, dsKey, buf); err != nil {
+			return nil, err
+		}
+	}
+	return newKeys, nil
+}
+
+// Put stores the provided keys in the underlying datastore, grouping them by
+// the first prefixLen bits. It returns only the keys that were not previously
+// persisted in the datastore (i.e., newly added keys).
+func (s *KeyStore) Put(ctx context.Context, keys ...mh.Multihash) ([]mh.Multihash, error) {
+	if len(keys) == 0 {
+		return nil, nil
+	}
+	s.lk.Lock()
+	defer s.lk.Unlock()
+
+	return s.putLocked(ctx, keys...)
+}
+
+// Get returns all keys whose bit256 representation matches the provided
+// prefix.
+func (s *KeyStore) Get(ctx context.Context, prefix bitstr.Key) ([]mh.Multihash, error) {
+	s.lk.Lock()
+	defer s.lk.Unlock()
+
+	result := make([]mh.Multihash, 0)
+	uniq := make(map[string]struct{})
+
+	if len(prefix) >= s.prefixLen {
+		dsKey := s.dsKey(bitstr.Key(prefix[:s.prefixLen]))
+		data, err := s.ds.Get(ctx, dsKey)
+		if err != nil {
+			if err == ds.ErrNotFound {
+				return nil, nil
+			}
+			return nil, err
+		}
+		var stored []mh.Multihash
+		if err := json.Unmarshal(data, &stored); err != nil {
+			return nil, err
+		}
+		for _, h := range stored {
+			bs := bitstr.Key(key.BitString(mhToBit256(h)))
+			if len(bs) >= len(prefix) && bs[:len(prefix)] == prefix {
+				if _, ok := uniq[string(h)]; !ok {
+					uniq[string(h)] = struct{}{}
+					result = append(result, h)
+				}
+			}
+		}
+		return result, nil
+	}
+
+	remaining := s.prefixLen - len(prefix)
+	limit := 1 << remaining
+	for i := range limit {
+		suffix := fmt.Sprintf("%0*b", remaining, i)
+		dsKey := s.dsKey(prefix + bitstr.Key(suffix))
+		data, err := s.ds.Get(ctx, dsKey)
+		if err != nil {
+			if err == ds.ErrNotFound {
+				continue
+			}
+			return nil, err
+		}
+		var stored []mh.Multihash
+		if err := json.Unmarshal(data, &stored); err != nil {
+			return nil, err
+		}
+		for _, h := range stored {
+			if _, ok := uniq[string(h)]; !ok {
+				uniq[string(h)] = struct{}{}
+				result = append(result, h)
+			}
+		}
+	}
+	return result, nil
+}
+
+// emptyLocked deletes all entries under the datastore prefix, assuming s.lk is
+// already held.
+func (s *KeyStore) emptyLocked(ctx context.Context) error {
+	res, err := s.ds.Query(ctx, query.Query{Prefix: s.base.String()})
+	if err != nil {
+		return err
+	}
+	defer res.Close()
+
+	for r := range res.Next() {
+		if r.Error != nil {
+			return r.Error
+		}
+		if err := s.ds.Delete(ctx, ds.NewKey(r.Key)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Empty deletes all entries under the datastore prefix.
+func (s *KeyStore) Empty(ctx context.Context) error {
+	s.lk.Lock()
+	defer s.lk.Unlock()
+
+	return s.emptyLocked(ctx)
+}
+
+// Delete removes the given keys from datastore.
+func (s *KeyStore) Delete(ctx context.Context, keys ...mh.Multihash) error {
+	if len(keys) == 0 {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	s.lk.Lock()
+	defer s.lk.Unlock()
+
+	groups := make(map[bitstr.Key][]mh.Multihash)
+	for _, h := range keys {
+		bs := bitstr.Key(key.BitString(mhToBit256(h)))
+		p := bitstr.Key(bs[:s.prefixLen])
+		groups[p] = append(groups[p], h)
+	}
+
+	for prefix, toDel := range groups {
+		dsKey := s.dsKey(prefix)
+		data, err := s.ds.Get(ctx, dsKey)
+		if err != nil {
+			if err == ds.ErrNotFound {
+				continue
+			}
+			return err
+		}
+
+		var stored []mh.Multihash
+		if err := json.Unmarshal(data, &stored); err != nil {
+			return err
+		}
+
+		rmSet := make(map[string]struct{}, len(toDel))
+		for _, h := range toDel {
+			rmSet[string(h)] = struct{}{}
+		}
+
+		remaining := stored[:0]
+		changed := false
+		for _, h := range stored {
+			if _, ok := rmSet[string(h)]; ok {
+				changed = true
+				continue
+			}
+			remaining = append(remaining, h)
+		}
+		if !changed {
+			continue
+		}
+		if len(remaining) == 0 {
+			if err := s.ds.Delete(ctx, dsKey); err != nil && err != ds.ErrNotFound {
+				return err
+			}
+			continue
+		}
+		buf, err := json.Marshal(remaining)
+		if err != nil {
+			return err
+		}
+		if err := s.ds.Put(ctx, dsKey, buf); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// mhToBit256 converts a multihash to a bit256.Key by hashing it with SHA-256.
+func mhToBit256(h mh.Multihash) bit256.Key {
+	hash := sha256.Sum256(h)
+	return bit256.NewKey(hash[:])
+}

--- a/provider/datastore/keystore_test.go
+++ b/provider/datastore/keystore_test.go
@@ -1,0 +1,198 @@
+package datastore
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ipfs/go-cid"
+	ds "github.com/ipfs/go-datastore"
+	mh "github.com/multiformats/go-multihash"
+
+	"github.com/probe-lab/go-libdht/kad/key"
+	"github.com/probe-lab/go-libdht/kad/key/bitstr"
+)
+
+func TestKeyStoreStoreAndGet(t *testing.T) {
+	store, err := NewKeyStore(context.Background(), ds.NewMapDatastore())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mhs := make([]mh.Multihash, 6)
+	for i := range mhs {
+		h, err := mh.Sum([]byte{byte(i)}, mh.SHA2_256, -1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		mhs[i] = h
+	}
+
+	added, err := store.Put(context.Background(), mhs...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(added) != len(mhs) {
+		t.Fatalf("expected %d new hashes, got %d", len(mhs), len(added))
+	}
+
+	added, err = store.Put(context.Background(), mhs...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(added) != 0 {
+		t.Fatalf("expected no new hashes on second put, got %d", len(added))
+	}
+
+	for _, h := range mhs {
+		prefix := bitstr.Key(key.BitString(mhToBit256(h))[:DefaultKeyStorePrefixLen])
+		got, err := store.Get(context.Background(), prefix)
+		if err != nil {
+			t.Fatal(err)
+		}
+		found := false
+		for _, m := range got {
+			if string(m) == string(h) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("expected to find multihash %v for prefix %s", h, prefix)
+		}
+	}
+
+	short := DefaultKeyStorePrefixLen / 2
+	p := bitstr.Key(key.BitString(mhToBit256(mhs[0]))[:short])
+	res, err := store.Get(context.Background(), p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res) == 0 {
+		t.Fatalf("expected results for prefix %s", p)
+	}
+
+	longPrefix := bitstr.Key(key.BitString(mhToBit256(mhs[0]))[:15])
+	res, err = store.Get(context.Background(), longPrefix)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, h := range res {
+		bs := bitstr.Key(key.BitString(mhToBit256(h)))
+		if bs[:15] != longPrefix {
+			t.Fatalf("returned hash does not match long prefix")
+		}
+	}
+}
+
+func TestKeyStoreReset(t *testing.T) {
+	store, err := NewKeyStore(context.Background(), ds.NewMapDatastore())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	first := make([]mh.Multihash, 2)
+	for i := range first {
+		h, err := mh.Sum([]byte{byte(i)}, mh.SHA2_256, -1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		first[i] = h
+	}
+	if _, err := store.Put(context.Background(), first...); err != nil {
+		t.Fatal(err)
+	}
+
+	secondChan := make(chan cid.Cid, 2)
+	second := make([]mh.Multihash, 2)
+	for i := range 2 {
+		h, err := mh.Sum([]byte{byte(i + 10)}, mh.SHA2_256, -1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		second[i] = h
+		secondChan <- cid.NewCidV1(cid.Raw, h)
+	}
+	close(secondChan)
+
+	err = store.ResetCids(context.Background(), secondChan)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// old hashes should not be present
+	for _, h := range first {
+		prefix := bitstr.Key(key.BitString(mhToBit256(h))[:DefaultKeyStorePrefixLen])
+		got, err := store.Get(context.Background(), prefix)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, m := range got {
+			if string(m) == string(h) {
+				t.Fatalf("expected old hash %v to be removed", h)
+			}
+		}
+	}
+
+	// new hashes should be retrievable
+	for _, h := range second {
+		prefix := bitstr.Key(key.BitString(mhToBit256(h))[:DefaultKeyStorePrefixLen])
+		got, err := store.Get(context.Background(), prefix)
+		if err != nil {
+			t.Fatal(err)
+		}
+		found := false
+		for _, m := range got {
+			if string(m) == string(h) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("expected hash %v after reset", h)
+		}
+	}
+}
+
+func TestKeyStoreDelete(t *testing.T) {
+	store, err := NewKeyStore(context.Background(), ds.NewMapDatastore())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mhs := make([]mh.Multihash, 3)
+	for i := range mhs {
+		h, err := mh.Sum([]byte{byte(i)}, mh.SHA2_256, -1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		mhs[i] = h
+	}
+	if _, err := store.Put(context.Background(), mhs...); err != nil {
+		t.Fatal(err)
+	}
+
+	delPrefix := bitstr.Key(key.BitString(mhToBit256(mhs[0]))[:DefaultKeyStorePrefixLen])
+	if err := store.Delete(context.Background(), mhs[0]); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := store.Get(context.Background(), delPrefix)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, h := range res {
+		if string(h) == string(mhs[0]) {
+			t.Fatalf("expected no hashes for prefix after delete")
+		}
+	}
+
+	// other hashes should still be retrievable
+	otherPrefix := bitstr.Key(key.BitString(mhToBit256(mhs[1]))[:DefaultKeyStorePrefixLen])
+	res, err = store.Get(context.Background(), otherPrefix)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res) == 0 {
+		t.Fatalf("expected remaining hashes for other prefix")
+	}
+}

--- a/provider/datastore/keystore_test.go
+++ b/provider/datastore/keystore_test.go
@@ -44,7 +44,7 @@ func TestKeyStoreStoreAndGet(t *testing.T) {
 	}
 
 	for _, h := range mhs {
-		prefix := bitstr.Key(key.BitString(mhToBit256(h))[:DefaultKeyStorePrefixLen])
+		prefix := bitstr.Key(key.BitString(mhToBit256(h))[:DefaultKeyStorePrefixBits])
 		got, err := store.Get(context.Background(), prefix)
 		if err != nil {
 			t.Fatal(err)
@@ -61,7 +61,7 @@ func TestKeyStoreStoreAndGet(t *testing.T) {
 		}
 	}
 
-	short := DefaultKeyStorePrefixLen / 2
+	short := DefaultKeyStorePrefixBits / 2
 	p := bitstr.Key(key.BitString(mhToBit256(mhs[0]))[:short])
 	res, err := store.Get(context.Background(), p)
 	if err != nil {
@@ -121,7 +121,7 @@ func TestKeyStoreReset(t *testing.T) {
 
 	// old hashes should not be present
 	for _, h := range first {
-		prefix := bitstr.Key(key.BitString(mhToBit256(h))[:DefaultKeyStorePrefixLen])
+		prefix := bitstr.Key(key.BitString(mhToBit256(h))[:DefaultKeyStorePrefixBits])
 		got, err := store.Get(context.Background(), prefix)
 		if err != nil {
 			t.Fatal(err)
@@ -135,7 +135,7 @@ func TestKeyStoreReset(t *testing.T) {
 
 	// new hashes should be retrievable
 	for _, h := range second {
-		prefix := bitstr.Key(key.BitString(mhToBit256(h))[:DefaultKeyStorePrefixLen])
+		prefix := bitstr.Key(key.BitString(mhToBit256(h))[:DefaultKeyStorePrefixBits])
 		got, err := store.Get(context.Background(), prefix)
 		if err != nil {
 			t.Fatal(err)
@@ -171,7 +171,7 @@ func TestKeyStoreDelete(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	delPrefix := bitstr.Key(key.BitString(mhToBit256(mhs[0]))[:DefaultKeyStorePrefixLen])
+	delPrefix := bitstr.Key(key.BitString(mhToBit256(mhs[0]))[:DefaultKeyStorePrefixBits])
 	if err := store.Delete(context.Background(), mhs[0]); err != nil {
 		t.Fatal(err)
 	}
@@ -187,7 +187,7 @@ func TestKeyStoreDelete(t *testing.T) {
 	}
 
 	// other hashes should still be retrievable
-	otherPrefix := bitstr.Key(key.BitString(mhToBit256(mhs[1]))[:DefaultKeyStorePrefixLen])
+	otherPrefix := bitstr.Key(key.BitString(mhToBit256(mhs[1]))[:DefaultKeyStorePrefixBits])
 	res, err = store.Get(context.Background(), otherPrefix)
 	if err != nil {
 		t.Fatal(err)

--- a/provider/datastore/keystore_test.go
+++ b/provider/datastore/keystore_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestKeyStoreStoreAndGet(t *testing.T) {
-	store, err := NewKeyStore(context.Background(), ds.NewMapDatastore())
+	store, err := NewKeyStore(ds.NewMapDatastore())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -85,7 +85,7 @@ func TestKeyStoreStoreAndGet(t *testing.T) {
 }
 
 func TestKeyStoreReset(t *testing.T) {
-	store, err := NewKeyStore(context.Background(), ds.NewMapDatastore())
+	store, err := NewKeyStore(ds.NewMapDatastore())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -154,7 +154,7 @@ func TestKeyStoreReset(t *testing.T) {
 }
 
 func TestKeyStoreDelete(t *testing.T) {
-	store, err := NewKeyStore(context.Background(), ds.NewMapDatastore())
+	store, err := NewKeyStore(ds.NewMapDatastore())
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Part of https://github.com/libp2p/go-libp2p-kad-dht/pull/1095

## Description

The KeyStore is a datastore backed state to keep track of the keys (multihashes) that should be periodically reprovided to the DHT swarm.

The keys are stored by DHT keyspace locality. They are grouped by (constant size) prefix and indexed by this prefix in the datastore. Note that the key by which they are addressed is their Kademlia identifier, and not the hash from the multihash.

## Operations

Readers (`Get()`) only make prefix requests, since the caller wants to retrieve all keys matching a specific set of peers in the network matching the keyspace prefix.

Writers (`Put()`) are expected to write random keys (not necessarily close in the keyspace).

Keys can be removed using `Delete()`.

Since it is tricky for kubo to determine whether a key should stop being provided or not, a garbage collection (reset) function is available to remove keys that shouldn't be reprovided anymore. Caller can provide a GC function, containing the list of all keys that the KeyStore is expected to hold. If the GC function is set, the KeyStore will periodically purge all its keys, and repopulate itself with the keys supplied by the GC/reset function.