### PR TITLE
fix: move non-error log to warning level

### DIFF
--- a/fullrt/dht.go
+++ b/fullrt/dht.go
@@ -503,7 +503,7 @@ func (dht *FullRT) GetClosestPeers(ctx context.Context, key string) ([]peer.ID, 
 			// Recover the peer ID from the key
 			p, ok := dht.keyToPeerMap[string(k)]
 			if !ok {
-				logger.Errorf("key not found in map")
+				logger.Warnf("key not found in map")
 				continue
 			}
 


### PR DESCRIPTION
Closes #1001 by adjusting log level -- this is no longer hard error, we `continue` so warning level feels better

