### PR TITLE
provider: trie allocation helper

### DIFF
--- a/provider/internal/helpers/trie.go
+++ b/provider/internal/helpers/trie.go
@@ -3,6 +3,7 @@ package helpers
 import (
 	"github.com/probe-lab/go-libdht/kad"
 	"github.com/probe-lab/go-libdht/kad/key"
+	"github.com/probe-lab/go-libdht/kad/key/bit256"
 	"github.com/probe-lab/go-libdht/kad/trie"
 )
 
@@ -174,4 +175,130 @@ func pruneSubtrieAtDepth[K0 kad.Key[K0], K1 kad.Key[K1], D any](t *trie.Trie[K0,
 		return true
 	}
 	return false
+}
+
+// mapInsert appends a slice of values to the map entry for the given key. If
+// the key doesn't exist, it creates a new slice pre-sized to the length of the
+// values being inserted to avoid multiple allocations.
+func mapInsert[K comparable, V any](m map[K][]V, k K, vs []V) {
+	if cur := m[k]; cur == nil {
+		// pre-size once
+		m[k] = append(make([]V, 0, len(vs)), vs...)
+	} else {
+		m[k] = append(cur, vs...)
+	}
+}
+
+// mapMerge merges all key-value pairs from the source map into the destination
+// map. Values from the source are appended to existing slices in the
+// destination.
+func mapMerge[K comparable, V any](dst, src map[K][]V) {
+	for k1, vs1 := range src {
+		mapInsert(dst, k1, vs1)
+	}
+}
+
+// AllocateToKClosest distributes items from the items trie to the k closest
+// destinations in the dests trie based on XOR distance between their keys.
+//
+// The algorithm uses the trie structure to efficiently compute proximity
+// without explicit distance calculations. Items are allocated to destinations
+// by traversing both tries simultaneously and selecting the k destinations
+// with the smallest XOR distance to each item's key.
+//
+// Returns a map where each destination value is associated with all items
+// allocated to it. If k is 0 or either trie is empty, returns an empty map.
+func AllocateToKClosest[K kad.Key[K], V0 any, V1 comparable](items *trie.Trie[K, V0], dests *trie.Trie[K, V1], k int) map[V1][]V0 {
+	return allocateToKClosestAtDepth(items, dests, k, 0)
+}
+
+// allocateToKClosestAtDepth performs the recursive allocation algorithm at a specific
+// trie depth. At each depth, it processes both branches (0 and 1) of the trie,
+// determining which destinations are closest to the items based on matching bit
+// patterns at the current depth.
+//
+// The algorithm prioritizes destinations in the same branch as items (smaller XOR
+// distance) and recursively processes deeper levels when more granular distance
+// calculations are needed to select exactly k destinations.
+//
+// Parameters:
+//   - items: trie containing items to be allocated
+//   - dests: trie containing destination candidates
+//   - k: maximum number of destinations to allocate each item to
+//   - depth: current bit depth in the trie traversal
+//
+// Returns a map of destination values to their allocated items.
+func allocateToKClosestAtDepth[K kad.Key[K], V0 any, V1 comparable](items *trie.Trie[K, V0], dests *trie.Trie[K, V1], k, depth int) map[V1][]V0 {
+	m := make(map[V1][]V0)
+	if k == 0 {
+		return m
+	}
+	for i := range 2 {
+		// Assign all items from branch i
+
+		matchingItemsBranch := items.Branch(i)
+		matchingItems := AllValues(matchingItemsBranch, bit256.ZeroKey())
+		if len(matchingItems) == 0 {
+			if items.IsNonEmptyLeaf() && int((*items.Key()).Bit(depth)) == i {
+				// items' current branch contains a single leaf
+				matchingItems = []V0{items.Data()}
+				matchingItemsBranch = items
+			} else {
+				// items' current branch is empty, skip it
+				continue
+			}
+		}
+
+		matchingDestsBranch := dests.Branch(i)
+		otherDestsBranch := dests.Branch(1 - i)
+		matchingDests := AllValues(matchingDestsBranch, bit256.ZeroKey())
+		otherDests := AllValues(otherDestsBranch, bit256.ZeroKey())
+		if dests.IsLeaf() {
+			// Single key (leaf) in dests
+			if dests.IsNonEmptyLeaf() {
+				if int((*dests.Key()).Bit(depth)) == i {
+					// Leaf matches current branch
+					matchingDests = []V1{dests.Data()}
+					matchingDestsBranch = dests
+				} else {
+					// Leaf matches other branch
+					otherDests = []V1{dests.Data()}
+					otherDestsBranch = dests
+				}
+			} else {
+				// Empty leaf, no dests to allocate items.
+				return m
+			}
+		}
+
+		if nMatchingDests := len(matchingDests); nMatchingDests <= k {
+			// Allocate matching items to the matching dests branch
+			for _, dest := range matchingDests {
+				mapInsert(m, dest, matchingItems)
+			}
+			if nMatchingDests == k || len(otherDests) == 0 {
+				// Items were assigned to all k dests, or other branch is empty.
+				continue
+			}
+
+			nMissingDests := k - nMatchingDests
+			if len(otherDests) <= nMissingDests {
+				// Other branch contains at most the missing number of dests to be
+				// allocated to. Allocate matching items to the other dests branch.
+				for _, dest := range otherDests {
+					mapInsert(m, dest, matchingItems)
+				}
+			} else {
+				// Other branch contains more than the missing number of dests, go one
+				// level deeper to assign matching items to the closest dests.
+				allocs := allocateToKClosestAtDepth(matchingItemsBranch, otherDestsBranch, nMissingDests, depth+1)
+				mapMerge(m, allocs)
+			}
+		} else {
+			// Number of matching dests is larger than k, go one level deeper.
+			allocs := allocateToKClosestAtDepth(matchingItemsBranch, matchingDestsBranch, k, depth+1)
+			mapMerge(m, allocs)
+		}
+	}
+	return m
 }

