### PR TITLE
provider: daemon

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/gammazero/deque v1.0.0
 	github.com/google/gopacket v1.1.19
 	github.com/google/uuid v1.6.0
-	github.com/guillaumemichel/reservedpool v0.1.0
+	github.com/guillaumemichel/reservedpool v0.2.0
 	github.com/hashicorp/golang-lru v1.0.2
 	github.com/ipfs/boxo v0.31.0
 	github.com/ipfs/go-cid v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -136,8 +136,8 @@ github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aN
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/grpc-gateway v1.5.0/go.mod h1:RSKVYQBd5MCa4OVpNdGskqpgL2+G+NZTnrVHpWWfpdw=
-github.com/guillaumemichel/reservedpool v0.1.0 h1:QOG3bsExi+Erk2TBzGan87uqA48Ns27uhhnwgCJup+Y=
-github.com/guillaumemichel/reservedpool v0.1.0/go.mod h1:sXSDIaef81TFdAJglsCFCMfgF5E5Z5xK1tFhjDhvbUc=
+github.com/guillaumemichel/reservedpool v0.2.0 h1:q73gtdMFJHtW+dDJ/fwtk34p7JprQv8fJSK7dEjf8Sw=
+github.com/guillaumemichel/reservedpool v0.2.0/go.mod h1:sXSDIaef81TFdAJglsCFCMfgF5E5Z5xK1tFhjDhvbUc=
 github.com/gxed/hashland/keccakpg v0.0.1/go.mod h1:kRzw3HkwxFU1mpmPP8v1WyQzwdGfmKFJ6tItnhQ67kU=
 github.com/gxed/hashland/murmur3 v0.0.1/go.mod h1:KjXop02n4/ckmZSnY2+HKcLud/tcmvhST0bie/0lS48=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=

--- a/provider/internal/connectivity/connectivity.go
+++ b/provider/internal/connectivity/connectivity.go
@@ -58,8 +58,9 @@ func New(checkFunc func() bool, backOnlineNotify func(), opts ...Option) (*Conne
 }
 
 // Close stops any running connectivity checks and prevents future ones.
-func (c *ConnectivityChecker) Close() {
+func (c *ConnectivityChecker) Close() error {
 	c.closeOnce.Do(func() { close(c.done) })
+	return nil
 }
 
 func (c *ConnectivityChecker) closed() bool {


### PR DESCRIPTION
Part of https://github.com/libp2p/go-libp2p-kad-dht/pull/1095

Depends on https://github.com/libp2p/go-libp2p-kad-dht/pull/1124

---

## Run and cleanup

This PR introduced the `run()` function (daemon) and changes how `Close()` is handled.

- [ ] Merged https://github.com/libp2p/go-libp2p-kad-dht/pull/1124
- [ ] Change merge target to be [`provider`](https://github.com/libp2p/go-libp2p-kad-dht/tree/provider) after https://github.com/libp2p/go-libp2p-kad-dht/pull/1124 is merged