### PR TITLE
refactor(provider): use adaptive deadline for CycleStats cleanup

### DIFF
--- a/provider/internal/timeseries/cycle_stats_test.go
+++ b/provider/internal/timeseries/cycle_stats_test.go
@@ -1,7 +1,11 @@
+//go:build go1.25
+// +build go1.25
+
 package timeseries
 
 import (
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/probe-lab/go-libdht/kad/key/bitstr"
@@ -9,7 +13,7 @@ import (
 )
 
 func TestCycleStatsSimple(t *testing.T) {
-	cs := NewCycleStats(time.Hour, time.Minute)
+	cs := NewCycleStats(time.Minute)
 
 	// Test empty stats
 	require.Equal(t, int64(0), cs.Sum(), "sum of empty CycleStats")
@@ -26,7 +30,7 @@ func TestCycleStatsSimple(t *testing.T) {
 }
 
 func TestCycleStatsSimpleFullyCovered(t *testing.T) {
-	cs := NewCycleStats(time.Hour, time.Minute)
+	cs := NewCycleStats(time.Minute)
 
 	// Single bit prefixes should cover full keyspace
 	cs.Add(bitstr.Key("0"), 10)
@@ -36,24 +40,27 @@ func TestCycleStatsSimpleFullyCovered(t *testing.T) {
 }
 
 func TestCycleStatsSimpleCleanup(t *testing.T) {
-	// Use very short TTL for testing
-	cs := NewCycleStats(time.Millisecond, time.Millisecond)
+	synctest.Test(t, func(t *testing.T) {
+		// Use very short durations for testing
+		maxDelay := time.Millisecond
+		cs := NewCycleStats(maxDelay)
 
-	cs.Add(bitstr.Key("0"), 10)
-	cs.Add(bitstr.Key("1"), 20)
+		cs.Add(bitstr.Key("0"), 10)
+		cs.Add(bitstr.Key("1"), 20)
 
-	require.Equal(t, 2, cs.Count(), "count before cleanup")
+		require.Equal(t, 2, cs.Count(), "count before cleanup")
 
-	// Wait for entries to expire
-	time.Sleep(5 * time.Millisecond)
-	cs.Cleanup()
+		// Wait for entries to expire
+		time.Sleep(5 * time.Millisecond)
+		cs.Cleanup(2 * time.Millisecond)
 
-	require.Equal(t, 0, cs.Count(), "count after cleanup")
-	require.Equal(t, int64(0), cs.Sum(), "sum after cleanup")
+		require.Equal(t, 0, cs.Count(), "count after cleanup")
+		require.Equal(t, int64(0), cs.Sum(), "sum after cleanup")
+	})
 }
 
 func TestCycleStatsReplacement(t *testing.T) {
-	cs := NewCycleStats(time.Hour, time.Minute)
+	cs := NewCycleStats(time.Minute)
 
 	// Add parent prefix
 	cs.Add(bitstr.Key(""), 100) // Root covers everything
@@ -71,7 +78,7 @@ func TestCycleStatsReplacement(t *testing.T) {
 }
 
 func TestCycleStatsShorterPrefix(t *testing.T) {
-	cs := NewCycleStats(time.Hour, time.Minute)
+	cs := NewCycleStats(time.Minute)
 
 	// Add some specific prefixes
 	cs.Add(bitstr.Key("000"), 10)
@@ -89,7 +96,7 @@ func TestCycleStatsShorterPrefix(t *testing.T) {
 }
 
 func TestCycleStatsZeroValues(t *testing.T) {
-	cs := NewCycleStats(time.Hour, time.Minute)
+	cs := NewCycleStats(time.Minute)
 
 	cs.Add(bitstr.Key("0"), 0)
 	cs.Add(bitstr.Key("1"), 10)
@@ -97,4 +104,142 @@ func TestCycleStatsZeroValues(t *testing.T) {
 	require.Equal(t, 2, cs.Count(), "count with zero value")
 	require.Equal(t, int64(10), cs.Sum(), "sum with zero value")
 	require.Equal(t, 5.0, cs.Avg(), "average with zero value")
+}
+
+func TestCycleStatsCleanupPromotesQueue(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		// This tests that when a parent entry expires, queued child entries are promoted
+		maxDelay := time.Millisecond
+		cs := NewCycleStats(maxDelay)
+
+		// Add parent prefix
+		cs.Add(bitstr.Key("0"), 100)
+		require.Equal(t, 1, cs.Count(), "should have 1 entry in main trie")
+		require.Equal(t, int64(100), cs.Sum(), "sum should be 100")
+
+		// Add one child prefix that goes into queue (doesn't fully cover "0")
+		time.Sleep(2 * time.Millisecond)
+		cs.Add(bitstr.Key("00"), 30)
+
+		// Child entry is in queue, not fully covering parent
+		// Main trie still shows parent
+		require.Equal(t, 1, cs.Count(), "should still have 1 entry (partial coverage)")
+		require.Equal(t, int64(100), cs.Sum(), "sum should still be 100 (queue not visible)")
+
+		// Now wait for parent to expire and clean up
+		time.Sleep(5 * time.Millisecond)
+		cs.Cleanup(3 * time.Millisecond)
+
+		// After cleanup, parent is removed and queued entry is promoted
+		require.Equal(t, 1, cs.Count(), "should have 1 entry after promotion")
+		require.Equal(t, int64(30), cs.Sum(), "sum should be 30 (queued entry promoted)")
+	})
+}
+
+func TestCycleStatsCleanupWithoutQueue(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		// Test that cleanup removes entries even when there's nothing in queue
+		maxDelay := time.Millisecond
+		cs := NewCycleStats(maxDelay)
+
+		cs.Add(bitstr.Key("0"), 10)
+		cs.Add(bitstr.Key("1"), 20)
+		require.Equal(t, 2, cs.Count(), "should have 2 entries")
+		require.Equal(t, int64(30), cs.Sum(), "sum should be 30")
+
+		// Wait for entries to expire
+		time.Sleep(5 * time.Millisecond)
+		cs.Cleanup(2 * time.Millisecond)
+
+		// Entries removed, nothing to promote
+		require.Equal(t, 0, cs.Count(), "should have 0 entries after cleanup")
+		require.Equal(t, int64(0), cs.Sum(), "sum should be 0")
+	})
+}
+
+func TestCycleStatsQueueCoverageAtRootLevel(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		// Test queue coverage detection - using root level like TestCycleStatsReplacement
+		maxDelay := time.Minute
+		cs := NewCycleStats(maxDelay)
+
+		// Add root
+		cs.Add(bitstr.Key(""), 100)
+		require.Equal(t, 1, cs.Count(), "should have 1 entry")
+		require.Equal(t, int64(100), cs.Sum(), "sum should be 100")
+
+		// Add first child - goes to queue
+		cs.Add(bitstr.Key("0"), 30)
+		// Queue doesn't fully cover yet
+		require.Equal(t, 1, cs.Count(), "should still have 1 entry (incomplete coverage)")
+		require.Equal(t, int64(100), cs.Sum(), "sum should still be 100")
+
+		// Add second child - achieves full coverage at root level
+		cs.Add(bitstr.Key("1"), 40)
+
+		// Now root is replaced with queue entries
+		require.Equal(t, 2, cs.Count(), "should have 2 entries after full coverage")
+		require.Equal(t, int64(70), cs.Sum(), "sum should be 70")
+	})
+}
+
+func TestCycleStatsCleanupWithDifferentDeadlines(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		// Test cleanup behavior with different deadline durations
+		maxDelay := time.Millisecond
+		cs := NewCycleStats(maxDelay)
+
+		// Add entries at different times
+		cs.Add(bitstr.Key("0"), 10)
+		time.Sleep(3 * time.Millisecond)
+		cs.Add(bitstr.Key("1"), 20)
+		time.Sleep(3 * time.Millisecond)
+		cs.Add(bitstr.Key("00"), 30) // Child of "0", goes to queue
+
+		require.Equal(t, 2, cs.Count(), "should have 2 entries in main trie")
+
+		// Cleanup with short deadline - only oldest entry expires
+		cs.Cleanup(4 * time.Millisecond)
+
+		// "0" expired and "00" promoted from queue, "1" still there
+		require.Equal(t, 2, cs.Count(), "should have 2 entries")
+		require.Contains(t, []int64{50, 50}, cs.Sum(), "sum should be 50")
+
+		// Cleanup with longer deadline - nothing else expires
+		cs.Cleanup(10 * time.Millisecond)
+		require.Equal(t, 2, cs.Count(), "should still have 2 entries")
+	})
+}
+
+func TestCycleStatsQueueDeduplicationWithinMaxDelay(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		// Test that queue entries within maxDelay window don't duplicate
+		maxDelay := 100 * time.Millisecond
+		cs := NewCycleStats(maxDelay)
+
+		// Add parent
+		cs.Add(bitstr.Key("0"), 100)
+		require.Equal(t, 1, cs.Count(), "should have 1 entry")
+		require.Equal(t, int64(100), cs.Sum(), "sum should be 100")
+
+		// Add child that goes to queue
+		cs.Add(bitstr.Key("00"), 30)
+		require.Equal(t, 1, cs.Count(), "parent still in main trie")
+		require.Equal(t, int64(100), cs.Sum(), "sum still 100 (queue not visible)")
+
+		// Try to add another entry for same prefix within maxDelay
+		// This should be skipped due to maxDelay check
+		cs.Add(bitstr.Key("00"), 40)
+		require.Equal(t, 1, cs.Count(), "should still have 1 entry")
+		require.Equal(t, int64(100), cs.Sum(), "sum still 100 (duplicate rejected)")
+
+		// Wait past maxDelay, then cleanup with a deadline that expires the parent
+		time.Sleep(150 * time.Millisecond)
+		cs.Cleanup(120 * time.Millisecond)
+
+		// Parent expired (added 150ms ago, deadline 120ms) and queued entry is promoted
+		// Queue had "00"->30 (the first add), the duplicate "00"->40 was rejected by maxDelay
+		require.Equal(t, 1, cs.Count(), "should have 1 entry (queue promoted)")
+		require.Equal(t, int64(30), cs.Sum(), "sum should be 30 (queued entry promoted)")
+	})
 }

