### PR TITLE
provider: ProvideStatus interface

### DIFF
--- a/provider/provider.go
+++ b/provider/provider.go
@@ -96,6 +96,6 @@ const (
 // When `state == StateProvided`, `ts` is the wall‑clock time of the most recent
 // successful provide operation (UTC).
 // For `StateQueued` or `StateUnknown`, `ts` is the zero `time.Time`.
-func (s *SweepingProvider) ProvideStatus(key mh.Multihash) (state ProvideState, ts time.Time) {
+func (s *SweepingProvider) ProvideStatus(key mh.Multihash) (state ProvideState, stateTime time.Time) {
 	return StateUnknown, time.Time{}
 }

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -93,9 +93,9 @@ const (
 
 // ProvideStatus reports the provider’s view of a key.
 //
-// When `state == StateProvided`, `ts` is the wall‑clock time of the most recent
-// successful provide operation (UTC).
-// For `StateQueued` or `StateUnknown`, `ts` is the zero `time.Time`.
-func (s *SweepingProvider) ProvideStatus(key mh.Multihash) (state ProvideState, stateTime time.Time) {
+// When `state == StateProvided`, `lastProvide` is the wall‑clock time of the
+// most recent successful provide operation (UTC).
+// For `StateQueued` or `StateUnknown`, `lastProvide` is the zero `time.Time`.
+func (s *SweepingProvider) ProvideStatus(key mh.Multihash) (state ProvideState, lastProvide time.Time) {
 	return StateUnknown, time.Time{}
 }

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -1,1 +1,69 @@
 package provider
+
+import (
+	"context"
+
+	mh "github.com/multiformats/go-multihash"
+)
+
+// Provider is an interface that defines the methods for DHT provides and
+// reprovides.
+//
+// Note that this interface is subject to change.
+type Provider interface {
+	// ProvideOnce sends provider records for the specified keys to the DHT swarm
+	// only once. It does not automatically reprovide those keys afterward.
+	ProvideOnce(context.Context, ...mh.Multihash) error
+
+	// StartProviding provides the given keys to the DHT swarm unless they were
+	// already provided in the past. The keys will be periodically reprovided until
+	// StopProviding is called for the same keys or user defined garbage collection
+	// deletes the keys.
+	StartProviding(...mh.Multihash)
+
+	// ForceStartProviding is similar to StartProviding, but it sends provider
+	// records out to the DHT regardless of whether the keys were already provided
+	// in the past. It keeps reproviding the keys until StopProviding is called
+	// for these keys.
+	ForceStartProviding(context.Context, ...mh.Multihash) error
+
+	// StopProviding stops reproviding the given keys to the DHT swarm. The node
+	// stops being referred as a provider when the provider records in the DHT
+	// swarm expire.
+	StopProviding(...mh.Multihash)
+}
+
+var _ Provider = &SweepingProvider{}
+
+type SweepingProvider struct {
+	// TODO: implement me
+}
+
+// ProvideOnce only sends provider records for the given keys out to the DHT
+// swarm. It does NOT take the responsibility to reprovide these keys.
+func (s *SweepingProvider) ProvideOnce(ctx context.Context, keys ...mh.Multihash) error {
+	// TODO: implement me
+	return nil
+}
+
+// StartProviding provides the given keys to the DHT swarm unless they were
+// already provided in the past. The keys will be periodically reprovided until
+// StopProviding is called for the same keys or user defined garbage collection
+// deletes the keys.
+func (s *SweepingProvider) StartProviding(keys ...mh.Multihash) {
+	// TODO: implement me
+}
+
+// ForceStartProviding is similar to StartProviding, but it sends provider
+// records out to the DHT even if the keys were already provided in the past.
+func (s *SweepingProvider) ForceStartProviding(ctx context.Context, keys ...mh.Multihash) error {
+	// TODO: implement me
+	return nil
+}
+
+// StopProviding stops reproviding the given keys to the DHT swarm. The node
+// stops being referred as a provider when the provider records in the DHT
+// swarm expire.
+func (s *SweepingProvider) StopProviding(keys ...mh.Multihash) {
+	// TODO: implement me
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -97,5 +97,6 @@ const (
 // most recent successful provide operation (UTC).
 // For `StateQueued` or `StateUnknown`, `lastProvide` is the zero `time.Time`.
 func (s *SweepingProvider) ProvideStatus(key mh.Multihash) (state ProvideState, lastProvide time.Time) {
+	// TODO: implement me
 	return StateUnknown, time.Time{}
 }

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -1,6 +1,8 @@
 package provider
 
 import (
+	"time"
+
 	mh "github.com/multiformats/go-multihash"
 )
 
@@ -78,4 +80,13 @@ func (s *SweepingProvider) StartProviding(force bool, keys ...mh.Multihash) {
 // `StopProviding`.
 func (s *SweepingProvider) StopProviding(keys ...mh.Multihash) {
 	// TODO: implement me
+}
+
+// LastProvideAt returns the wall‑clock time at which `key` was most recently
+// advertised to the DHT by this node.
+//
+// If the key has never been provided, the second return value is **false** and
+// the first is the zero `time.Time`.
+func (s *SweepingProvider) LastProvideAt(key mh.Multihash) (time.Time, bool) {
+	return time.Time{}, false
 }

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -1,69 +1,81 @@
 package provider
 
 import (
-	"context"
-
 	mh "github.com/multiformats/go-multihash"
 )
 
-// Provider is an interface that defines the methods for DHT provides and
-// reprovides.
-//
-// Note that this interface is subject to change.
-type Provider interface {
-	// ProvideOnce sends provider records for the specified keys to the DHT swarm
-	// only once. It does not automatically reprovide those keys afterward.
-	ProvideOnce(context.Context, ...mh.Multihash) error
-
-	// StartProviding provides the given keys to the DHT swarm unless they were
-	// already provided in the past. The keys will be periodically reprovided until
-	// StopProviding is called for the same keys or user defined garbage collection
-	// deletes the keys.
-	StartProviding(...mh.Multihash)
-
-	// ForceStartProviding is similar to StartProviding, but it sends provider
-	// records out to the DHT regardless of whether the keys were already provided
-	// in the past. It keeps reproviding the keys until StopProviding is called
-	// for these keys.
-	ForceStartProviding(context.Context, ...mh.Multihash) error
+// DHTProvider is an interface for providing keys to a DHT swarm. It holds a
+// state of keys to be advertised, and is responsible for periodically
+// publishing provider records for these keys to the DHT swarm before the
+// records expire.
+type DHTProvider interface {
+	// StartProviding ensures keys are periodically advertised to the DHT swarm.
+	//
+	// If the `keys` aren't currently being reprovided, they are added to the
+	// queue to be provided to the DHT swarm as soon as possible, and scheduled
+	// to be reprovided periodically. If `force` is set to true, all keys are
+	// provided to the DHT swarm, regardless of whether they were already being
+	// reprovided in the past. `keys` keep being reprovided until `StopProviding`
+	// is called.
+	//
+	// This operation is asynchronous, it returns as soon as the `keys` are added
+	// to the provide queue, and provides happens asynchronously.
+	StartProviding(force bool, keys ...mh.Multihash)
 
 	// StopProviding stops reproviding the given keys to the DHT swarm. The node
 	// stops being referred as a provider when the provider records in the DHT
 	// swarm expire.
-	StopProviding(...mh.Multihash)
+	//
+	// Remove the `keys` from the schedule and return immediately. Valid records
+	// can remain in the DHT swarm up to the provider record TTL after calling
+	// `StopProviding`.
+	StopProviding(keys ...mh.Multihash)
+
+	// ProvideOnce sends provider records for the specified keys to the DHT swarm
+	// only once. It does not automatically reprovide those keys afterward.
+	//
+	// Add the supplied multihashes to the provide queue, and return immediately.
+	// The provide operation happens asynchronously.
+	ProvideOnce(keys ...mh.Multihash)
 }
 
-var _ Provider = &SweepingProvider{}
+var _ DHTProvider = &SweepingProvider{}
 
 type SweepingProvider struct {
 	// TODO: implement me
 }
 
-// ProvideOnce only sends provider records for the given keys out to the DHT
-// swarm. It does NOT take the responsibility to reprovide these keys.
-func (s *SweepingProvider) ProvideOnce(ctx context.Context, keys ...mh.Multihash) error {
-	// TODO: implement me
-	return nil
-}
-
-// StartProviding provides the given keys to the DHT swarm unless they were
-// already provided in the past. The keys will be periodically reprovided until
-// StopProviding is called for the same keys or user defined garbage collection
-// deletes the keys.
-func (s *SweepingProvider) StartProviding(keys ...mh.Multihash) {
+// ProvideOnce sends provider records for the specified keys to the DHT swarm
+// only once. It does not automatically reprovide those keys afterward.
+//
+// Add the supplied multihashes to the provide queue, and return immediately.
+// The provide operation happens asynchronously.
+func (s *SweepingProvider) ProvideOnce(keys ...mh.Multihash) {
 	// TODO: implement me
 }
 
-// ForceStartProviding is similar to StartProviding, but it sends provider
-// records out to the DHT even if the keys were already provided in the past.
-func (s *SweepingProvider) ForceStartProviding(ctx context.Context, keys ...mh.Multihash) error {
+// StartProviding ensures keys are periodically advertised to the DHT swarm.
+//
+// If the `keys` aren't currently being reprovided, they are added to the
+// queue to be provided to the DHT swarm as soon as possible, and scheduled
+// to be reprovided periodically. If `force` is set to true, all keys are
+// provided to the DHT swarm, regardless of whether they were already being
+// reprovided in the past. `keys` keep being reprovided until `StopProviding`
+// is called.
+//
+// This operation is asynchronous, it returns as soon as the `keys` are added
+// to the provide queue, and provides happens asynchronously.
+func (s *SweepingProvider) StartProviding(force bool, keys ...mh.Multihash) {
 	// TODO: implement me
-	return nil
 }
 
 // StopProviding stops reproviding the given keys to the DHT swarm. The node
 // stops being referred as a provider when the provider records in the DHT
 // swarm expire.
+//
+// Remove the `keys` from the schedule and return immediately. Valid records
+// can remain in the DHT swarm up to the provider record TTL after calling
+// `StopProviding`.
 func (s *SweepingProvider) StopProviding(keys ...mh.Multihash) {
 	// TODO: implement me
 }

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -82,11 +82,20 @@ func (s *SweepingProvider) StopProviding(keys ...mh.Multihash) {
 	// TODO: implement me
 }
 
-// LastProvideAt returns the wall‑clock time at which `key` was most recently
-// advertised to the DHT by this node.
+// ProvideState encodes the current relationship between this node and `key`.
+type ProvideState uint8
+
+const (
+	StateUnknown  ProvideState = iota // we have no record of the key
+	StateQueued                       // key is queued to be provided
+	StateProvided                     // key was provided at least once
+)
+
+// ProvideStatus reports the provider’s view of a key.
 //
-// If the key has never been provided, the second return value is **false** and
-// the first is the zero `time.Time`.
-func (s *SweepingProvider) LastProvideAt(key mh.Multihash) (time.Time, bool) {
-	return time.Time{}, false
+// When `state == StateProvided`, `ts` is the wall‑clock time of the most recent
+// successful provide operation (UTC).
+// For `StateQueued` or `StateUnknown`, `ts` is the zero `time.Time`.
+func (s *SweepingProvider) ProvideStatus(key mh.Multihash) (state ProvideState, ts time.Time) {
+	return StateUnknown, time.Time{}
 }


### PR DESCRIPTION
Part of https://github.com/libp2p/go-libp2p-kad-dht/pull/1095

Depends on https://github.com/libp2p/go-libp2p-kad-dht/pull/1098

---

Interface for polling the provide status of a specific key. Since this method isn't required for the provider to operate, this method isn't included in the `DHTProvider` interface https://github.com/libp2p/go-libp2p-kad-dht/pull/1093.

---

Merging this PR isn't urgent, since the method isn't implemented yet in https://github.com/libp2p/go-libp2p-kad-dht/pull/1082, and it isn't required for the providing to work.