### PR TITLE
fix(provider): don't empty mapdatastore keystore on close

### DIFF
--- a/provider/dual/provider.go
+++ b/provider/dual/provider.go
@@ -47,7 +47,7 @@ func New(d *dual.DHT, opts ...Option) (*SweepingProvider, error) {
 			ds.Close()
 			return nil, fmt.Errorf("couldn't create a keystore: %w", err)
 		}
-		cleanupFuncs = []func() error{ds.Close, cfg.keystore.Close, func() error { return cfg.keystore.Empty(context.Background()) }}
+		cleanupFuncs = []func() error{ds.Close, cfg.keystore.Close}
 	}
 
 	sweepingProviders := make([]*provider.SweepingProvider, 2)

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -175,7 +175,7 @@ func New(opts ...Option) (*SweepingProvider, error) {
 			cleanup(cleanupFuncs)
 			return nil, err
 		}
-		cleanupFuncs = append(cleanupFuncs, cfg.keystore.Close, func() error { return cfg.keystore.Empty(context.Background()) })
+		cleanupFuncs = append(cleanupFuncs, cfg.keystore.Close)
 	}
 	meter := otel.Meter("github.com/libp2p/go-libp2p-kad-dht/provider")
 	providerCounter, err := meter.Int64Counter(


### PR DESCRIPTION
As the datastore is in-memory, there is no need to empty it.