--- a/provider/internal/timeseries/doc.go
+++ b/provider/internal/timeseries/doc.go
@@ -1,20 +1,22 @@
-// Package timeseries provides time-windowed data structures for collecting
-// and analyzing performance metrics in the libp2p Kademlia DHT provider.
+// Package timeseries provides time-windowed data structures for collecting and
+// analyzing performance metrics in the libp2p Kademlia DHT provider.
 //
 // This package contains three main types of time series collectors:
 //
 // IntTimeSeries maintains a rolling window of integer values with automatic
-// cleanup of expired entries. It's used for tracking counts and durations
-// over time, such as the number of keys provided or operation durations.
+// cleanup of expired entries. It's used for tracking counts and durations over
+// time, such as the number of keys provided or operation durations.
 //
-// FloatTimeSeries maintains a rolling window of weighted float values,
-// useful for computing weighted averages. Each entry has a value and a
-// weight, allowing for more sophisticated statistical calculations.
+// FloatTimeSeries maintains a rolling window of weighted float values, useful
+// for computing weighted averages. Each entry has a value and a weight,
+// allowing for more sophisticated statistical calculations.
 //
-// CycleStats tracks statistics organized by keyspace prefixes with TTL-based
-// cleanup. It uses a trie structure to efficiently aggregate statistics
-// across different regions of the DHT keyspace. This is particularly useful
-// for tracking reprovide operations that cover different keyspace regions.
+// CycleStats tracks statistics organized by keyspace prefixes with
+// deadline-based cleanup. It uses a trie structure to efficiently aggregate
+// statistics across different regions of the DHT keyspace. This is
+// particularly useful for tracking reprovide operations that cover different
+// keyspace regions. The cleanup deadline is provided dynamically, allowing
+// adaptive retention based on actual reprovide cycle durations.
 //
 // All types are thread-safe and designed for high-frequency updates with
 // minimal lock contention. The retention periods are configurable and
