### PR TITLE
provider: adding provide and reprovide queue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.23.8
 
 require (
 	github.com/filecoin-project/go-clock v0.1.0
+	github.com/gammazero/deque v1.0.0
 	github.com/google/gopacket v1.1.19
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/golang-lru v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -78,6 +78,8 @@ github.com/francoispqt/gojay v1.2.13/go.mod h1:ehT5mTG4ua4581f1++1WLG0vPdaA9HaiD
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/gammazero/deque v1.0.0 h1:LTmimT8H7bXkkCy6gZX7zNLtkbz4NdS2z8LZuor3j34=
+github.com/gammazero/deque v1.0.0/go.mod h1:iflpYvtGfM3U8S8j+sZEKIak3SAKYpA5/SQewgfXDKo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.1.1/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/go-check/check v0.0.0-20180628173108-788fd7840127/go.mod h1:9ES+weclKsC9YodN5RgxqK/VD9HM9JsCSh7rNhMZE98=

--- a/provider/internal/queue/prefix.go
+++ b/provider/internal/queue/prefix.go
@@ -1,0 +1,116 @@
+package queue
+
+import (
+	"slices"
+
+	"github.com/gammazero/deque"
+	"github.com/libp2p/go-libp2p-kad-dht/provider/internal/keyspace"
+	"github.com/probe-lab/go-libdht/kad/key/bit256"
+	"github.com/probe-lab/go-libdht/kad/key/bitstr"
+	"github.com/probe-lab/go-libdht/kad/trie"
+)
+
+// prefixQueue is a non-thread safe queue storing non overlapping, unique
+// prefixes of kademlia keys, in the order they were enqueued.
+type prefixQueue struct {
+	queue    deque.Deque[bitstr.Key]          // used to preserve the queue order
+	prefixes *trie.Trie[bitstr.Key, struct{}] // used to track prefixes in the queue
+}
+
+// Push adds a prefix to the queue.
+//
+// If prefix is already in the queue, this is a no-op.
+//
+// If the queue contains superstrings of the supplied prefix, insert the
+// supplied prefix at the position of the first superstring in the queue, and
+// remove all superstrings from the queue. The prefixes are consolidated around
+// the shortest prefix.
+func (q *prefixQueue) Push(prefix bitstr.Key) {
+	if subtrie, ok := keyspace.FindSubtrie(q.prefixes, prefix); ok {
+		// Prefix is a prefix of (at least) an existing prefix in the queue.
+		entriesToRemove := keyspace.AllEntries(subtrie, bit256.ZeroKey())
+		prefixesToRemove := make([]bitstr.Key, len(entriesToRemove))
+		for i, entry := range entriesToRemove {
+			prefixesToRemove[i] = entry.Key
+		}
+		// Remove superstrings of `prefix` from the queue
+		firstRemovedIndex := q.removePrefixesFromQueue(prefixesToRemove)
+		// Insert `prefix` in the queue at the location of the first removed
+		// prefix (last in order of deletion).
+		q.queue.Insert(firstRemovedIndex, prefix)
+		// Add `prefix` to prefixes trie.
+		q.prefixes.Add(prefix, struct{}{})
+	} else if _, ok := keyspace.FindPrefixOfKey(q.prefixes, prefix); !ok {
+		// No prefixes of `prefix` found in the queue.
+		q.queue.PushBack(prefix)
+		q.prefixes.Add(prefix, struct{}{})
+	}
+}
+
+// Pop removes and returns the first prefix from the queue.
+func (q *prefixQueue) Pop() (bitstr.Key, bool) {
+	if q.queue.Len() == 0 {
+		return bitstr.Key(""), false
+	}
+	// Dequeue the first prefix from the queue.
+	prefix := q.queue.PopFront()
+	// Remove the prefix from the prefixes trie.
+	q.prefixes.Remove(prefix)
+
+	return prefix, true
+}
+
+// Remove removes a prefix or all its superstrings from the queue, if any.
+func (q *prefixQueue) Remove(prefix bitstr.Key) bool {
+	subtrie, ok := keyspace.FindSubtrie(q.prefixes, prefix)
+	if !ok {
+		return false
+	}
+	entriesToRemove := keyspace.AllEntries(subtrie, bit256.ZeroKey())
+	prefixesToRemove := make([]bitstr.Key, len(entriesToRemove))
+	for i, entry := range entriesToRemove {
+		prefixesToRemove[i] = entry.Key
+	}
+	q.removePrefixesFromQueue(prefixesToRemove)
+	return true
+}
+
+// Returns the number of prefixes in the queue.
+func (q *prefixQueue) Size() int {
+	return q.queue.Len()
+}
+
+// Clear removes all keys from the queue and returns the number of keys that
+// were removed.
+func (q *prefixQueue) Clear() int {
+	size := q.Size()
+
+	q.queue.Clear()
+	*q.prefixes = trie.Trie[bitstr.Key, struct{}]{}
+
+	return size
+}
+
+// removeSubtrieFromQueue removes all keys in the provided subtrie from q.queue
+// and q.prefixes. Returns the position of the first removed key in the queue.
+func (q *prefixQueue) removePrefixesFromQueue(prefixes []bitstr.Key) int {
+	indexes := make([]int, 0, len(prefixes))
+	for _, prefix := range prefixes {
+		// Remove elements from the queue that are superstrings of `prefix`.
+		q.prefixes.Remove(prefix)
+		// Find indexes of the superstrings in the queue.
+		index := q.queue.Index(func(element bitstr.Key) bool { return element == prefix })
+		if index >= 0 {
+			indexes = append(indexes, index)
+		}
+	}
+	// Sort indexes to remove in descending order so that we can remove them
+	// without affecting the indexes of the remaining elements.
+	slices.Sort(indexes)
+	slices.Reverse(indexes)
+	// Remove items in the queue that are prefixes of `prefix`
+	for _, index := range indexes {
+		q.queue.Remove(index)
+	}
+	return indexes[len(indexes)-1] // return the position of the first removed key
+}

--- a/provider/internal/queue/provide.go
+++ b/provider/internal/queue/provide.go
@@ -1,0 +1,191 @@
+package queue
+
+import (
+	"sync"
+
+	mh "github.com/multiformats/go-multihash"
+
+	"github.com/probe-lab/go-libdht/kad/key/bit256"
+	"github.com/probe-lab/go-libdht/kad/key/bitstr"
+	"github.com/probe-lab/go-libdht/kad/trie"
+
+	"github.com/libp2p/go-libp2p-kad-dht/provider/internal/keyspace"
+)
+
+// ProvideQueue is a thread-safe queue storing multihashes about to be provided
+// to a Kademlia DHT, allowing smart batching.
+//
+// The queue groups keys by their kademlia identifier prefixes, so that keys
+// that should be allocated to the same DHT peers are dequeued together from
+// the queue, for efficient batch providing.
+//
+// The insertion order of prefixes is preserved, but not for keys. Inserting
+// keys matching a prefix that is already in the queue inserts the keys at the
+// position of the existing prefix.
+//
+// ProvideQueue allows dequeuing the first prefix of the queue, with all
+// matching keys or dequeuing all keys matching a requested prefix.
+type ProvideQueue struct {
+	mu sync.Mutex
+
+	queue prefixQueue
+	keys  *trie.Trie[bit256.Key, mh.Multihash] // used to store keys in the queue
+}
+
+// NewProvideQueue creates a new ProvideQueue instance.
+func NewProvideQueue() *ProvideQueue {
+	return &ProvideQueue{
+		queue: prefixQueue{prefixes: trie.New[bitstr.Key, struct{}]()},
+		keys:  trie.New[bit256.Key, mh.Multihash](),
+	}
+}
+
+// Enqueue adds the supplied keys to the queue under the given prefix.
+//
+// If the prefix already sits in the queue, supplied keys join the queue at the
+// position of the existing prefix. If the queue contains prefixes that are
+// superstrings of the supplied prefix, all keys matching the supplied prefix
+// are consolidated at the position of the first matching superstring in the
+// queue.
+//
+// If supplied prefix doesn't exist yet in the queue, add it at the end.
+//
+// Supplied keys MUST match the supplied prefix.
+func (q *ProvideQueue) Enqueue(prefix bitstr.Key, keys ...mh.Multihash) {
+	if len(keys) == 0 {
+		return
+	}
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	// Enqueue the prefix in the queue if required.
+	q.queue.Push(prefix)
+
+	// Add keys to the keys trie.
+	for _, h := range keys {
+		q.keys.Add(keyspace.MhToBit256(h), h)
+	}
+}
+
+// Dequeue pops the first prefix of the queue along with all matching keys.
+//
+// The prefix and keys are removed from the queue. If the queue is empty,
+// return false and the empty prefix.
+func (q *ProvideQueue) Dequeue() (bitstr.Key, []mh.Multihash, bool) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	prefix, ok := q.queue.Pop()
+	if !ok {
+		return prefix, nil, false
+	}
+
+	// Get all keys that match the prefix.
+	subtrie, _ := keyspace.FindSubtrie(q.keys, prefix)
+	keys := keyspace.AllValues(subtrie, bit256.ZeroKey())
+
+	// Remove the keys from the keys trie.
+	keyspace.PruneSubtrie(q.keys, prefix)
+
+	return prefix, keys, true
+}
+
+// DequeueMatching returns keys matching the given prefix from the queue.
+//
+// The keys and prefix are removed from the queue. If the queue is empty, or
+// supplied prefix doesn't match any keys, an empty slice is returned.
+func (q *ProvideQueue) DequeueMatching(prefix bitstr.Key) []mh.Multihash {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	subtrie, ok := keyspace.FindSubtrie(q.keys, prefix)
+	if !ok {
+		// No keys matching the prefix.
+		return nil
+	}
+	keys := keyspace.AllValues(subtrie, bit256.ZeroKey())
+
+	// Remove the keys from the keys trie.
+	keyspace.PruneSubtrie(q.keys, prefix)
+
+	// Remove prefix and its superstrings from queue if any.
+	removed := q.queue.Remove(prefix)
+	if !removed {
+		// prefix and superstrings not in queue.
+		if shorterPrefix, ok := keyspace.FindPrefixOfKey(q.queue.prefixes, prefix); ok {
+			// prefix is a superstring of some other shorter prefix in the queue.
+			// Leave it in the queue, unless the shorter prefix doesn't have any
+			// matching keys left.
+			if _, ok := keyspace.FindSubtrie(q.keys, shorterPrefix); !ok {
+				// No keys matching shorterPrefix, remove shorterPrefix from queue.
+				q.queue.Remove(shorterPrefix)
+			}
+		}
+	}
+	return keys
+}
+
+// Remove removes the supplied keys from the queue.
+//
+// If this operation removes the last keys for prefixes in the queue, remove
+// the prefixes from the queue.
+func (q *ProvideQueue) Remove(keys ...mh.Multihash) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	matchingPrefixes := make(map[bitstr.Key]struct{})
+
+	// Remove keys from the keys trie.
+	for _, h := range keys {
+		k := keyspace.MhToBit256(h)
+		q.keys.Remove(k)
+		if prefix, ok := keyspace.FindPrefixOfKey(q.queue.prefixes, k); ok {
+			// Get the trie leaf matching the key, if any.
+			matchingPrefixes[prefix] = struct{}{}
+		}
+	}
+
+	// For matching prefixes, if no more keys are matching, remove them from
+	// queue.
+	prefixesToRemove := make([]bitstr.Key, 0)
+	for prefix := range matchingPrefixes {
+		if _, ok := keyspace.FindSubtrie(q.keys, prefix); !ok {
+			prefixesToRemove = append(prefixesToRemove, prefix)
+		}
+	}
+	if len(prefixesToRemove) > 0 {
+		q.queue.removePrefixesFromQueue(prefixesToRemove)
+	}
+}
+
+// IsEmpty returns true if the queue is empty.
+func (q *ProvideQueue) IsEmpty() bool {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return q.queue.Size() == 0
+}
+
+// Size returns the number of regions containing at least one key in the queue.
+func (q *ProvideQueue) Size() int {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return q.sizeNoLock()
+}
+
+// sizeNoLock returns the number of regions containing at least one key in the
+// queue. It assumes the mutex is held already.
+func (q *ProvideQueue) sizeNoLock() int {
+	return q.keys.Size()
+}
+
+// Clear removes all keys from the queue and returns the number of keys that
+// were removed.
+func (q *ProvideQueue) Clear() int {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	size := q.sizeNoLock()
+
+	q.queue.Clear()
+	*q.keys = trie.Trie[bit256.Key, mh.Multihash]{}
+
+	return size
+}

