### PR TITLE
provider: trie region helpers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/ipfs/go-log/v2 v2.6.0
 	github.com/ipfs/go-test v0.2.2
 	github.com/libp2p/go-libp2p v0.41.1
-	github.com/libp2p/go-libp2p-kbucket v0.7.0
+	github.com/libp2p/go-libp2p-kbucket v0.7.1-0.20250718125122-f77e735b68e8
 	github.com/libp2p/go-libp2p-record v0.3.1
 	github.com/libp2p/go-libp2p-routing-helpers v0.7.5
 	github.com/libp2p/go-libp2p-testing v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -220,8 +220,8 @@ github.com/libp2p/go-libp2p-asn-util v0.4.1/go.mod h1:d/NI6XZ9qxw67b4e+NgpQexCIi
 github.com/libp2p/go-libp2p-core v0.2.4/go.mod h1:STh4fdfa5vDYr0/SzYYeqnt+E6KfEV5VxfIrm0bcI0g=
 github.com/libp2p/go-libp2p-core v0.3.0/go.mod h1:ACp3DmS3/N64c2jDzcV429ukDpicbL6+TrrxANBjPGw=
 github.com/libp2p/go-libp2p-kbucket v0.3.1/go.mod h1:oyjT5O7tS9CQurok++ERgc46YLwEpuGoFq9ubvoUOio=
-github.com/libp2p/go-libp2p-kbucket v0.7.0 h1:vYDvRjkyJPeWunQXqcW2Z6E93Ywx7fX0jgzb/dGOKCs=
-github.com/libp2p/go-libp2p-kbucket v0.7.0/go.mod h1:blOINGIj1yiPYlVEX0Rj9QwEkmVnz3EP8LK1dRKBC6g=
+github.com/libp2p/go-libp2p-kbucket v0.7.1-0.20250718125122-f77e735b68e8 h1:8FdUnEJQniowxU1XvXGxbLG+1fl8TnS01PwyCtTUzQ0=
+github.com/libp2p/go-libp2p-kbucket v0.7.1-0.20250718125122-f77e735b68e8/go.mod h1:3CofRbwJbTybT8WVM2z/h5dj2FPNar6YLyxUc4Tmv1E=
 github.com/libp2p/go-libp2p-peerstore v0.1.4/go.mod h1:+4BDbDiiKf4PzpANZDAT+knVdLxvqh7hXOujessqdzs=
 github.com/libp2p/go-libp2p-record v0.3.1 h1:cly48Xi5GjNw5Wq+7gmjfBiG9HCzQVkiZOUZ8kUl+Fg=
 github.com/libp2p/go-libp2p-record v0.3.1/go.mod h1:T8itUkLcWQLCYMqtX7Th6r7SexyUJpIyPgks757td/E=

