### PR TITLE
provider: add ShortestCoveredPrefix helper

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/ipfs/go-log/v2 v2.6.0
 	github.com/ipfs/go-test v0.2.2
 	github.com/libp2p/go-libp2p v0.41.1
-	github.com/libp2p/go-libp2p-kbucket v0.7.0
+	github.com/libp2p/go-libp2p-kbucket v0.7.1-0.20250718125122-f77e735b68e8
 	github.com/libp2p/go-libp2p-record v0.3.1
 	github.com/libp2p/go-libp2p-routing-helpers v0.7.5
 	github.com/libp2p/go-libp2p-testing v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -220,8 +220,8 @@ github.com/libp2p/go-libp2p-asn-util v0.4.1/go.mod h1:d/NI6XZ9qxw67b4e+NgpQexCIi
 github.com/libp2p/go-libp2p-core v0.2.4/go.mod h1:STh4fdfa5vDYr0/SzYYeqnt+E6KfEV5VxfIrm0bcI0g=
 github.com/libp2p/go-libp2p-core v0.3.0/go.mod h1:ACp3DmS3/N64c2jDzcV429ukDpicbL6+TrrxANBjPGw=
 github.com/libp2p/go-libp2p-kbucket v0.3.1/go.mod h1:oyjT5O7tS9CQurok++ERgc46YLwEpuGoFq9ubvoUOio=
-github.com/libp2p/go-libp2p-kbucket v0.7.0 h1:vYDvRjkyJPeWunQXqcW2Z6E93Ywx7fX0jgzb/dGOKCs=
-github.com/libp2p/go-libp2p-kbucket v0.7.0/go.mod h1:blOINGIj1yiPYlVEX0Rj9QwEkmVnz3EP8LK1dRKBC6g=
+github.com/libp2p/go-libp2p-kbucket v0.7.1-0.20250718125122-f77e735b68e8 h1:8FdUnEJQniowxU1XvXGxbLG+1fl8TnS01PwyCtTUzQ0=
+github.com/libp2p/go-libp2p-kbucket v0.7.1-0.20250718125122-f77e735b68e8/go.mod h1:3CofRbwJbTybT8WVM2z/h5dj2FPNar6YLyxUc4Tmv1E=
 github.com/libp2p/go-libp2p-peerstore v0.1.4/go.mod h1:+4BDbDiiKf4PzpANZDAT+knVdLxvqh7hXOujessqdzs=
 github.com/libp2p/go-libp2p-record v0.3.1 h1:cly48Xi5GjNw5Wq+7gmjfBiG9HCzQVkiZOUZ8kUl+Fg=
 github.com/libp2p/go-libp2p-record v0.3.1/go.mod h1:T8itUkLcWQLCYMqtX7Th6r7SexyUJpIyPgks757td/E=

--- a/provider/internal/helpers/key.go
+++ b/provider/internal/helpers/key.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"sort"
 
+	kb "github.com/libp2p/go-libp2p-kbucket"
 	"github.com/libp2p/go-libp2p/core/peer"
 	mh "github.com/multiformats/go-multihash"
 
@@ -97,6 +98,37 @@ func KeyToBytes[K kad.Key[K]](k K) []byte {
 		b[byteIndex] = by
 	}
 	return b
+}
+
+// ShortestCoveredPrefix takes as input the `target` key and the list of
+// closest peers to this key. It returns a prefix of `requested` that is
+// covered by these peers, along with the peers matching this prefix.
+//
+// We say that a set of peers fully "covers" a prefix of the global keyspace,
+// if all the peers matching this prefix are included in the set.
+//
+// If every peer shares the same CPL to `target`, then no deeper zone is
+// covered, we learn that the adjacent sibling branch is empty. In this case we
+// return the prefix one bit deeper (`minCPL+1`) and an empty peer list.
+func ShortestCoveredPrefix(target bitstr.Key, peers []peer.ID) (bitstr.Key, []peer.ID) {
+	if len(peers) == 0 {
+		return target, peers
+	}
+	// Sort the peers by their distance to the requested key.
+	peers = kb.SortClosestPeers(peers, KeyToBytes(target))
+
+	minCpl := target.BitLen() // key bitlen
+	coveredCpl := 0
+	lastCoveredPeerIndex := 0
+	for i, p := range peers {
+		cpl := key.CommonPrefixLength(target, PeerIDToBit256(p))
+		if cpl < minCpl {
+			coveredCpl = cpl + 1
+			lastCoveredPeerIndex = i
+			minCpl = cpl
+		}
+	}
+	return target[:coveredCpl], peers[:lastCoveredPeerIndex]
 }
 
 // PrefixAndKeys is a struct that holds a prefix and the multihashes whose


### PR DESCRIPTION
Part of https://github.com/libp2p/go-libp2p-kad-dht/pull/1095

Depends on https://github.com/libp2p/go-libp2p-kad-dht/pull/1101

---

Add helper function computing the shortest keyspace prefix covered by the closest peer ids to a target key.