### PR TITLE
refactor(provider): closestPeerToPrefix coverage trie

### DIFF
--- a/provider/internal/keyspace/trie.go
+++ b/provider/internal/keyspace/trie.go
@@ -200,10 +200,17 @@ func pruneSubtrieAtDepth[K0 kad.Key[K0], K1 kad.Key[K1], D any](t *trie.Trie[K0,
 //   - GapsInTrie: ["0001", "0011", "01"]
 func TrieGaps[K kad.Key[K], D any](t *trie.Trie[bitstr.Key, D], target bitstr.Key, order K) []bitstr.Key {
 	if t.IsLeaf() {
-		if k := t.Key(); k != nil && IsBitstrPrefix(target, *k) {
-			siblingPrefixes := SiblingPrefixes(*k)[len(target):]
-			sortBitstrKeysByOrder(siblingPrefixes, order)
-			return siblingPrefixes
+		if k := t.Key(); k != nil {
+			if IsBitstrPrefix(target, *k) {
+				siblingPrefixes := SiblingPrefixes(*k)[len(target):]
+				sortBitstrKeysByOrder(siblingPrefixes, order)
+				return siblingPrefixes
+			}
+			if IsBitstrPrefix(*k, target) {
+				// The only key in the trie is a prefix of target, meaning the whole
+				// target is covered.
+				return nil
+			}
 		}
 		return []bitstr.Key{target}
 	}

--- a/provider/internal/keyspace/trie_test.go
+++ b/provider/internal/keyspace/trie_test.go
@@ -588,6 +588,24 @@ func TestTrieGaps(t *testing.T) {
 		tr := initTrie(keys)
 		require.Equal(t, []bitstr.Key{"01", "001"}, TrieGaps(tr, "0", bitstr.Key("1111")))
 	})
+
+	t.Run("Target longer than only key in trie", func(t *testing.T) {
+		keys := []bitstr.Key{
+			"00",
+		}
+		tr := initTrie(keys)
+		require.Empty(t, TrieGaps(tr, "000", bit256.ZeroKey()))
+	})
+
+	t.Run("Target is superstring of key in trie", func(t *testing.T) {
+		keys := []bitstr.Key{
+			"00",
+			"01",
+			"101",
+		}
+		tr := initTrie(keys)
+		require.Empty(t, TrieGaps(tr, "000", bit256.ZeroKey()))
+	})
 }
 
 func TestSortBitstrKeysByOrder(t *testing.T) {

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -665,7 +665,7 @@ func (s *SweepingProvider) closestPeersToPrefix(prefix bitstr.Key) ([]peer.ID, e
 	for p := range allClosestPeers {
 		peers = append(peers, p)
 	}
-	logger.Infof("region %s exploration required %d requests to discover %d peers in %s", prefix, i+1, len(allClosestPeers), time.Since(startTime))
+	logger.Debugf("region %s exploration required %d requests to discover %d peers in %s", prefix, i+1, len(allClosestPeers), time.Since(startTime))
 	return peers, nil
 }
 

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -632,8 +632,10 @@ func (s *SweepingProvider) closestPeersToPrefix(prefix bitstr.Key) ([]peer.ID, e
 			allClosestPeers[p] = struct{}{}
 		}
 
-		keyspace.PruneSubtrie(coverageTrie, coveredPrefix)
-		coverageTrie.Add(coveredPrefix, struct{}{})
+		if _, ok := keyspace.FindPrefixOfKey(coverageTrie, coveredPrefix); !ok {
+			keyspace.PruneSubtrie(coverageTrie, coveredPrefix)
+			coverageTrie.Add(coveredPrefix, struct{}{})
+		}
 
 		gaps = keyspace.TrieGaps(coverageTrie, prefix, s.order)
 		if len(gaps) == 0 {

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -654,11 +654,12 @@ func (s *SweepingProvider) closestPeersToPrefix(prefix bitstr.Key) ([]peer.ID, e
 				break
 			}
 		}
+		logger.Debugw("closestPeersToPrefix", "i", i, "prefix", prefix, "prevPrefix", nextPrefix, "fullKey[:12]", fullKey[:12], "coveredPrefix", coveredPrefix, "len(coveredPeers)", len(coveredPeers), "len(allClosestPeers)", len(allClosestPeers), "gaps", gaps)
 
 		nextPrefix = gaps[0]
 	}
 	if i == maxExplorationPrefixSearches {
-		logger.Warn("closestPeersToPrefix needed more than maxPrefixSearches iterations", "gaps", gaps)
+		logger.Warnw("closestPeersToPrefix needed more than maxPrefixSearches iterations", "gaps", gaps)
 	}
 	peers := make([]peer.ID, 0, len(allClosestPeers))
 	for p := range allClosestPeers {

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/probe-lab/go-libdht/kad/key/bitstr"
 	"github.com/probe-lab/go-libdht/kad/trie"
 
+	"github.com/libp2p/go-libp2p-kad-dht/amino"
 	pb "github.com/libp2p/go-libp2p-kad-dht/pb"
 	"github.com/libp2p/go-libp2p-kad-dht/provider/internal/connectivity"
 	"github.com/libp2p/go-libp2p-kad-dht/provider/internal/keyspace"
@@ -1420,5 +1421,68 @@ func TestOperationsOffline(t *testing.T) {
 		require.ErrorIs(t, err, ErrOffline)
 		err = prov.StopProviding(k) // no error for StopProviding
 		require.NoError(t, err)
+	})
+}
+
+// TestClosestPeersToPrefixErrors tests error handling in closestPeersToPrefix
+func TestClosestPeersToPrefixErrors(t *testing.T) {
+	t.Run("OfflineNode", func(t *testing.T) {
+		// Test that closestPeersToPrefix returns error when node is offline
+		callCount := atomic.Int32{}
+		router := &mockRouter{
+			getClosestPeersFunc: func(ctx context.Context, k string) ([]peer.ID, error) {
+				callCount.Add(1)
+				return []peer.ID{"peer1"}, nil
+			},
+		}
+
+		// Create a connectivity checker that reports offline
+		offlineChecker, err := connectivity.New(func() bool { return false })
+		require.NoError(t, err)
+
+		prov := &SweepingProvider{
+			ctx:               context.Background(),
+			router:            router,
+			order:             bit256.ZeroKey(),
+			replicationFactor: amino.DefaultBucketSize,
+			connectivity:      offlineChecker,
+		}
+
+		prefix := bitstr.Key("0101")
+		_, err = prov.closestPeersToPrefix(prefix)
+
+		require.Error(t, err)
+		require.Equal(t, int32(0), callCount.Load(), "router should not be called when offline")
+	})
+
+	t.Run("NetworkError", func(t *testing.T) {
+		// Test error propagation from GetClosestPeers
+		synctest.Test(t, func(t *testing.T) {
+			networkErr := errors.New("network timeout")
+			router := &mockRouter{
+				getClosestPeersFunc: func(ctx context.Context, k string) ([]peer.ID, error) {
+					return nil, networkErr
+				},
+			}
+
+			prov := &SweepingProvider{
+				ctx:               context.Background(),
+				connectivity:      noopConnectivityChecker(),
+				router:            router,
+				order:             bit256.ZeroKey(),
+				replicationFactor: amino.DefaultBucketSize,
+			}
+			prov.connectivity.Start()
+			defer prov.connectivity.Close()
+
+			synctest.Wait()
+			require.True(t, prov.connectivity.IsOnline())
+
+			prefix := bitstr.Key("0101")
+			_, err := prov.closestPeersToPrefix(prefix)
+
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "network timeout")
+		})
 	})
 }

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -900,7 +900,7 @@ func TestStartProvidingSingle(t *testing.T) {
 		synctest.Wait()
 		require.True(t, prov.connectivity.IsOnline())
 		prov.avgPrefixLenLk.Lock()
-		require.Greater(t, prov.cachedAvgPrefixLen, 0) // TODO: FLAKY
+		require.Greater(t, prov.cachedAvgPrefixLen, 0)
 		prov.avgPrefixLenLk.Unlock()
 
 		err = prov.StartProviding(true, h)


### PR DESCRIPTION
Refactor of `closestPeerToPrefix` to use a trie to ensure keyspace coverage (instead of binary prefix stack).