### PR TITLE
provider: use quartz for testing time

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/libp2p/go-libp2p-kad-dht
 go 1.23.10
 
 require (
+	github.com/coder/quartz v0.2.1
 	github.com/filecoin-project/go-clock v0.1.0
 	github.com/gammazero/deque v1.0.0
 	github.com/google/gopacket v1.1.19

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/coder/quartz v0.2.1 h1:QgQ2Vc1+mvzewg2uD/nj8MJ9p9gE+QhGJm+Z+NGnrSE=
+github.com/coder/quartz v0.2.1/go.mod h1:vsiCc+AHViMKH2CQpGIpFgdHIEQsxwm8yCscqKmzbRA=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=

--- a/provider/internal/connectivity/connectivity_test.go
+++ b/provider/internal/connectivity/connectivity_test.go
@@ -1,676 +1,434 @@
 package connectivity
 
 import (
-	"sync"
+	"context"
 	"sync/atomic"
 	"testing"
 	"time"
 
-	"github.com/filecoin-project/go-clock"
-	"github.com/stretchr/testify/assert"
+	"github.com/coder/quartz"
 	"github.com/stretchr/testify/require"
 )
 
-func eventually(t *testing.T, condition func() bool, maxDelay time.Duration, args ...any) {
-	step := time.Millisecond
-	for range maxDelay / step {
-		if condition() {
-			return
-		}
-		time.Sleep(step)
-	}
-	t.Fatal(args...)
-}
+var (
+	onlineCheckFunc  = func() bool { return true }
+	offlineCheckFunc = func() bool { return false }
+)
 
-func TestConnectivityChecker_New(t *testing.T) {
-	t.Parallel()
-
-	t.Run("starts offline when checkFunc returns false", func(t *testing.T) {
-		checkFunc := func() bool { return false }
-
-		checker, err := New(checkFunc)
+func TestNewConnectiviyChecker(t *testing.T) {
+	t.Run("initial state is offline", func(t *testing.T) {
+		connChecker, err := New(onlineCheckFunc)
 		require.NoError(t, err)
-		defer checker.Close()
 
-		// Give some time for initialization
-		eventually(t, func() bool { return !checker.IsOnline() }, 20*time.Millisecond, "checker should be offline")
-
-		assert.False(t, checker.IsOnline())
+		require.False(t, connChecker.IsOnline())
 	})
 
-	t.Run("starts online when checkFunc returns true", func(t *testing.T) {
-		checkFunc := func() bool { return true }
+	t.Run("start online", func(t *testing.T) {
+		onlineCount := atomic.Int32{}
+		onOnline := func() { onlineCount.Add(1) }
 
-		checker, err := New(checkFunc)
-		require.NoError(t, err)
-		checker.Start()
-		defer checker.Close()
-
-		// Give some time for initialization
-		eventually(t, checker.IsOnline, 20*time.Millisecond, "checker should be online")
-
-		require.True(t, checker.IsOnline())
-	})
-
-	t.Run("with custom options", func(t *testing.T) {
-		mockClock := clock.NewMock()
-		checkFunc := func() bool { return true }
-
-		checker, err := New(checkFunc,
-			WithClock(mockClock),
-			WithOnlineCheckInterval(30*time.Second),
+		clk := quartz.NewMock(t)
+		connChecker, err := New(onlineCheckFunc,
+			WithMockClock(clk),
+			WithOnOnline(onOnline),
 		)
 		require.NoError(t, err)
-		defer checker.Close()
 
-		assert.NotNil(t, checker)
+		require.False(t, connChecker.IsOnline())
+
+		connChecker.Start()
+
+		connChecker.mutex.Lock() // wait for node to come online
+		_, ok := clk.Peek()
+		connChecker.mutex.Unlock()
+		require.False(t, ok)
+
+		require.True(t, connChecker.IsOnline())
+		require.Equal(t, int32(1), onlineCount.Load())
 	})
 
-	t.Run("with invalid options", func(t *testing.T) {
-		checkFunc := func() bool { return true }
+	t.Run("start offline", func(t *testing.T) {
+		onlineCount, offlineCount := atomic.Int32{}, atomic.Int32{}
+		onOnline := func() { onlineCount.Add(1) }
+		onOffline := func() { offlineCount.Add(1) }
 
-		_, err := New(checkFunc,
-			WithOnlineCheckInterval(-1*time.Second),
+		clk := quartz.NewMock(t)
+		connChecker, err := New(offlineCheckFunc,
+			WithMockClock(clk),
+			WithOnOnline(onOnline),
+			WithOnOffline(onOffline),
 		)
-		assert.Error(t, err)
+		require.NoError(t, err)
 
-		_, err = New(checkFunc,
-			WithOfflineDelay(-1*time.Second),
-		)
-		assert.Error(t, err)
+		require.False(t, connChecker.IsOnline())
+
+		connChecker.Start()
+
+		require.False(t, connChecker.mutex.TryLock()) // node probing until it comes online
+
+		require.False(t, connChecker.IsOnline())
+		require.Equal(t, int32(0), onlineCount.Load())
+		require.Equal(t, int32(0), offlineCount.Load())
 	})
 }
 
-func TestConnectivityChecker_Close(t *testing.T) {
-	t.Parallel()
+func TestStateTransition(t *testing.T) {
+	t.Run("offline to online", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
 
-	t.Run("close stops all operations", func(t *testing.T) {
-		checkFunc := func() bool { return false }
+		checkInterval := time.Second
+		offlineDelay := time.Minute
 
-		checker, err := New(checkFunc)
+		clk := quartz.NewMock(t)
+
+		online := atomic.Bool{} // start offline
+		checkFunc := func() bool { return online.Load() }
+
+		onlineChan, offlineChan := make(chan struct{}), make(chan struct{})
+		onOnline := func() { close(onlineChan) }
+		onOffline := func() { close(offlineChan) }
+
+		trap := clk.Trap().NewTimer("periodicProbe")
+		defer trap.Close()
+
+		connChecker, err := New(checkFunc,
+			WithMockClock(clk),
+			WithOfflineDelay(offlineDelay),
+			WithOnlineCheckInterval(checkInterval),
+			WithOnOnline(onOnline),
+			WithOnOffline(onOffline),
+		)
 		require.NoError(t, err)
 
-		err = checker.Close()
-		assert.NoError(t, err)
+		require.False(t, connChecker.IsOnline())
+		connChecker.Start()
 
-		// Multiple closes should not panic
-		err = checker.Close()
-		assert.NoError(t, err)
+		trap.MustWait(context.Background()).MustRelease(context.Background())
+
+		online.Store(true)
+		_, w := clk.AdvanceNext()
+		w.MustWait(ctx)
+
+		<-onlineChan // wait for onOnline to be run
+		require.True(t, connChecker.IsOnline())
+		select {
+		case <-offlineChan:
+			require.FailNow(t, "onOffline shouldn't have been called")
+		default:
+		}
 	})
 
-	t.Run("operations after close are ignored", func(t *testing.T) {
-		checkFunc := func() bool { return true }
+	t.Run("online to disconnected to offline", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
 
-		checker, err := New(checkFunc)
+		checkInterval := time.Second
+		offlineDelay := time.Minute
+
+		clk := quartz.NewMock(t)
+
+		online := atomic.Bool{}
+		online.Store(true)
+		checkFunc := func() bool { return online.Load() }
+
+		onlineChan, offlineChan := make(chan struct{}), make(chan struct{})
+		onOnline := func() { close(onlineChan) }
+		onOffline := func() { close(offlineChan) }
+
+		trap := clk.Trap().NewTimer("periodicProbe")
+		defer trap.Close()
+
+		connChecker, err := New(checkFunc,
+			WithMockClock(clk),
+			WithOfflineDelay(offlineDelay),
+			WithOnlineCheckInterval(checkInterval),
+			WithOnOnline(onOnline),
+			WithOnOffline(onOffline),
+		)
 		require.NoError(t, err)
 
-		checker.Close()
+		require.False(t, connChecker.IsOnline())
+		connChecker.Start()
 
-		// TriggerCheck should be ignored after close
-		checker.TriggerCheck()
+		<-onlineChan // wait for onOnline to be run
+		require.True(t, connChecker.IsOnline())
+		require.Equal(t, clk.Now(), connChecker.lastCheck)
 
-		// State should still be accessible
-		_ = checker.IsOnline()
+		online.Store(false)
+		// Cannot trigger check yet
+		connChecker.TriggerCheck()
+		require.True(t, connChecker.mutex.TryLock()) // node still online
+		connChecker.mutex.Unlock()
+
+		clk.Advance(checkInterval - 1)
+		connChecker.TriggerCheck()
+		require.True(t, connChecker.mutex.TryLock()) // node still online
+		connChecker.mutex.Unlock()
+
+		clk.Advance(1)
+		connChecker.TriggerCheck()
+		require.False(t, connChecker.mutex.TryLock())
+
+		trap.MustWait(context.Background()).MustRelease(context.Background())
+		require.False(t, connChecker.IsOnline())
+		select {
+		case <-offlineChan:
+			require.FailNow(t, "onOffline shouldn't have been called")
+		default: // Disconnected but not Offline
+		}
+
+		connChecker.TriggerCheck() // noop since Disconnected
+		require.False(t, connChecker.mutex.TryLock())
+
+		// Wait for offlineDelay to elapse
+		advanced := checkInterval
+		for advanced < offlineDelay {
+			d, w := clk.AdvanceNext()
+			w.MustWait(ctx)
+			advanced += d
+		}
+
+		// Now Offline
+		require.False(t, connChecker.IsOnline())
+		<-offlineChan // wait for callback to be run
+
+		connChecker.TriggerCheck() // noop since Offline
+		require.False(t, connChecker.mutex.TryLock())
+	})
+
+	t.Run("remain online", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		checkInterval := time.Second
+		offlineDelay := time.Minute
+
+		clk := quartz.NewMock(t)
+
+		online := atomic.Bool{}
+		online.Store(true)
+		checkCount := atomic.Int32{}
+		checkFunc := func() bool { checkCount.Add(1); return online.Load() }
+
+		onlineChan, offlineChan := make(chan struct{}), make(chan struct{})
+		onOnline := func() { close(onlineChan) }
+		onOffline := func() { close(offlineChan) }
+
+		startTime := clk.Now()
+
+		trap := clk.Trap().Now()
+		defer trap.Close()
+
+		connChecker, err := New(checkFunc,
+			WithMockClock(clk),
+			WithOfflineDelay(offlineDelay),
+			WithOnlineCheckInterval(checkInterval),
+			WithOnOnline(onOnline),
+			WithOnOffline(onOffline),
+		)
+		require.NoError(t, err)
+
+		require.False(t, connChecker.IsOnline())
+		connChecker.Start()
+
+		trap.MustWait(ctx).MustRelease(ctx)
+		<-onlineChan
+
+		require.True(t, connChecker.IsOnline())
+		require.Equal(t, int32(1), checkCount.Load())
+		require.Equal(t, startTime, connChecker.lastCheck)
+
+		connChecker.TriggerCheck() // recent check, should be no-op
+		require.Equal(t, int32(1), checkCount.Load())
+
+		clk.Advance(checkInterval - 1).MustWait(ctx)
+		connChecker.TriggerCheck() // recent check, should be no-op
+		require.Equal(t, int32(1), checkCount.Load())
+
+		clk.Advance(1).MustWait(ctx)
+		connChecker.TriggerCheck() // checkInterval has passed, new check is run
+		trap.MustWait(ctx).MustRelease(ctx)
+		require.Equal(t, int32(2), checkCount.Load())
+
+		clk.Advance(checkInterval).MustWait(ctx)
+		connChecker.TriggerCheck() // checkInterval has passed, new check is run
+		trap.MustWait(ctx).MustRelease(ctx)
+		require.Equal(t, int32(3), checkCount.Load())
 	})
 }
 
-func TestConnectivityChecker_TriggerCheck_WithMockClock(t *testing.T) {
-	t.Parallel()
-
-	t.Run("ignores check when interval not passed", func(t *testing.T) {
-		mockClock := clock.NewMock()
-		var checkCount atomic.Int32
-
-		checkFunc := func() bool {
-			checkCount.Add(1)
-			return true
-		}
-
-		checker, err := New(checkFunc,
-			WithClock(mockClock),
-			WithOnlineCheckInterval(1*time.Minute),
-		)
-		require.NoError(t, err)
-		checker.Start()
-		defer checker.Close()
-
-		// Wait for initial check
-		time.Sleep(10 * time.Millisecond)
-
-		initialCount := checkCount.Load()
-
-		// Trigger check immediately - should be ignored
-		checker.TriggerCheck()
-		time.Sleep(10 * time.Millisecond)
-
-		assert.Equal(t, initialCount, checkCount.Load())
-
-		// Advance clock and trigger check - should work
-		mockClock.Add(2 * time.Minute)
-		checker.TriggerCheck()
-		time.Sleep(10 * time.Millisecond)
-
-		assert.Greater(t, checkCount.Load(), initialCount)
-	})
-
-	t.Run("transitions from online to offline", func(t *testing.T) {
-		var isOnline atomic.Bool
-		isOnline.Store(true)
-
-		checkFunc := func() bool {
-			return isOnline.Load()
-		}
-
-		var onlineCallCount, offlineCallCount atomic.Int32
-		onlineNotify := func() { onlineCallCount.Add(1) }
-		offlineNotify := func() { offlineCallCount.Add(1) }
-
-		checker, err := New(checkFunc,
-			WithOnlineCheckInterval(10*time.Millisecond), // Very short interval
-			WithOfflineDelay(100*time.Millisecond),       // Short delay for testing
-			WithOnOnline(onlineNotify),
-			WithOnOffline(offlineNotify),
-		)
-		require.NoError(t, err)
-		checker.Start()
-		defer checker.Close()
-
-		// Wait for initialization - should be online
-		time.Sleep(30 * time.Millisecond)
-		assert.True(t, checker.IsOnline())
-
-		// Make checkFunc return false and trigger check
-		isOnline.Store(false)
-
-		// Wait for online check interval to pass before triggering
-		time.Sleep(20 * time.Millisecond)
-		checker.TriggerCheck()
-		time.Sleep(30 * time.Millisecond)
-
-		// Should be in Disconnected state
-		require.False(t, checker.IsOnline())
-		assert.Equal(t, offlineCallCount.Load(), int32(0))
-
-		// Wait for offline delay to pass
-		time.Sleep(150 * time.Millisecond)
-
-		// Should be offline and callback should be called
-		require.False(t, checker.IsOnline())
-		assert.Greater(t, offlineCallCount.Load(), int32(0))
-	})
-
-	t.Run("transitions from offline to online", func(t *testing.T) {
-		mockClock := clock.NewMock()
-		var isOnline atomic.Bool
-		isOnline.Store(false)
-
-		checkFunc := func() bool {
-			return isOnline.Load()
-		}
-
-		var onlineCallCount atomic.Int32
-		onlineNotify := func() { onlineCallCount.Add(1) }
-
-		checker, err := New(checkFunc,
-			WithClock(mockClock),
-			WithOnOnline(onlineNotify),
-		)
-		require.NoError(t, err)
-		checker.Start()
-		defer checker.Close()
-
-		// Wait for initialization
-		time.Sleep(10 * time.Millisecond)
-		assert.False(t, checker.IsOnline())
-
-		// Make checkFunc return true
-		isOnline.Store(true)
-
-		// Advance clock to trigger offline check
-		mockClock.Add(1 * time.Minute)
-		time.Sleep(50 * time.Millisecond)
-
-		// Should be online and callback should be called
-		assert.True(t, checker.IsOnline())
-		assert.Greater(t, onlineCallCount.Load(), int32(0))
-	})
-
-	t.Run("concurrent trigger checks", func(t *testing.T) {
-		mockClock := clock.NewMock()
-		var checkCount atomic.Int32
-
-		checkFunc := func() bool {
-			checkCount.Add(1)
-			time.Sleep(50 * time.Millisecond) // Simulate slow check
-			return true
-		}
-
-		checker, err := New(checkFunc,
-			WithClock(mockClock),
-			WithOnlineCheckInterval(1*time.Minute),
-		)
-		require.NoError(t, err)
-		defer checker.Close()
-
-		// Wait for initialization to complete
-		time.Sleep(100 * time.Millisecond) // Longer wait to ensure initialization goroutine completes
-		initialCount := checkCount.Load()
-
-		// Advance clock
-		mockClock.Add(2 * time.Minute)
-
-		// Launch multiple concurrent checks
-		var wg sync.WaitGroup
-		for range 10 {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				checker.TriggerCheck()
-			}()
-		}
-		wg.Wait()
-
-		// Wait for any ongoing checks to complete
-		time.Sleep(100 * time.Millisecond)
-
-		finalCount := checkCount.Load()
-
-		// Only one additional check should have been performed (due to mutex)
-		// The mutex should prevent concurrent checks, so we should see exactly initialCount+1 or maybe +2 due to timing
-		assert.GreaterOrEqual(t, finalCount, initialCount+1)
-		assert.LessOrEqual(t, finalCount, initialCount+2) // Allow for slight timing variations
-	})
-
-	t.Run("probe loop with periodic checks", func(t *testing.T) {
-		mockClock := clock.NewMock()
-		var isOnline atomic.Bool
-		var checkCount atomic.Int32
-		isOnline.Store(false)
-
-		checkFunc := func() bool {
-			checkCount.Add(1)
-			return isOnline.Load()
-		}
-
-		var onlineCallCount atomic.Int32
-		onlineNotify := func() { onlineCallCount.Add(1) }
-
-		checker, err := New(checkFunc,
-			WithClock(mockClock),
-			WithOnOnline(onlineNotify),
-		)
-		require.NoError(t, err)
-		checker.Start()
-		defer checker.Close()
-
-		// Wait for initialization
-		time.Sleep(10 * time.Millisecond)
-		initialCheckCount := checkCount.Load()
-
-		// Advance clock multiple times to trigger periodic checks
-		for range 3 {
-			mockClock.Add(31 * time.Second)
-			time.Sleep(10 * time.Millisecond)
-		}
-
-		// Multiple checks should have been performed
-		assert.Greater(t, checkCount.Load(), initialCheckCount)
-
-		// Now make it go online
-		isOnline.Store(true)
-		mockClock.Add(31 * time.Second)
-		time.Sleep(50 * time.Millisecond)
-
-		// Should be online and callback called
-		assert.True(t, checker.IsOnline())
-		assert.Greater(t, onlineCallCount.Load(), int32(0))
-	})
-}
-
-func TestConnectivityChecker_StateTransitions(t *testing.T) {
-	t.Parallel()
-
-	t.Run("all state values", func(t *testing.T) {
-		var isOnline atomic.Bool
-		isOnline.Store(true)
-
-		checkFunc := func() bool {
-			return isOnline.Load()
-		}
-
-		checker, err := New(checkFunc,
-			WithOnlineCheckInterval(10*time.Millisecond), // Very short interval to allow quick trigger
-			WithOfflineDelay(100*time.Millisecond),       // Short delay for testing
-		)
-		require.NoError(t, err)
-		checker.Start()
-		defer checker.Close()
-
-		// Wait for initialization - should be Online
-		time.Sleep(30 * time.Millisecond)
-		assert.True(t, checker.IsOnline())
-
-		// Make offline and trigger check - should be Disconnected
-		isOnline.Store(false)
-
-		// Wait for online check interval to pass before triggering
-		time.Sleep(20 * time.Millisecond)
-		checker.TriggerCheck()
-		time.Sleep(30 * time.Millisecond)
-
-		assert.False(t, checker.IsOnline())
-
-		// Wait beyond offline delay - should be Offline
-		time.Sleep(150 * time.Millisecond)
-		assert.False(t, checker.IsOnline())
-	})
-}
-
-func TestConnectivityChecker_Callbacks(t *testing.T) {
-	t.Parallel()
-
-	t.Run("callbacks are called appropriately", func(t *testing.T) {
-		var isOnline atomic.Bool
-		isOnline.Store(true) // Start online first
-
-		checkFunc := func() bool {
-			return isOnline.Load()
-		}
-
-		var onlineCallCount, offlineCallCount atomic.Int32
-		onlineNotify := func() { onlineCallCount.Add(1) }
-		offlineNotify := func() { offlineCallCount.Add(1) }
-
-		checker, err := New(checkFunc,
-			WithOnlineCheckInterval(10*time.Millisecond), // Very short interval
-			WithOfflineDelay(100*time.Millisecond),       // Short delay for testing
-			WithOnOnline(onlineNotify),
-			WithOnOffline(offlineNotify),
-		)
-		require.NoError(t, err)
-		checker.Start()
-		defer checker.Close()
-
-		// Wait for initialization - should be online
-		time.Sleep(30 * time.Millisecond)
-		assert.True(t, checker.IsOnline())
-
-		// Go offline and trigger a check to start the offline transition
-		isOnline.Store(false)
-
-		// Wait for online check interval to pass before triggering
-		time.Sleep(20 * time.Millisecond)
-		checker.TriggerCheck()
-
-		// Wait for offline delay to pass and offline callback to be called
-		time.Sleep(150 * time.Millisecond)
-
-		// Should have called offline callback
-		assert.Greater(t, offlineCallCount.Load(), int32(0))
-
-		// Go online
-		isOnline.Store(true)
-		time.Sleep(50 * time.Millisecond)
-
-		// Should have called online callback
-		assert.Greater(t, onlineCallCount.Load(), int32(0))
-	})
-
-	t.Run("panic in callback doesn't break checker", func(t *testing.T) {
-		var isOnline atomic.Bool
-		isOnline.Store(false)
-
-		checkFunc := func() bool {
-			return isOnline.Load()
-		}
-
-		safeCallback := func() {
-			defer func() {
-				if r := recover(); r != nil {
-					// Expected panic, recover and continue
-				}
-			}()
-			panic("test panic")
-		}
-
-		// This should not panic during construction or operation
-		checker, err := New(checkFunc,
-			WithOnOnline(safeCallback),
-			WithOnOffline(safeCallback),
-			WithOfflineDelay(50*time.Millisecond),
-		)
-		require.NoError(t, err)
-		defer checker.Close()
-
-		// Wait for potential panics during initialization
-		time.Sleep(100 * time.Millisecond)
-
-		// Go online - should not panic the test
-		isOnline.Store(true)
-		time.Sleep(100 * time.Millisecond)
-
-		// Checker should still be functional
-		assert.NotPanics(t, func() {
-			checker.IsOnline()
-		})
-	})
-}
-
-func TestConnectivityChecker_EdgeCases(t *testing.T) {
-	t.Parallel()
-
-	t.Run("close during probe loop", func(t *testing.T) {
-		var checkCount atomic.Int32
-		checkFunc := func() bool {
-			checkCount.Add(1)
-			return false
-		}
-
-		checker, err := New(checkFunc)
-		require.NoError(t, err)
-		checker.Start()
-
-		// Let it run for a bit
-		time.Sleep(50 * time.Millisecond)
-		initialCount := checkCount.Load()
-
-		// Close and verify no more checks happen
-		checker.Close()
-		time.Sleep(50 * time.Millisecond)
-
-		// Should have stopped checking
-		finalCount := checkCount.Load()
-		time.Sleep(50 * time.Millisecond)
-		laterCount := checkCount.Load()
-
-		assert.Greater(t, initialCount, int32(0))
-		assert.Equal(t, finalCount, laterCount) // No new checks after close
-	})
-
-	t.Run("trigger check after close", func(t *testing.T) {
-		var checkCount atomic.Int32
-		checkFunc := func() bool {
-			checkCount.Add(1)
-			return true
-		}
-
-		checker, err := New(checkFunc)
-		require.NoError(t, err)
-
-		time.Sleep(10 * time.Millisecond)
-		checker.Close()
-
-		initialCount := checkCount.Load()
-
-		// Should be ignored
-		checker.TriggerCheck()
-		time.Sleep(10 * time.Millisecond)
-
-		assert.Equal(t, initialCount, checkCount.Load())
-	})
-
-	t.Run("high frequency operations", func(t *testing.T) {
-		mockClock := clock.NewMock()
-		var isOnline atomic.Bool
-		isOnline.Store(true)
-
-		checkFunc := func() bool {
-			return isOnline.Load()
-		}
-
-		checker, err := New(checkFunc,
-			WithClock(mockClock),
-			WithOnlineCheckInterval(100*time.Millisecond),
-		)
-		require.NoError(t, err)
-		checker.Start()
-		defer checker.Close()
-
-		// Rapid state checks should work
-		for range 100 {
-			go func() {
-				checker.IsOnline()
-			}()
-		}
-
-		// Rapid trigger checks with clock advancement
-		for range 10 {
-			mockClock.Add(200 * time.Millisecond)
-			checker.TriggerCheck()
-		}
-
-		time.Sleep(100 * time.Millisecond)
-
-		// Should still be functional
-		assert.True(t, checker.IsOnline())
-	})
-}
-
-func TestConnectivityChecker_Options(t *testing.T) {
-	t.Parallel()
-
-	t.Run("WithOfflineDelay", func(t *testing.T) {
-		// Use real time for this test since mock clock with timers is complex
-		var isOnline atomic.Bool
-		isOnline.Store(true)
-
-		checkFunc := func() bool {
-			return isOnline.Load()
-		}
-
-		var offlineCallCount atomic.Int32
-		offlineNotify := func() { offlineCallCount.Add(1) }
-
-		checker, err := New(checkFunc,
-			WithOnlineCheckInterval(10*time.Millisecond), // Very short interval
-			WithOfflineDelay(100*time.Millisecond),       // Short delay for testing
-			WithOnOffline(offlineNotify),
-		)
-		require.NoError(t, err)
-		checker.Start()
-		defer checker.Close()
-
-		// Wait for initialization - should be online
-		time.Sleep(30 * time.Millisecond)
-		assert.True(t, checker.IsOnline())
-
-		// Go offline and trigger check
-		isOnline.Store(false)
-
-		// Wait for online check interval to pass before triggering
-		time.Sleep(20 * time.Millisecond)
-		checker.TriggerCheck()
-		time.Sleep(30 * time.Millisecond)
-
-		// Should be disconnected, not offline yet
-		require.False(t, checker.IsOnline())
-		assert.Equal(t, int32(0), offlineCallCount.Load())
-
-		// Wait for offline delay to pass
-		time.Sleep(150 * time.Millisecond)
-
-		// Now offline
-		require.False(t, checker.IsOnline())
-		assert.Greater(t, offlineCallCount.Load(), int32(0))
-	})
-
-	t.Run("zero offline delay", func(t *testing.T) {
-		var isOnline atomic.Bool
-		isOnline.Store(true)
-
-		checkFunc := func() bool {
-			return isOnline.Load()
-		}
-
-		var offlineCallCount atomic.Int32
-		offlineNotify := func() { offlineCallCount.Add(1) }
-
-		checker, err := New(checkFunc,
-			WithOnlineCheckInterval(10*time.Millisecond), // Very short interval
-			WithOfflineDelay(0),
-			WithOnOffline(offlineNotify),
-		)
-		require.NoError(t, err)
-		checker.Start()
-		defer checker.Close()
-
-		// Wait for initialization to complete - should be online
-		time.Sleep(20 * time.Millisecond)
-		assert.True(t, checker.IsOnline())
-
-		// Go offline and trigger check
-		isOnline.Store(false)
-
-		// Wait for online check interval to pass before triggering
-		time.Sleep(20 * time.Millisecond)
-		checker.TriggerCheck()
-
-		// Give time for state to change to Disconnected first
-		time.Sleep(20 * time.Millisecond)
-
-		// With zero delay, should quickly transition to Offline
-		time.Sleep(50 * time.Millisecond)
-
-		assert.False(t, checker.IsOnline())
-		assert.Greater(t, offlineCallCount.Load(), int32(0))
-	})
-}
-
-// Benchmark tests to ensure performance
-func BenchmarkConnectivityChecker_StateAccess(b *testing.B) {
-	checkFunc := func() bool { return true }
-
-	checker, err := New(checkFunc)
-	require.NoError(b, err)
-	defer checker.Close()
-
-	b.ResetTimer()
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			checker.IsOnline()
-		}
-	})
-}
-
-func BenchmarkConnectivityChecker_TriggerCheck(b *testing.B) {
-	mockClock := clock.NewMock()
-	var checkCount atomic.Int32
-
-	checkFunc := func() bool {
-		checkCount.Add(1)
-		return true
-	}
-
-	checker, err := New(checkFunc,
-		WithClock(mockClock),
-		WithOnlineCheckInterval(1*time.Nanosecond), // Allow rapid checks
+func TestSetCallbacks(t *testing.T) {
+	// Callbacks MUST be set before calling Start()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	oldOnlineCount, oldOfflineCount, newOnlineCount, newOfflineCount := atomic.Int32{}, atomic.Int32{}, atomic.Int32{}, atomic.Int32{}
+	onlineChan, offlineChan := make(chan struct{}), make(chan struct{})
+	oldOnOnline := func() { oldOnlineCount.Add(1); close(onlineChan) }
+	oldOnOffline := func() { oldOfflineCount.Add(1); close(offlineChan) }
+	newOnOnline := func() { newOnlineCount.Add(1); close(onlineChan) }
+	newOnOffline := func() { newOfflineCount.Add(1); close(offlineChan) }
+
+	checkInterval := time.Second
+	online := atomic.Bool{}
+	online.Store(true)
+	checkFunc := func() bool { return online.Load() }
+	clk := quartz.NewMock(t)
+
+	connChecker, err := New(checkFunc,
+		WithMockClock(clk),
+		WithOnOnline(oldOnOnline),
+		WithOnOffline(oldOnOffline),
+		WithOfflineDelay(0),
+		WithOnlineCheckInterval(checkInterval),
 	)
-	require.NoError(b, err)
-	defer checker.Close()
+	require.NoError(t, err)
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		mockClock.Add(1 * time.Nanosecond)
-		checker.TriggerCheck()
+	connChecker.SetCallbacks(newOnOnline, newOnOffline)
+
+	connChecker.Start()
+
+	<-onlineChan // wait for newOnOnline to be called
+	require.True(t, connChecker.IsOnline())
+	require.Equal(t, int32(0), oldOnlineCount.Load())
+	require.Equal(t, int32(1), newOnlineCount.Load())
+
+	// Wait until we can perform a new check
+	clk.Advance(checkInterval).MustWait(ctx)
+
+	// Go offline
+	online.Store(false)
+	connChecker.TriggerCheck()
+	require.False(t, connChecker.mutex.TryLock()) // node probing until it comes online
+
+	<-offlineChan // wait for newOnOffline to be called
+	require.False(t, connChecker.IsOnline())
+	require.Equal(t, int32(0), oldOfflineCount.Load())
+	require.Equal(t, int32(1), newOfflineCount.Load())
+}
+
+func TestExponentialBackoff(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	clk := quartz.NewMock(t)
+	initTrap := clk.Trap().NewTimer("periodicProbe")
+	resetTrap := clk.Trap().TimerReset()
+	defer func() {
+		initTrap.Close()
+		resetTrap.Close()
+	}()
+
+	connChecker, err := New(offlineCheckFunc,
+		WithMockClock(clk),
+	)
+	require.NoError(t, err)
+
+	connChecker.Start()
+	require.False(t, connChecker.mutex.TryLock()) // node probing until it comes online
+	require.False(t, connChecker.IsOnline())
+
+	initTrap.MustWait(ctx).MustRelease(ctx)
+
+	expectedWait := initialBackoffDelay
+	for expectedWait < maxBackoffDelay {
+		d, w := clk.AdvanceNext()
+		w.MustWait(ctx)
+		require.Equal(t, expectedWait, d)
+		resetTrap.MustWait(ctx).MustRelease(ctx)
+		expectedWait *= 2
 	}
+	d, w := clk.AdvanceNext()
+	w.MustWait(ctx)
+	require.Equal(t, maxBackoffDelay, d)
+	resetTrap.MustWait(ctx).MustRelease(ctx)
+
+	d, w = clk.AdvanceNext()
+	w.MustWait(ctx)
+	require.Equal(t, maxBackoffDelay, d)
+}
+
+func TestInvalidOptions(t *testing.T) {
+	t.Run("negative online check interval", func(t *testing.T) {
+		_, err := New(onlineCheckFunc, WithOnlineCheckInterval(-1))
+		require.Error(t, err)
+	})
+
+	t.Run("negative offline delay", func(t *testing.T) {
+		_, err := New(onlineCheckFunc, WithOfflineDelay(-1*time.Hour))
+		require.Error(t, err)
+	})
+}
+
+func TestClose(t *testing.T) {
+	t.Run("close while offline", func(t *testing.T) {
+		connChecker, err := New(offlineCheckFunc)
+		require.NoError(t, err)
+
+		connChecker.Start()
+		require.False(t, connChecker.mutex.TryLock()) // node probing until it comes online
+		require.False(t, connChecker.IsOnline())
+
+		err = connChecker.Close()
+		require.NoError(t, err)
+
+		require.True(t, connChecker.mutex.TryLock())
+		connChecker.mutex.Unlock()
+	})
+
+	t.Run("close while online", func(t *testing.T) {
+		onlineChan := make(chan struct{})
+		onOnline := func() { close(onlineChan) }
+		connChecker, err := New(onlineCheckFunc,
+			WithOnOnline(onOnline),
+		)
+		require.NoError(t, err)
+
+		connChecker.Start()
+		<-onlineChan
+		require.True(t, connChecker.IsOnline())
+
+		connChecker.Close()
+	})
+
+	t.Run("SetCallbacks after Close", func(t *testing.T) {
+		onlineChan, offlineChan := make(chan struct{}), make(chan struct{})
+		onOnline := func() { close(onlineChan) }
+		onOffline := func() { close(offlineChan) }
+
+		connChecker, err := New(offlineCheckFunc)
+		require.NoError(t, err)
+
+		require.Nil(t, connChecker.onOffline)
+		require.Nil(t, connChecker.onOnline)
+
+		connChecker.Close()
+		connChecker.SetCallbacks(onOnline, onOffline)
+
+		// Assert that callbacks were NOT set
+		require.Nil(t, connChecker.onOffline)
+		require.Nil(t, connChecker.onOnline)
+	})
+
+	t.Run("TriggerCheck after Close", func(t *testing.T) {
+		connChecker, err := New(offlineCheckFunc)
+		require.NoError(t, err)
+
+		connChecker.Start()
+		require.False(t, connChecker.mutex.TryLock()) // node probing until it comes online
+		require.False(t, connChecker.IsOnline())
+
+		err = connChecker.Close()
+		require.NoError(t, err)
+
+		require.True(t, connChecker.mutex.TryLock())
+		connChecker.mutex.Unlock()
+
+		connChecker.TriggerCheck() // noop since closed
+
+		require.True(t, connChecker.mutex.TryLock())
+		connChecker.mutex.Unlock()
+		require.False(t, connChecker.IsOnline())
+	})
 }

--- a/provider/internal/connectivity/options.go
+++ b/provider/internal/connectivity/options.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/filecoin-project/go-clock"
+	"github.com/coder/quartz"
 )
 
 type config struct {
-	clock               clock.Clock
+	clock               quartz.Clock
 	onlineCheckInterval time.Duration // minimum check interval when online
 
 	offlineDelay time.Duration
@@ -29,13 +29,13 @@ func (cfg *config) apply(opts ...Option) error {
 type Option func(opt *config) error
 
 var DefaultConfig = func(cfg *config) error {
-	cfg.clock = clock.New()
+	cfg.clock = quartz.NewReal()
 	cfg.onlineCheckInterval = 1 * time.Minute
 	return nil
 }
 
 // WithClock sets the clock used by the connectivity checker.
-func WithClock(c clock.Clock) Option {
+func WithMockClock(c *quartz.Mock) Option {
 	return func(cfg *config) error {
 		cfg.clock = c
 		return nil


### PR DESCRIPTION
## Summary

Refactor tests to use [`github.com/coder/quartz`](https://github.com/coder/quartz) instead of [`github.com/benbjohnson/clock`](https://github.com/benbjohnson/clock) or its fork [`github.com/filecoin-project/go-clock`](https://github.com/filecoin-project/go-clock)

## Benefits

* Better control of time (and goroutines!) in tests
* Deterministic testing (no flakes)
* Faster