### PR TITLE
provider: refresh schedule

### DIFF
--- a/provider/datastore/keystore.go
+++ b/provider/datastore/keystore.go
@@ -369,6 +369,63 @@ func (s *KeyStore) Get(ctx context.Context, prefix bitstr.Key) ([]mh.Multihash, 
 	return result, nil
 }
 
+// ContainsPrefix reports whether the KeyStore currently holds at least one
+// multihash whose kademlia identifier (bit256.Key) starts with the provided
+// bit-prefix.
+func (s *KeyStore) ContainsPrefix(ctx context.Context, prefix bitstr.Key) (bool, error) {
+	if s.closed() {
+		return false, ErrKeyStoreClosed
+	}
+	s.lk.Lock()
+	defer s.lk.Unlock()
+
+	// Case 1: shorter than bucket length — any bucket with this key-prefix is enough.
+	if len(prefix) < s.prefixLen {
+		rem := s.prefixLen - len(prefix)
+		limit := 1 << rem
+		for i := range limit {
+			suffix := fmt.Sprintf("%0*b", rem, i)
+			dsKey := s.dsKey(prefix + bitstr.Key(suffix))
+			exists, err := s.ds.Has(ctx, dsKey)
+			if err != nil {
+				return false, err
+			}
+			if exists {
+				return true, nil
+			}
+		}
+		return false, nil
+	}
+
+	// Case 2: at least a full bucket prefix — check that bucket's content.
+	dsKey := s.dsKey(bitstr.Key(prefix[:s.prefixLen]))
+
+	// Fast path when asking exactly for a bucket prefix: existence implies non-empty.
+	if len(prefix) == s.prefixLen {
+		exists, err := s.ds.Has(ctx, dsKey)
+		return exists, err
+	}
+
+	// Longer-than-bucket: must inspect entries and see if any starts with `prefix`.
+	data, err := s.ds.Get(ctx, dsKey)
+	if err != nil {
+		if err == ds.ErrNotFound {
+			return false, nil
+		}
+		return false, err
+	}
+	var stored []mh.Multihash
+	if err := json.Unmarshal(data, &stored); err != nil {
+		return false, err
+	}
+	for _, h := range stored {
+		if keyspace.IsPrefix(prefix, keyspace.MhToBit256(h)) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 // emptyLocked deletes all entries under the datastore prefix, assuming s.lk is
 // already held.
 func (s *KeyStore) emptyLocked(ctx context.Context) error {

--- a/provider/datastore/keystore.go
+++ b/provider/datastore/keystore.go
@@ -402,8 +402,7 @@ func (s *KeyStore) ContainsPrefix(ctx context.Context, prefix bitstr.Key) (bool,
 
 	// Fast path when asking exactly for a bucket prefix: existence implies non-empty.
 	if len(prefix) == s.prefixLen {
-		exists, err := s.ds.Has(ctx, dsKey)
-		return exists, err
+		return s.ds.Has(ctx, dsKey)
 	}
 
 	// Longer-than-bucket: must inspect entries and see if any starts with `prefix`.

--- a/provider/datastore/keystore_test.go
+++ b/provider/datastore/keystore_test.go
@@ -2,12 +2,15 @@ package datastore
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/ipfs/go-cid"
 	ds "github.com/ipfs/go-datastore"
+	"github.com/ipfs/go-test/random"
 	"github.com/libp2p/go-libp2p-kad-dht/provider/internal/keyspace"
 	mh "github.com/multiformats/go-multihash"
+	"github.com/stretchr/testify/require"
 
 	"github.com/probe-lab/go-libdht/kad/key"
 	"github.com/probe-lab/go-libdht/kad/key/bitstr"
@@ -83,6 +86,60 @@ func TestKeyStoreStoreAndGet(t *testing.T) {
 			t.Fatalf("returned hash does not match long prefix")
 		}
 	}
+}
+
+func genMultihashesMatchingPrefix(prefix bitstr.Key, n int) []mh.Multihash {
+	mhs := make([]mh.Multihash, 0, n)
+	for i := 0; len(mhs) < n; i++ {
+		h := random.Multihashes(1)[0]
+		k := keyspace.MhToBit256(h)
+		if keyspace.IsPrefix(prefix, k) {
+			mhs = append(mhs, h)
+		}
+	}
+	return mhs
+}
+
+func TestKeyStoreContainsPrefix(t *testing.T) {
+	ctx := context.Background()
+	store, err := NewKeyStore(ds.NewMapDatastore())
+	require.NoError(t, err)
+
+	ok, err := store.ContainsPrefix(ctx, bitstr.Key("0000"))
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	generated := genMultihashesMatchingPrefix(bitstr.Key(strings.Repeat("0", DefaultKeyStorePrefixBits+4)), 1)
+	require.True(t, keyspace.IsPrefix(bitstr.Key("0000"), keyspace.MhToBit256(generated[0])))
+	store.Put(ctx, generated...)
+
+	ok, err = store.ContainsPrefix(ctx, bitstr.Key("0"))
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	ok, err = store.ContainsPrefix(ctx, bitstr.Key("0000"))
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	ok, err = store.ContainsPrefix(ctx, bitstr.Key(strings.Repeat("0", DefaultKeyStorePrefixBits)))
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	ok, err = store.ContainsPrefix(ctx, bitstr.Key(strings.Repeat("0", DefaultKeyStorePrefixBits+4)))
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	ok, err = store.ContainsPrefix(ctx, bitstr.Key("1"))
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	ok, err = store.ContainsPrefix(ctx, bitstr.Key("0001"))
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	ok, err = store.ContainsPrefix(ctx, bitstr.Key(strings.Repeat("0", DefaultKeyStorePrefixBits+2)+"1"))
+	require.NoError(t, err)
+	require.False(t, ok)
 }
 
 func TestKeyStoreReset(t *testing.T) {

--- a/provider/internal/keyspace/key.go
+++ b/provider/internal/keyspace/key.go
@@ -134,20 +134,24 @@ func ShortestCoveredPrefix(target bitstr.Key, peers []peer.ID) (bitstr.Key, []pe
 // ExtendBinaryPrefix returns all bitstrings of length n that start with prefix.
 // Example: prefix="1101", n=6 -> ["110100", "110101", "110110", "110111"].
 func ExtendBinaryPrefix(prefix bitstr.Key, n int) []bitstr.Key {
-	if n < 0 || len(prefix) > n {
+	extraBits := n - len(prefix)
+	if n < 0 || extraBits < 0 {
 		return nil
 	}
 
+	extLen := 1 << extraBits // 2^extraBits
+	rd := make([]bitstr.Key, 0, extLen)
+	wr := make([]bitstr.Key, 1, extLen)
+	wr[0] = prefix
+
 	// Iteratively append bits until reaching length n.
-	res := []bitstr.Key{prefix}
-	for i := len(prefix); i < n; i++ {
-		next := make([]bitstr.Key, 0, len(res)*2)
-		for _, s := range res {
-			next = append(next, s+"0", s+"1")
+	for range extraBits {
+		rd, wr = wr, rd[:0]
+		for _, s := range rd {
+			wr = append(wr, s+"0", s+"1")
 		}
-		res = next
 	}
-	return res
+	return wr
 }
 
 // SiblingPrefixes returns the prefixes of the sibling subtrees along the path

--- a/provider/internal/keyspace/key.go
+++ b/provider/internal/keyspace/key.go
@@ -131,6 +131,38 @@ func ShortestCoveredPrefix(target bitstr.Key, peers []peer.ID) (bitstr.Key, []pe
 	return target[:coveredCpl], peers[:lastCoveredPeerIndex]
 }
 
+// ExtendBinaryPrefix returns all bitstrings of length n that start with prefix.
+// Example: prefix="1101", n=6 -> ["110100", "110101", "110110", "110111"].
+func ExtendBinaryPrefix(prefix bitstr.Key, n int) []bitstr.Key {
+	if n < 0 || len(prefix) > n {
+		return nil
+	}
+
+	// Iteratively append bits until reaching length n.
+	res := []bitstr.Key{prefix}
+	for i := len(prefix); i < n; i++ {
+		next := make([]bitstr.Key, 0, len(res)*2)
+		for _, s := range res {
+			next = append(next, s+"0", s+"1")
+		}
+		res = next
+	}
+	return res
+}
+
+// SiblingPrefixes returns the prefixes of the sibling subtrees along the path
+// to key. Together with the subtree under `key` itself, these prefixes
+// partition the keyspace.
+//
+// For key "1100" it returns: ["0", "10", "111", "1101"].
+func SiblingPrefixes(key bitstr.Key) []bitstr.Key {
+	complements := make([]bitstr.Key, len(key))
+	for i := range key {
+		complements[i] = FlipLastBit(key[:i+1])
+	}
+	return complements
+}
+
 // PrefixAndKeys is a struct that holds a prefix and the multihashes whose
 // kademlia identifier share the same prefix.
 type PrefixAndKeys struct {

--- a/provider/internal/keyspace/key_test.go
+++ b/provider/internal/keyspace/key_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ipfs/go-test/random"
 	kb "github.com/libp2p/go-libp2p-kbucket"
 	"github.com/libp2p/go-libp2p/core/peer"
 	mh "github.com/multiformats/go-multihash"
@@ -178,9 +179,7 @@ func TestShortestCoveredPrefix(t *testing.T) {
 	for range nIterations {
 		minCpl := KeyLen
 		largestCplCount := 0
-		for i := range peers {
-			peers[i] = genRandPeerID(t)
-		}
+		peers = random.Peers(nPeers)
 		peers = kb.SortClosestPeers(peers, target[:])
 		for i := range peers {
 			cpl = kb.CommonPrefixLen(kb.ConvertPeerID(peers[i]), target[:])
@@ -201,6 +200,30 @@ func TestShortestCoveredPrefix(t *testing.T) {
 	prefix, coveredPeers = ShortestCoveredPrefix(bstrTarget, nil)
 	require.Equal(t, bstrTarget, prefix)
 	require.Empty(t, coveredPeers)
+}
+
+func TestExtendBinaryPrefix(t *testing.T) {
+	prefix := bitstr.Key("")
+	l := 1
+	require.Equal(t, []bitstr.Key{"0", "1"}, ExtendBinaryPrefix(prefix, l))
+	prefix = bitstr.Key("1101")
+	l = 6
+	require.Equal(t, []bitstr.Key{"110100", "110101", "110110", "110111"}, ExtendBinaryPrefix(prefix, l))
+}
+
+func TestSiblingPrefixes(t *testing.T) {
+	k := bitstr.Key("")
+	require.Empty(t, SiblingPrefixes(k))
+	k = bitstr.Key("0")
+	require.Equal(t, []bitstr.Key{"1"}, SiblingPrefixes(k))
+	k = bitstr.Key("1")
+	require.Equal(t, []bitstr.Key{"0"}, SiblingPrefixes(k))
+	k = bitstr.Key("00")
+	require.Equal(t, []bitstr.Key{"1", "01"}, SiblingPrefixes(k))
+	k = bitstr.Key("000")
+	require.Equal(t, []bitstr.Key{"1", "01", "001"}, SiblingPrefixes(k))
+	k = bitstr.Key("1100")
+	require.Equal(t, []bitstr.Key{"0", "10", "111", "1101"}, SiblingPrefixes(k))
 }
 
 func genMultihashes(n int) []mh.Multihash {

--- a/provider/internal/keyspace/trie.go
+++ b/provider/internal/keyspace/trie.go
@@ -3,6 +3,7 @@ package keyspace
 import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	mh "github.com/multiformats/go-multihash"
+
 	"github.com/probe-lab/go-libdht/kad"
 	"github.com/probe-lab/go-libdht/kad/key"
 	"github.com/probe-lab/go-libdht/kad/key/bit256"
@@ -196,7 +197,7 @@ func TrieGaps[D any](t *trie.Trie[bitstr.Key, D]) []bitstr.Key {
 }
 
 func trieGapsAtDepth[D any](t *trie.Trie[bitstr.Key, D], depth int) []bitstr.Key {
-	gaps := []bitstr.Key{}
+	var gaps []bitstr.Key
 	for i := range 2 {
 		bstr := bitstr.Key(byte('0' + i))
 		if b := t.Branch(i); b == nil {

--- a/provider/internal/keyspace/trie_test.go
+++ b/provider/internal/keyspace/trie_test.go
@@ -6,8 +6,8 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/ipfs/go-test/random"
 	kb "github.com/libp2p/go-libp2p-kbucket"
-	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/peer"
 	mh "github.com/multiformats/go-multihash"
 
@@ -418,6 +418,117 @@ func TestPruneSubtrie(t *testing.T) {
 	require.True(t, tr.Branch(0).IsEmptyLeaf())
 }
 
+func TestTrieGaps(t *testing.T) {
+	initTrie := func(keys []bitstr.Key) *trie.Trie[bitstr.Key, struct{}] {
+		tr := trie.New[bitstr.Key, struct{}]()
+		for _, k := range keys {
+			tr.Add(k, struct{}{})
+		}
+		return tr
+	}
+	t.Run("Gap in empty trie", func(t *testing.T) {
+		keys := []bitstr.Key{}
+		tr := initTrie(keys)
+		require.Equal(t, []bitstr.Key{""}, TrieGaps(tr))
+	})
+	t.Run("No gaps in flat trie", func(t *testing.T) {
+		keys := []bitstr.Key{
+			"0",
+			"1",
+		}
+		tr := initTrie(keys)
+		require.Empty(t, TrieGaps(tr))
+	})
+	t.Run("No gaps in unbalanced trie", func(t *testing.T) {
+		keys := []bitstr.Key{
+			"0",
+			"10",
+			"110",
+			"111",
+		}
+		tr := initTrie(keys)
+		require.Empty(t, TrieGaps(tr))
+	})
+	t.Run("No gaps in trie with empty key", func(t *testing.T) {
+		keys := []bitstr.Key{
+			"",
+		}
+		tr := initTrie(keys)
+		require.Empty(t, TrieGaps(tr))
+	})
+	t.Run("Gap with single key - 0", func(t *testing.T) {
+		keys := []bitstr.Key{
+			"0",
+		}
+		tr := initTrie(keys)
+		require.Equal(t, []bitstr.Key{"1"}, TrieGaps(tr))
+	})
+	t.Run("Gap with single key - 1", func(t *testing.T) {
+		keys := []bitstr.Key{
+			"1",
+		}
+		tr := initTrie(keys)
+		require.Equal(t, []bitstr.Key{"0"}, TrieGaps(tr))
+	})
+	t.Run("Gap with single key - 11101101", func(t *testing.T) {
+		keys := []bitstr.Key{
+			"11101101",
+		}
+		tr := initTrie(keys)
+		require.Equal(t, SiblingPrefixes(keys[0]), TrieGaps(tr))
+	})
+	t.Run("Gap missing single key - 0", func(t *testing.T) {
+		keys := []bitstr.Key{
+			"0",
+			"10",
+			"110",
+		}
+		tr := initTrie(keys)
+		require.Equal(t, []bitstr.Key{"111"}, TrieGaps(tr))
+	})
+	t.Run("Gap missing single key - 1", func(t *testing.T) {
+		keys := []bitstr.Key{
+			"0",
+			"10",
+			"1100",
+			"1101",
+		}
+		tr := initTrie(keys)
+		require.Equal(t, []bitstr.Key{"111"}, TrieGaps(tr))
+	})
+	t.Run("Gap missing single key - 2", func(t *testing.T) {
+		keys := []bitstr.Key{
+			"000",
+			"001",
+			"01",
+			"10",
+			"1100",
+			"1101",
+		}
+		tr := initTrie(keys)
+		require.Equal(t, []bitstr.Key{"111"}, TrieGaps(tr))
+	})
+	t.Run("Gap missing multiple keys - 0", func(t *testing.T) {
+		keys := []bitstr.Key{
+			"000",
+			"01",
+			"10",
+			"1100",
+			"1101",
+		}
+		tr := initTrie(keys)
+		require.Equal(t, []bitstr.Key{"001", "111"}, TrieGaps(tr))
+	})
+	t.Run("Gap missing multiple keys - 1", func(t *testing.T) {
+		keys := []bitstr.Key{
+			"000",
+			"1101",
+		}
+		tr := initTrie(keys)
+		require.Equal(t, []bitstr.Key{"01", "001", "10", "111", "1100"}, TrieGaps(tr))
+	})
+}
+
 func TestAllocateToKClosestSingle(t *testing.T) {
 	destKeys := []bitstr.Key{
 		"0000",
@@ -557,14 +668,6 @@ func TestAllocateToKClosest(t *testing.T) {
 	}
 }
 
-func genRandPeerID(t *testing.T) peer.ID {
-	_, pub, err := crypto.GenerateKeyPair(crypto.Ed25519, -1)
-	require.NoError(t, err)
-	pid, err := peer.IDFromPublicKey(pub)
-	require.NoError(t, err)
-	return pid
-}
-
 func TestRegionsFromPeers(t *testing.T) {
 	// No peers
 	regions, commonPrefix := RegionsFromPeers(nil, 1, bit256.ZeroKey())
@@ -572,14 +675,14 @@ func TestRegionsFromPeers(t *testing.T) {
 	require.Equal(t, bitstr.Key(""), commonPrefix)
 
 	// Single peer
-	p0 := genRandPeerID(t)
+	p0 := random.Peers(1)[0]
 	regions, commonPrefix = RegionsFromPeers([]peer.ID{p0}, 1, bit256.ZeroKey())
 	require.Len(t, regions, 1)
 	bstrPid0 := bitstr.Key(key.BitString(PeerIDToBit256(p0)))
 	require.Equal(t, bstrPid0, commonPrefix)
 
 	// Two peers
-	p1 := genRandPeerID(t)
+	p1 := random.Peers(1)[0]
 	regions, commonPrefix = RegionsFromPeers([]peer.ID{p0, p1}, 2, bit256.ZeroKey())
 	require.Len(t, regions, 1)
 	cpl := key.CommonPrefixLength(bstrPid0, PeerIDToBit256(p1))
@@ -587,7 +690,7 @@ func TestRegionsFromPeers(t *testing.T) {
 	require.Equal(t, common, commonPrefix)
 
 	// Three peers
-	p2 := genRandPeerID(t)
+	p2 := random.Peers(1)[0]
 	regions, commonPrefix = RegionsFromPeers([]peer.ID{p0, p1, p2}, 2, bit256.ZeroKey())
 	require.Len(t, regions, 1)
 	cpl = key.CommonPrefixLength(common, PeerIDToBit256(p2))

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -1252,6 +1252,8 @@ func TestRefreshSchedule(t *testing.T) {
 	}
 	keyStore.Put(ctx, keys...)
 	prov.RefreshSchedule()
+	// Assert that only the prefixes containing matching keys in the KeyStore
+	// have been added to the schedule.
 	require.Equal(t, 1+len(newPrefixes), prov.schedule.Size())
 	for _, p := range newPrefixes {
 		ok, _ = trie.Find(prov.schedule, p)

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/filecoin-project/go-clock"
 	"github.com/guillaumemichel/reservedpool"
+	ds "github.com/ipfs/go-datastore"
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/ipfs/go-test/random"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -1157,4 +1158,103 @@ func TestStartProvidingUnstableNetwork(t *testing.T) {
 		return true
 	}
 	waitUntil(t, providedAllKeys, 200*time.Millisecond, "waiting for all keys to be reprovided")
+}
+
+func TestAddToSchedule(t *testing.T) {
+	mockClock := clock.NewMock()
+	prov := SweepingProvider{
+		clock:             mockClock,
+		reprovideInterval: time.Hour,
+		schedule:          trie.New[bitstr.Key, time.Duration](),
+		scheduleTimer:     mockClock.Timer(time.Hour),
+
+		cachedAvgPrefixLen:   4,
+		avgPrefixLenValidity: time.Minute,
+		lastAvgPrefixLen:     mockClock.Now(),
+	}
+
+	ok, _ := trie.Find(prov.schedule, "0000")
+
+	require.False(t, ok)
+	keys := genMultihashesMatchingPrefix("0000", 4)
+	prov.AddToSchedule(keys...)
+	ok, _ = trie.Find(prov.schedule, "0000")
+	require.True(t, ok)
+	require.Equal(t, 1, prov.schedule.Size())
+
+	// Nothing should have changed
+	prov.AddToSchedule(keys...)
+	ok, _ = trie.Find(prov.schedule, "0000")
+	require.True(t, ok)
+	require.Equal(t, 1, prov.schedule.Size())
+
+	keys = append(keys, append(genMultihashesMatchingPrefix("0111", 1), genMultihashesMatchingPrefix("1000", 3)...)...)
+	prov.AddToSchedule(keys...)
+	require.Equal(t, 3, prov.schedule.Size())
+	ok, _ = trie.Find(prov.schedule, "0000")
+	require.True(t, ok)
+	ok, _ = trie.Find(prov.schedule, "0111")
+	require.True(t, ok)
+	ok, _ = trie.Find(prov.schedule, "1000")
+	require.True(t, ok)
+}
+
+func TestRefreshSchedule(t *testing.T) {
+	ctx := context.Background()
+	mapDs := ds.NewMapDatastore()
+	defer mapDs.Close()
+	keyStore, err := datastore.NewKeyStore(mapDs)
+	require.NoError(t, err)
+
+	mockClock := clock.NewMock()
+	prov := SweepingProvider{
+		keyStore: keyStore,
+
+		clock:             mockClock,
+		reprovideInterval: time.Hour,
+		schedule:          trie.New[bitstr.Key, time.Duration](),
+		scheduleTimer:     mockClock.Timer(time.Hour),
+
+		cachedAvgPrefixLen:   4,
+		avgPrefixLenValidity: time.Minute,
+		lastAvgPrefixLen:     mockClock.Now(),
+	}
+
+	// Schedule is empty
+	require.Equal(t, 0, prov.schedule.Size())
+	prov.RefreshSchedule()
+	require.Equal(t, 0, prov.schedule.Size())
+
+	// Add key to keystore
+	k := genMultihashesMatchingPrefix("00000", 1)[0]
+	keyStore.Put(ctx, k)
+
+	// Refresh schedule should add the key to the schedule
+	require.Equal(t, 0, prov.schedule.Size())
+	prov.RefreshSchedule()
+	require.Equal(t, 1, prov.schedule.Size())
+	ok, _ := trie.Find(prov.schedule, bitstr.Key("0000"))
+	require.True(t, ok)
+
+	// Add another key starting with same prefix to keystore
+	k = genMultihashesMatchingPrefix("00001", 1)[0]
+	keyStore.Put(ctx, k)
+	prov.RefreshSchedule()
+	require.Equal(t, 1, prov.schedule.Size())
+	ok, _ = trie.Find(prov.schedule, bitstr.Key("0000"))
+	require.True(t, ok)
+
+	// Add multiple keys and verify associated prefixes are scheduled.
+	newPrefixes := []bitstr.Key{"0100", "0110", "0111"}
+	keys := make([]mh.Multihash, 0, len(newPrefixes))
+	for _, p := range newPrefixes {
+		keys = append(keys, genMultihashesMatchingPrefix(p, 1)...)
+	}
+	keyStore.Put(ctx, keys...)
+	prov.RefreshSchedule()
+	require.Equal(t, 1+len(newPrefixes), prov.schedule.Size())
+	for _, p := range newPrefixes {
+		ok, _ = trie.Find(prov.schedule, p)
+		require.True(t, ok)
+	}
 }


### PR DESCRIPTION
Part of https://github.com/libp2p/go-libp2p-kad-dht/pull/1095

---

## Add to Schedule

`SweepingProvider.AddToSchedule` makes sure that prefixes covering the supplied keys are included in the schedule, so that the keys are reprovided in time.

This is necessary for when keys are added directly in the keystore, since adding a key to the keystore doesn't translate to scheduling its associated prefix for reprovide.

This will be used in the `dual.DHT` provider and composable DHT routers.

## Schedule Refresh

`SweepingProvider.RefreshSchedule` syncs the schedule with the keystore.

If keys have been added to the keystore, they will be reprovided as long as their associated prefix is scheduled. Since kubo handles garbage collection of keys that shouldn't be reprovided anymore by directly resetting the keystore, it is possible that new keys are added to the keystore, but not to the schedule.

This function should be called after resetting the keystore, to make sure the schedule is sync with the keystore.

Also when the node boots up, it can add all keys that were provided before the node stops directly to the keystore for them to be reprovided (but not provided as soon as the node starts up).

Note that this function only adds prefixes to the schedule for keys in the keystore, it doesn't remove any keys from the schedule. Removal of prefixes matching to no keys is done automatically during the reprovide operation.