@@ -34,7 +36,8 @@
 //	weightedAvg := averages.Avg()
 //
 //	// Track keyspace region statistics
-//	stats := NewCycleStats(time.Hour, time.Minute)
+//	stats := NewCycleStats(time.Minute)
 //	stats.Add("101", 42) // prefix "101", value 42
+//	stats.Cleanup(2 * time.Hour) // cleanup entries older than 2 hours
 //	total := stats.Sum()
 package timeseries

--- a/provider/stats.go
+++ b/provider/stats.go
@@ -123,17 +123,30 @@ func (s *SweepingProvider) Stats() stats.Stats {
 
 	// Take snapshots of cycle stats data while holding the lock
 	s.stats.cycleStatsLk.Lock()
-	s.stats.keysPerReprovide.Cleanup()
-	s.stats.reprovideDuration.Cleanup()
-	s.stats.peers.Cleanup()
-	s.stats.reachable.Cleanup()
+
+	// We need to clean up the CycleStats with an appropriate deadline. This
+	// deadline should be reprovideInterval + maxReprovideDelay + reprovideDuration.
+	// But since we don't know reprovideDuration yet, we do a two-step cleanup.
+
+	// First, clean up reprovideDuration with 2*reprovideInterval to get an initial average
+	s.stats.reprovideDuration.Cleanup(2 * s.reprovideInterval)
+	reprovideDurationAvg := s.stats.reprovideDuration.Avg()
+
+	// Now calculate the proper deadline: reprovideInterval + maxReprovideDelay + reprovideDuration
+	statsDeadline := s.reprovideInterval + s.maxReprovideDelay + time.Duration(reprovideDurationAvg)
+
+	// Clean up all CycleStats with the calculated deadline
+	s.stats.reprovideDuration.Cleanup(statsDeadline)
+	s.stats.keysPerReprovide.Cleanup(statsDeadline)
+	s.stats.peers.Cleanup(statsDeadline)
+	s.stats.reachable.Cleanup(statsDeadline)
 
 	// Capture data for calculations outside the lock
 	keysPerProvideSum := s.stats.keysPerProvide.Sum()
 	provideDurationSum := s.stats.provideDuration.Sum()
 	keysPerReprovideSum := s.stats.keysPerReprovide.Sum()
 	reprovideDurationSum := s.stats.reprovideDuration.Sum()
-	reprovideDurationAvg := s.stats.reprovideDuration.Avg()
+	reprovideDurationAvg = s.stats.reprovideDuration.Avg()
 	keysPerReprovideAvg := s.stats.keysPerReprovide.Avg()
 	reprovideDurationCount := s.stats.reprovideDuration.Count()
 	peersSum := s.stats.peers.Sum()
@@ -216,10 +229,10 @@ func newOperationStats(reprovideInterval, maxDelay time.Duration) operationStats
 		regionSize:      timeseries.NewIntTimeSeries(reprovideInterval),
 		avgHolders:      timeseries.NewFloatTimeSeries(reprovideInterval),
 
-		keysPerReprovide:  timeseries.NewCycleStats(reprovideInterval, maxDelay),
-		reprovideDuration: timeseries.NewCycleStats(reprovideInterval, maxDelay),
-		peers:             timeseries.NewCycleStats(reprovideInterval, maxDelay),
-		reachable:         timeseries.NewCycleStats(reprovideInterval, maxDelay),
+		keysPerReprovide:  timeseries.NewCycleStats(maxDelay),
+		reprovideDuration: timeseries.NewCycleStats(maxDelay),
+		peers:             timeseries.NewCycleStats(maxDelay),
+		reachable:         timeseries.NewCycleStats(maxDelay),
 	}
 }
 


### PR DESCRIPTION
## Problem

The `FullyCovered` metric could incorrectly report false even with complete keyspace coverage because entries expired after a fixed `ttl + maxDelay`, but actual reprovide operations can take significantly longer than `maxDelay`. When regions are reprovided with scheduling jitter (up to `maxReprovideDelay`) and the actual reprovide operation duration varies, entries could expire mid-cycle before the keyspace traversal completes, leading to incomplete statistics and inaccurate coverage metrics.

Other metrics can also be off/shifted.

## Proposed solution

The deadline is now calculated as `reprovideInterval + maxReprovideDelay + reprovideDuration` to ensure entries survive for:
  - One complete reprovide interval
  - Maximum scheduling delay for when the region gets reprovided
  - The actual measured time it takes to reprovide that region

This adaptive approach ensures data retention matches actual reprovide cycle behavior, preventing premature expiry and maintaining accurate statistics throughout the cycle.

The tradeoff is to keep items slightly longer in the queue, and wait longer before expiring items to be sure not to expire them before we have a potential replacement.