### PR TITLE
provider: helpers pacakge rename

### DIFF
--- a/provider/internal/keyspace/key.go
+++ b/provider/internal/keyspace/key.go
@@ -1,4 +1,4 @@
-package helpers
+package keyspace
 
 import (
 	"crypto/sha256"

--- a/provider/internal/keyspace/key_test.go
+++ b/provider/internal/keyspace/key_test.go
@@ -1,4 +1,4 @@
-package helpers
+package keyspace
 
 import (
 	"crypto/rand"

--- a/provider/internal/keyspace/trie.go
+++ b/provider/internal/keyspace/trie.go
@@ -1,4 +1,4 @@
-package helpers
+package keyspace
 
 import (
 	"github.com/libp2p/go-libp2p/core/peer"

--- a/provider/internal/keyspace/trie_test.go
+++ b/provider/internal/keyspace/trie_test.go
@@ -1,4 +1,4 @@
-package helpers
+package keyspace
 
 import (
 	"crypto/rand"


### PR DESCRIPTION
Part of https://github.com/libp2p/go-libp2p-kad-dht/pull/1095

Depends on https://github.com/libp2p/go-libp2p-kad-dht/pull/1109

---

It is bad to name packages `helpers`. Renamed to `keyspace`.

This change happens in this last `keyspace` PR, since the directory and file renamed causes conflicts when merging with dependent PRs.

### Checklist
- [ ] Merged https://github.com/libp2p/go-libp2p-kad-dht/pull/1109
- [ ] Change merge target to be [`provider`](https://github.com/libp2p/go-libp2p-kad-dht/tree/provider) after https://github.com/libp2p/go-libp2p-kad-dht/pull/1109 is merged