--- a/provider/internal/queue/provide.go
+++ b/provider/internal/queue/provide.go
@@ -168,12 +168,6 @@ func (q *ProvideQueue) IsEmpty() bool {
 func (q *ProvideQueue) Size() int {
 	q.mu.Lock()
 	defer q.mu.Unlock()
-	return q.sizeNoLock()
-}
-
-// sizeNoLock returns the number of regions containing at least one key in the
-// queue. It assumes the mutex is held already.
-func (q *ProvideQueue) sizeNoLock() int {
 	return q.keys.Size()
 }
 
@@ -182,7 +176,7 @@ func (q *ProvideQueue) sizeNoLock() int {
 func (q *ProvideQueue) Clear() int {
 	q.mu.Lock()
 	defer q.mu.Unlock()
-	size := q.sizeNoLock()
+	size := q.keys.Size()
 
 	q.queue.Clear()
 	*q.keys = trie.Trie[bit256.Key, mh.Multihash]{}

--- a/provider/internal/queue/provide_test.go
+++ b/provider/internal/queue/provide_test.go
@@ -1,0 +1,287 @@
+package queue
+
+import (
+	"crypto/rand"
+	"testing"
+
+	mh "github.com/multiformats/go-multihash"
+
+	"github.com/probe-lab/go-libdht/kad/key/bitstr"
+	"github.com/probe-lab/go-libdht/kad/trie"
+	"github.com/stretchr/testify/require"
+
+	"github.com/libp2p/go-libp2p-kad-dht/provider/internal/keyspace"
+)
+
+func genMultihashesMatchingPrefix(prefix bitstr.Key, n int) []mh.Multihash {
+	mhs := make([]mh.Multihash, 0, n)
+	for i := 0; len(mhs) < n; i++ {
+		digest := make([]byte, 32)
+		if _, err := rand.Read(digest); err != nil {
+			panic(err)
+		}
+		h, err := mh.Encode(digest, mh.SHA2_256)
+		if err != nil {
+			panic(err)
+		}
+		k := keyspace.MhToBit256(h)
+		if keyspace.IsPrefix(prefix, k) {
+			mhs = append(mhs, h)
+		}
+	}
+	return mhs
+}
+
+func TestProvideEnqueueSimple(t *testing.T) {
+	nMultihashesPerPrefix := 1 << 4
+
+	q := NewProvideQueue()
+
+	// Enqueue no multihash
+	q.Enqueue(bitstr.Key("1010"))
+	require.Equal(t, q.Size(), 0)
+
+	prefixes := []bitstr.Key{
+		"000",
+		"001",
+		"010",
+		"011",
+		"10",
+	}
+	for _, prefix := range prefixes {
+		mhs := genMultihashesMatchingPrefix(prefix, nMultihashesPerPrefix)
+		q.Enqueue(prefix, mhs...)
+	}
+
+	// Verify prefixes are in the queue
+	require.Equal(t, len(prefixes), q.queue.prefixes.Size())
+	require.Equal(t, len(prefixes), q.queue.queue.Len())
+	for _, prefix := range prefixes {
+		require.GreaterOrEqual(t, q.queue.queue.Index(func(k bitstr.Key) bool { return k == prefix }), 0)
+		ok, _ := trie.Find(q.queue.prefixes, prefix)
+		require.True(t, ok)
+	}
+	// Verify the count of multihashes matches
+	require.Equal(t, len(prefixes)*nMultihashesPerPrefix, q.Size())
+}
+
+func TestProvideEnqueueOverlapping(t *testing.T) {
+	nMultihashesPerPrefix := 1 << 4
+
+	q := NewProvideQueue()
+
+	prefixes := []bitstr.Key{
+		"000",
+		"0000",
+	}
+	for _, prefix := range prefixes {
+		mhs := genMultihashesMatchingPrefix(prefix, nMultihashesPerPrefix)
+		q.Enqueue(prefix, mhs...)
+	}
+
+	require.Equal(t, 1, q.queue.prefixes.Size()) // Only shortest prefix should remain
+	require.Equal(t, 1, q.queue.queue.Len())
+	require.GreaterOrEqual(t, q.queue.queue.Index(func(k bitstr.Key) bool { return k == prefixes[0] }), 0) // "000" is in queue
+	require.Negative(t, q.queue.queue.Index(func(k bitstr.Key) bool { return k == prefixes[1] }))          // "0000" is NOT in queue
+
+	// Verify the count of multihashes matches
+	require.Equal(t, len(prefixes)*nMultihashesPerPrefix, q.Size())
+
+	prefixes = []bitstr.Key{
+		"1111",
+		"111",
+	}
+	for _, prefix := range prefixes {
+		mhs := genMultihashesMatchingPrefix(prefix, nMultihashesPerPrefix)
+		q.Enqueue(prefix, mhs...)
+	}
+
+	require.Equal(t, 2, q.queue.prefixes.Size()) // only "000" and "111" should remain
+	require.Equal(t, 2, q.queue.queue.Len())
+	require.GreaterOrEqual(t, q.queue.queue.Index(func(k bitstr.Key) bool { return k == prefixes[1] }), 0) // "111" is in queue
+	require.Negative(t, q.queue.queue.Index(func(k bitstr.Key) bool { return k == prefixes[0] }))          // "1111" is NOT in queue
+
+	// Verify the count of multihashes matches
+	require.Equal(t, 2*len(prefixes)*nMultihashesPerPrefix, q.Size())
+}
+
+func TestProvideDequeue(t *testing.T) {
+	nMultihashesPerPrefix := 1 << 4
+	q := NewProvideQueue()
+	prefixes := []bitstr.Key{
+		"100",
+		"001",
+		"010",
+		"11",
+		"000",
+	}
+	mhMap := make(map[bitstr.Key][]mh.Multihash)
+	for _, prefix := range prefixes {
+		mhs := genMultihashesMatchingPrefix(prefix, nMultihashesPerPrefix)
+		q.Enqueue(prefix, mhs...)
+		mhMap[prefix] = mhs
+	}
+	require.Equal(t, q.queue.prefixes.Size(), len(prefixes))
+	require.Equal(t, q.queue.queue.Len(), len(prefixes))
+	require.Equal(t, q.Size(), len(prefixes)*nMultihashesPerPrefix)
+
+	for i := 0; !q.IsEmpty(); i++ {
+		prefix, mhs, ok := q.Dequeue()
+		require.True(t, ok)
+		require.Equal(t, prefixes[i], prefix)
+		require.ElementsMatch(t, mhMap[prefix], mhs)
+		require.Negative(t, q.queue.queue.Index(func(k bitstr.Key) bool { return k == prefix })) // prefix not in queue anymore
+		require.False(t, q.queue.prefixes.Remove(prefix))
+		require.Equal(t, q.Size(), (len(prefixes)-i-1)*nMultihashesPerPrefix)
+	}
+
+	prefix, mhs, ok := q.Dequeue()
+	require.False(t, ok) // Queue is empty
+	require.Equal(t, bitstr.Key(""), prefix)
+	require.Empty(t, mhs)
+}
+
+func TestProvideDequeueMatching(t *testing.T) {
+	nMultihashesPerPrefix := 1 << 4
+	q := NewProvideQueue()
+	prefixes := []bitstr.Key{
+		"0010",
+		"100",
+		"010",
+		"0011",
+		"11",
+		"000",
+	}
+	mhMap := make(map[bitstr.Key][]mh.Multihash)
+	for _, prefix := range prefixes {
+		mhs := genMultihashesMatchingPrefix(prefix, nMultihashesPerPrefix)
+		q.Enqueue(prefix, mhs...)
+		mhMap[prefix] = mhs
+	}
+	require.Equal(t, q.queue.prefixes.Size(), len(prefixes))
+	require.Equal(t, q.queue.queue.Len(), len(prefixes))
+	require.Equal(t, q.Size(), len(prefixes)*nMultihashesPerPrefix)
+
+	// Prefix not in queue.
+	mhs := q.DequeueMatching(bitstr.Key("101"))
+	require.Empty(t, mhs)
+
+	mhs = q.DequeueMatching(bitstr.Key("010"))
+	require.ElementsMatch(t, mhMap[bitstr.Key("010")], mhs)
+	require.Equal(t, 5, q.queue.queue.Len())
+	require.Equal(t, 5, q.queue.prefixes.Size())
+	// Verify queue order didn't change
+	require.Equal(t, 0, q.queue.queue.Index(func(k bitstr.Key) bool { return k == bitstr.Key("0010") }))
+	require.Equal(t, 1, q.queue.queue.Index(func(k bitstr.Key) bool { return k == bitstr.Key("100") }))
+	require.Equal(t, 2, q.queue.queue.Index(func(k bitstr.Key) bool { return k == bitstr.Key("0011") }))
+	require.Equal(t, 3, q.queue.queue.Index(func(k bitstr.Key) bool { return k == bitstr.Key("11") }))
+	require.Equal(t, 4, q.queue.queue.Index(func(k bitstr.Key) bool { return k == bitstr.Key("000") }))
+
+	mhs = q.DequeueMatching(bitstr.Key("001"))
+	require.ElementsMatch(t, append(mhMap[bitstr.Key("0010")], mhMap[bitstr.Key("0011")]...), mhs)
+	require.Equal(t, 3, q.queue.queue.Len())
+	require.Equal(t, 3, q.queue.prefixes.Size())
+	// Verify queue order didn't change
+	require.Equal(t, 0, q.queue.queue.Index(func(k bitstr.Key) bool { return k == bitstr.Key("100") }))
+	require.Equal(t, 1, q.queue.queue.Index(func(k bitstr.Key) bool { return k == bitstr.Key("11") }))
+	require.Equal(t, 2, q.queue.queue.Index(func(k bitstr.Key) bool { return k == bitstr.Key("000") }))
+
+	// Prefix not in queue.
+	mhs = q.DequeueMatching(bitstr.Key("011"))
+	require.Empty(t, mhs)
+
+	// Partial prefix
+	mhs0 := q.DequeueMatching(bitstr.Key("110"))
+	if len(mhs0) > 0 {
+		require.Equal(t, 3, q.queue.queue.Len())
+		require.Equal(t, 3, q.queue.prefixes.Size())
+		require.Equal(t, 0, q.queue.queue.Index(func(k bitstr.Key) bool { return k == bitstr.Key("100") }))
+		require.Equal(t, 1, q.queue.queue.Index(func(k bitstr.Key) bool { return k == bitstr.Key("11") }))
+		require.Equal(t, 2, q.queue.queue.Index(func(k bitstr.Key) bool { return k == bitstr.Key("000") }))
+	}
+	mhs1 := q.DequeueMatching(bitstr.Key("111"))
+	require.Equal(t, 2, q.queue.queue.Len())
+	require.Equal(t, 2, q.queue.prefixes.Size())
+	require.Equal(t, 0, q.queue.queue.Index(func(k bitstr.Key) bool { return k == bitstr.Key("100") }))
+	require.Equal(t, 1, q.queue.queue.Index(func(k bitstr.Key) bool { return k == bitstr.Key("000") }))
+	require.ElementsMatch(t, append(mhs0, mhs1...), mhMap[bitstr.Key("11")])
+
+	prefix, mhs, ok := q.Dequeue()
+	require.True(t, ok)
+	require.Equal(t, bitstr.Key("100"), prefix)
+	require.ElementsMatch(t, mhMap[bitstr.Key("100")], mhs)
+
+	mhs = q.DequeueMatching(bitstr.Key("000"))
+	require.ElementsMatch(t, mhMap[bitstr.Key("000")], mhs)
+
+	require.Equal(t, 0, q.queue.queue.Len())
+	require.True(t, q.IsEmpty())
+
+	mhs = q.DequeueMatching(bitstr.Key("000"))
+	require.Empty(t, mhs)
+}
+
+func TestProvideRemove(t *testing.T) {
+	nMultihashesPerPrefix := 1 << 2
+	q := NewProvideQueue()
+	prefixes := []bitstr.Key{
+		"0010",
+		"100",
+		"010",
+	}
+	mhMap := make(map[bitstr.Key][]mh.Multihash)
+	for _, prefix := range prefixes {
+		mhs := genMultihashesMatchingPrefix(prefix, nMultihashesPerPrefix)
+		q.Enqueue(prefix, mhs...)
+		mhMap[prefix] = mhs
+	}
+	require.Equal(t, len(prefixes), q.queue.prefixes.Size())
+	require.Equal(t, len(prefixes), q.queue.queue.Len())
+	require.Equal(t, len(prefixes)*nMultihashesPerPrefix, q.Size())
+
+	q.Remove(mhMap[bitstr.Key("0010")][:2]...)
+	require.Equal(t, len(prefixes)*nMultihashesPerPrefix-2, q.Size())
+	require.Equal(t, q.queue.queue.At(0), bitstr.Key("0010"))
+
+	q.Remove(mhMap[bitstr.Key("100")]...)
+	require.Equal(t, len(prefixes)*nMultihashesPerPrefix-6, q.Size())
+	require.Equal(t, q.queue.queue.At(1), bitstr.Key("010"))
+
+	q.Remove(mhMap[bitstr.Key("0010")][2])
+	require.Equal(t, len(prefixes)*nMultihashesPerPrefix-7, q.Size())
+	require.Equal(t, q.queue.queue.At(0), bitstr.Key("0010"))
+
+	q.Remove(append([]mh.Multihash{mhMap[bitstr.Key("0010")][3]}, mhMap[bitstr.Key("010")][1:3]...)...)
+	require.Equal(t, 2, q.Size())
+	require.Equal(t, q.queue.queue.At(0), bitstr.Key("010"))
+}
+
+func TestProvideClearQueue(t *testing.T) {
+	nMultihashesPerPrefix := 1 << 4
+	q := NewProvideQueue()
+	require.True(t, q.IsEmpty())
+	prefixes := []bitstr.Key{
+		"000",
+		"001",
+		"010",
+		"011",
+		"10",
+	}
+	for _, prefix := range prefixes {
+		mhs := genMultihashesMatchingPrefix(prefix, nMultihashesPerPrefix)
+		q.Enqueue(prefix, mhs...)
+	}
+
+	require.False(t, q.IsEmpty())
+	require.Equal(t, q.queue.prefixes.Size(), len(prefixes))
+	require.Equal(t, q.queue.queue.Len(), len(prefixes))
+	require.Equal(t, q.Size(), len(prefixes)*nMultihashesPerPrefix)
+
+	cleared := q.Clear()
+	require.Equal(t, len(prefixes)*nMultihashesPerPrefix, cleared)
+	require.True(t, q.IsEmpty())
+
+	require.True(t, q.keys.IsEmptyLeaf())
+	require.True(t, q.queue.prefixes.IsEmptyLeaf())
+	require.Equal(t, 0, q.queue.queue.Len())
+}

--- a/provider/internal/queue/provide_test.go
+++ b/provider/internal/queue/provide_test.go
@@ -1,9 +1,9 @@
 package queue
 
 import (
-	"crypto/rand"
 	"testing"
 
+	"github.com/ipfs/go-test/random"
 	mh "github.com/multiformats/go-multihash"
 
 	"github.com/probe-lab/go-libdht/kad/key/bitstr"
@@ -16,14 +16,7 @@ import (
 func genMultihashesMatchingPrefix(prefix bitstr.Key, n int) []mh.Multihash {
 	mhs := make([]mh.Multihash, 0, n)
 	for i := 0; len(mhs) < n; i++ {
-		digest := make([]byte, 32)
-		if _, err := rand.Read(digest); err != nil {
-			panic(err)
-		}
-		h, err := mh.Encode(digest, mh.SHA2_256)
-		if err != nil {
-			panic(err)
-		}
+		h := random.Multihashes(1)[0]
 		k := keyspace.MhToBit256(h)
 		if keyspace.IsPrefix(prefix, k) {
 			mhs = append(mhs, h)

--- a/provider/internal/queue/reprovide.go
+++ b/provider/internal/queue/reprovide.go
@@ -1,0 +1,70 @@
+package queue
+
+import (
+	"sync"
+
+	"github.com/probe-lab/go-libdht/kad/key/bitstr"
+	"github.com/probe-lab/go-libdht/kad/trie"
+)
+
+// ReprovideQueue is a thread-safe queue storing non-overlapping, unique
+// kademlia keyspace prefixes in the order they were enqueued.
+type ReprovideQueue struct {
+	mu    sync.Mutex
+	queue prefixQueue
+}
+
+// New creates a new ReprovideQueue instance.
+func NewReprovideQueue() *ReprovideQueue {
+	return &ReprovideQueue{queue: prefixQueue{prefixes: trie.New[bitstr.Key, struct{}]()}}
+}
+
+// Enqueue adds the supplied prefix to the queue.
+//
+// If the prefix is already in the queue, this is a no-op.
+//
+// If the queue contains superstrings of the supplied prefix, insert the
+// supplied prefix at the position of the first superstring in the queue, and
+// remove all superstrings from the queue. The prefixes are consolidated around
+// the shortest prefix.
+func (q *ReprovideQueue) Enqueue(prefix bitstr.Key) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.queue.Push(prefix)
+}
+
+// Dequeue removes and returns the first prefix from the queue.
+func (q *ReprovideQueue) Dequeue() (bitstr.Key, bool) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return q.queue.Pop()
+}
+
+// Remove removes a prefix or all its superstrings from the queue, if any.
+func (q *ReprovideQueue) Remove(prefix bitstr.Key) bool {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return q.queue.Remove(prefix)
+}
+
+// IsEmpty returns true if the queue is empty.
+func (q *ReprovideQueue) IsEmpty() bool {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return q.queue.Size() == 0
+}
+
+// Size returns the number of prefixes currently in the queue.
+func (q *ReprovideQueue) Size() int {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return q.queue.Size()
+}
+
+// Clear removes all prefixes from the queue and returns the number of removed
+// prefixes.
+func (q *ReprovideQueue) Clear() int {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return q.queue.Clear()
+}

--- a/provider/internal/queue/reprovide_test.go
+++ b/provider/internal/queue/reprovide_test.go
@@ -1,0 +1,112 @@
+package queue
+
+import (
+	"testing"
+
+	"github.com/probe-lab/go-libdht/kad/key/bitstr"
+	"github.com/probe-lab/go-libdht/kad/trie"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReprovideEnqueue(t *testing.T) {
+	q := NewReprovideQueue()
+
+	q.Enqueue("000")
+	require.Equal(t, 1, q.Size())
+	q.Enqueue("101")
+	require.Equal(t, 2, q.Size())
+	q.Enqueue("000")
+	require.Equal(t, 2, q.Size()) // Duplicate prefix, size should not change
+	q.Enqueue("001")
+	require.Equal(t, 3, q.Size())
+	q.Enqueue("1000")
+	require.Equal(t, 4, q.Size())
+	q.Enqueue("1001")
+	require.Equal(t, 5, q.Size())
+
+	q.Enqueue("10")
+	require.Equal(t, 3, q.Size()) // "10" consolidates "1000", "1001" and "101"
+	require.Equal(t, bitstr.Key("000"), q.queue.queue.At(0))
+	require.Equal(t, bitstr.Key("10"), q.queue.queue.At(1)) // "10" has taken the place of "101"
+	require.Equal(t, bitstr.Key("001"), q.queue.queue.At(2))
+}
+
+func TestReprovideDequeue(t *testing.T) {
+	keys := []bitstr.Key{
+		"10",
+		"001",
+		"00001",
+		"00000",
+		"111",
+		"1101",
+	}
+
+	q := NewReprovideQueue()
+	for _, k := range keys {
+		q.Enqueue(k)
+	}
+	require.False(t, q.IsEmpty())
+
+	for i, k := range keys {
+		dequeued, ok := q.Dequeue()
+		require.True(t, ok)
+		require.Equal(t, k, dequeued)
+		require.Equal(t, len(keys)-i-1, q.Size())
+	}
+
+	require.True(t, q.IsEmpty())
+	_, ok := q.Dequeue()
+	require.False(t, ok)
+
+	require.True(t, q.IsEmpty())
+}
+
+func TestReprovideRemove(t *testing.T) {
+	keys := []bitstr.Key{
+		"10",
+		"001",
+		"00001",
+		"00000",
+		"111",
+		"1101",
+	}
+	q := NewReprovideQueue()
+	for _, k := range keys {
+		q.Enqueue(k)
+	}
+
+	ok := q.Remove("001")
+	require.True(t, ok)
+	require.Negative(t, q.queue.queue.Index(func(k bitstr.Key) bool { return k == bitstr.Key("001") })) // not in queue
+	ok, _ = trie.Find(q.queue.prefixes, bitstr.Key("001"))                                              // not in trie
+	require.False(t, ok)
+
+	ok = q.Remove("1111") // not in queue
+	require.False(t, ok)
+
+	require.Equal(t, len(keys)-1, q.Size())
+	// Test order
+	require.Equal(t, keys[0], q.queue.queue.At(0))
+	require.Equal(t, keys[2], q.queue.queue.At(1))
+}
+
+func TestReprovideClearQueue(t *testing.T) {
+	keys := []bitstr.Key{
+		"10",
+		"001",
+		"00001",
+		"00000",
+		"111",
+		"1101",
+	}
+	q := NewReprovideQueue()
+	for _, k := range keys {
+		q.Enqueue(k)
+	}
+
+	cleared := q.Clear()
+	require.Equal(t, len(keys), cleared)
+	require.True(t, q.IsEmpty())
+	require.Equal(t, 0, q.queue.prefixes.Size())
+	require.Equal(t, 0, q.queue.queue.Len())
+}


### PR DESCRIPTION
Part of https://github.com/libp2p/go-libp2p-kad-dht/pull/1095

---

This PR adds 2 queues implementations:

### Reprovide queue

This queue keeps track of the prefixes associated with the keyspace regions that should be reprovided as soon as possible. These regions end up in the queue if the provider failed to reprovide them on time.

### Provide queue

This queue keeps track of all the keys that should be provided as soon as possible. The keys are grouped by common prefix to optimize batch providing.

Both queues make use of the `prefixQueue`.