--- a/provider/internal/helpers/trie_test.go
+++ b/provider/internal/helpers/trie_test.go
@@ -412,3 +412,142 @@ func TestPruneSubtrie(t *testing.T) {
 	require.Equal(t, 1, tr.Size())
 	require.True(t, tr.Branch(0).IsEmptyLeaf())
 }
+
+func TestAllocateToKClosestSingle(t *testing.T) {
+	destKeys := []bitstr.Key{
+		"0000",
+		"0001",
+		"0011",
+		"0100",
+		"0110",
+		"1010",
+		"1101",
+		"1110",
+	}
+	dests := trie.New[bitstr.Key, bitstr.Key]()
+	for _, k := range destKeys {
+		dests.Add(k, k)
+	}
+	itemKeys := []bitstr.Key{
+		"0000",
+	}
+	items := trie.New[bitstr.Key, bitstr.Key]()
+	for _, k := range itemKeys {
+		items.Add(k, k)
+	}
+	allocs := AllocateToKClosest(items, dests, 3)
+
+	// "0000" should be assigned to ["0000", "0001", "0011"]
+	expected := map[bitstr.Key][]bitstr.Key{
+		"0000": {"0000"},
+		"0001": {"0000"},
+		"0011": {"0000"},
+	}
+	require.Equal(t, expected, allocs)
+}
+
+func TestAllocateToKClosestBasic(t *testing.T) {
+	destKeys := []bitstr.Key{
+		"0000",
+		"0001",
+		"0011",
+		"0100",
+		"0110",
+		"1010",
+		"1101",
+		"1110",
+	}
+	dests := trie.New[bitstr.Key, bitstr.Key]()
+	for _, k := range destKeys {
+		dests.Add(k, k)
+	}
+	itemKeys := []bitstr.Key{
+		"0000",
+		"0011",
+		"0111",
+		"1001",
+		"1011",
+		"1100",
+		"1101",
+	}
+	items := trie.New[bitstr.Key, bitstr.Key]()
+	for _, k := range itemKeys {
+		items.Add(k, k)
+	}
+	allocs := AllocateToKClosest(items, dests, 3)
+
+	expected := map[bitstr.Key][]bitstr.Key{
+		"0000": {"0000", "0011"},
+		"0001": {"0000", "0011"},
+		"0011": {"0000", "0011", "0111"},
+		"0100": {"0111"},
+		"0110": {"0111"},
+		"1010": {"1001", "1011", "1100", "1101"},
+		"1101": {"1001", "1011", "1100", "1101"},
+		"1110": {"1001", "1011", "1100", "1101"},
+	}
+	require.Equal(t, expected, allocs)
+}
+
+func TestAllocateToKClosestSingleDest(t *testing.T) {
+	destKeys := []bitstr.Key{
+		"0000",
+	}
+	dests := trie.New[bitstr.Key, bitstr.Key]()
+	for _, k := range destKeys {
+		dests.Add(k, k)
+	}
+	itemKeys := []bitstr.Key{
+		"0000",
+		"0011",
+		"0111",
+		"1001",
+		"1011",
+		"1100",
+		"1101",
+	}
+	items := trie.New[bitstr.Key, bitstr.Key]()
+	for _, k := range itemKeys {
+		items.Add(k, k)
+	}
+	allocs := AllocateToKClosest(items, dests, 3)
+
+	require.Len(t, allocs, 1)
+	require.ElementsMatch(t, allocs[destKeys[0]], itemKeys)
+}
+
+func genRandBit256() bit256.Key {
+	var b [32]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		panic(err)
+	}
+	return bit256.NewKey(b[:])
+}
+
+func TestAllocateToKClosest(t *testing.T) {
+	nItems := 2 << 12
+	nDests := 2 << 10
+	replication := 12
+
+	items := trie.New[bit256.Key, bit256.Key]()
+	for range nItems {
+		i := genRandBit256()
+		items.Add(i, i)
+	}
+	dests := trie.New[bit256.Key, bit256.Key]()
+	for range nDests {
+		d := genRandBit256()
+		dests.Add(d, d)
+	}
+
+	allocs := AllocateToKClosest(items, dests, replication)
+
+	for _, itemEntry := range AllEntries(items, bit256.ZeroKey()) {
+		i := itemEntry.Key
+		closest := trie.Closest(dests, i, replication)
+		for _, closestEntry := range closest {
+			d := closestEntry.Key
+			require.Contains(t, allocs[d], i, "Item %s should be allocated to destination %s", key.BitString(i), key.BitString(d))
+		}
+	}
+}


### PR DESCRIPTION
Part of https://github.com/libp2p/go-libp2p-kad-dht/pull/1095

Depends on https://github.com/libp2p/go-libp2p-kad-dht/pull/1107

---

This helper is used to allocate keys to (re)provide to the closest peers we have discovered in the network.

We already have scanned a region (prefix) of the network keyspace and found all the peers starting with this prefix. We have organised these peers in a trie (`dests`).

We have a trie of all keys (`items`) belonging to this region of the keyspace, starting with prefix identifying the keyspace region.

The keys must be assigned to their `k` (20) closest peers, however the peers trie contains more than 20 peers. This algorithm assigns all `items` (keys) to their closest `k` `dests` (peers) in an efficient way.

The algorithm returns a map `peer -> []key`, in other words the CID allocations for each peer in this region.

### Checklist
- [ ] Merged https://github.com/libp2p/go-libp2p-kad-dht/pull/1107
- [ ] Change merge target to be [`provider`](https://github.com/libp2p/go-libp2p-kad-dht/tree/provider) after https://github.com/libp2p/go-libp2p-kad-dht/pull/1107 is merged