### PR TITLE
feat(provider): exit early region exploration if no new peers discovered

### DIFF
--- a/provider/provider.go
+++ b/provider/provider.go
@@ -689,18 +689,11 @@ func (s *SweepingProvider) closestPeersToPrefix(prefix bitstr.Key) ([]peer.ID, e
 		// Track whether we discovered any new peers. If too many consecutive
 		// lookups find no new peers, break early as we've likely found all peers
 		// in the region.
-		freshPeerFound := false
+		closestPeersBefore := len(allClosestPeers)
 		for _, p := range coveredPeers {
-			if !freshPeerFound {
-				if _, ok := allClosestPeers[p]; !ok {
-					allClosestPeers[p] = struct{}{}
-					freshPeerFound = true
-				}
-			} else {
-				allClosestPeers[p] = struct{}{}
-			}
+			allClosestPeers[p] = struct{}{}
 		}
-		if !freshPeerFound {
+		if len(allClosestPeers) <= closestPeersBefore {
 			noFreshPeersFoundCount++
 			if noFreshPeersFoundCount >= maxConsecutiveNoFreshPeers {
 				break


### PR DESCRIPTION
## Summary

Optimize the region exploration process in `closestPeersToPrefix` by detecting when no new peers are being discovered after multiple attempts and exiting early to avoid wasting network requests.

## Changes

  - Add early exit mechanism in `closestPeersToPrefix` that breaks after `maxConsecutiveNoFreshPeers` (2) consecutive lookups with no new peer discoveries
  - Track whether each DHT lookup discovers fresh peers not already in the known peer set

## Motivation

In networks with a small number of peers (e.g LAN DHT with 2 peers only), the prefix exploration may use all the `maxExplorationPrefixSearches` to repeatedly send `FIND_NODE` requests to the same peers, since their IDs may not cover the desired keyspace.

Hence in this case, the DHT swarm would have been fully explored, and the (re)provide operation should carry on with the discovered peers (even if there are less than `reprovideFactor` peers).