--- a/provider/internal/helpers/trie_test.go
+++ b/provider/internal/helpers/trie_test.go
@@ -6,6 +6,10 @@ import (
 	"sort"
 	"testing"
 
+	kb "github.com/libp2p/go-libp2p-kbucket"
+	"github.com/libp2p/go-libp2p/core/peer"
+	mh "github.com/multiformats/go-multihash"
+
 	"github.com/probe-lab/go-libdht/kad/key"
 	"github.com/probe-lab/go-libdht/kad/key/bit256"
 	"github.com/probe-lab/go-libdht/kad/key/bitstr"
@@ -548,6 +552,96 @@ func TestAllocateToKClosest(t *testing.T) {
 		for _, closestEntry := range closest {
 			d := closestEntry.Key
 			require.Contains(t, allocs[d], i, "Item %s should be allocated to destination %s", key.BitString(i), key.BitString(d))
+		}
+	}
+}
+
+func TestExtractMinimalRegions(t *testing.T) {
+	replicationFactor := 3
+	selfID := [32]byte{}
+	order := bit256.NewKey(selfID[:])
+
+	genPeerWithPrefix := func(prefix bitstr.Key) peer.ID {
+		k := FirstFullKeyWithPrefix(prefix, order)
+		bs := KeyToBytes(k)
+		pid, err := kb.GenRandPeerIDWithCPL(bs, uint(len(prefix)))
+		require.NoError(t, err)
+		return pid
+	}
+
+	prefixes := []bitstr.Key{
+		"00000",
+		"00001",
+		"00101",
+		"00110",
+		"01000",
+		"01001",
+		"01011",
+		"01100",
+		"10100",
+		"11000",
+		"11001",
+		"11010",
+		"11110",
+		"11111",
+	}
+
+	// Binary trie of peers
+	//                                     ____________I___________
+	//                                    /                        \
+	//                 __________________/__                      __\_______
+	//                /                     \                    /          \
+	//         ______/_                     _\_                 /           _\_______
+	//        /        \                   /   \               /           /         \
+	//       /         _\_             ___/_    \             /       ____/_          \
+	//      /         /   \           /     \    \           /       /      \          \
+	//     / \       /     \        / \      \    \         /       / \      \        / \
+	// 00000 00001 00101 00110  01000 01001 01011 01100  10100  11000 11001 11010 11110 11111
+	//
+	// Groups are expected to be:
+	// * [00000, 00001, 00101, 00110]
+	// * [01000, 01001, 01011, 01100]
+	// * [10100, 11000, 11001, 11010, 11110, 11111]
+
+	pids := make([]peer.ID, len(prefixes))
+	peersTrie := trie.New[bit256.Key, peer.ID]()
+
+	// Test behavior when trie is empty
+	regions := ExtractMinimalRegions(peersTrie, bitstr.Key(""), replicationFactor, order)
+	require.Nil(t, regions)
+	for i := range pids {
+		pid := genPeerWithPrefix(prefixes[i])
+		pids[i] = pid
+		peersTrie.Add(PeerIDToBit256(pid), pid)
+	}
+
+	regions = ExtractMinimalRegions(peersTrie, bitstr.Key(""), replicationFactor, order)
+	require.Len(t, regions, 3)
+	require.Equal(t, bitstr.Key("00"), regions[0].Prefix)
+	require.Equal(t, bitstr.Key("01"), regions[1].Prefix)
+	require.Equal(t, bitstr.Key("1"), regions[2].Prefix)
+	require.Equal(t, 4, regions[0].Peers.Size())
+	require.Equal(t, 4, regions[1].Peers.Size())
+	require.Equal(t, 6, regions[2].Peers.Size())
+}
+
+func TestAssignKeysToRegions(t *testing.T) {
+	regions := []Region{
+		{Prefix: "0", Peers: nil, Keys: nil},
+		{Prefix: "1", Peers: nil, Keys: nil},
+	}
+
+	nKeys := 1 << 8
+	mhs := make([]mh.Multihash, nKeys)
+	for i, h := range genMultihashes(nKeys) {
+		mhs[i] = h
+	}
+
+	regions = AssignKeysToRegions(regions, mhs)
+	for _, r := range regions {
+		for _, h := range AllValues(r.Keys, bit256.ZeroKey()) {
+			k := MhToBit256(h)
+			require.True(t, IsPrefix(r.Prefix, k))
 		}
 	}
 }


### PR DESCRIPTION
Part of https://github.com/libp2p/go-libp2p-kad-dht/pull/1095

Depends on https://github.com/libp2p/go-libp2p-kad-dht/pull/1108

---

After we have found all peers whose kademlia identifier start with a given `prefix`, we want to break these peers in the smallest possible regions of `>20` peers. This is the optimal size for batch reproviding.

This algorithm breaks a trie of peers in the smallest possible tries, such that no trie has `<=20` peers.

A _visual_ example of the minimal region extraction is shown in the tests.

Another trivial method allocates keys to the matching region (identified by its `prefix`).

### Checklist
- [ ] Merged https://github.com/libp2p/go-libp2p-kad-dht/pull/1108
- [ ] Change merge target to be [`provider`](https://github.com/libp2p/go-libp2p-kad-dht/tree/provider) after https://github.com/libp2p/go-libp2p-kad-dht/pull/1108 is merged