### PR TITLE
refactor(provider): switch to bit256.NewKeyFromArray

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/multiformats/go-multibase v0.2.0
 	github.com/multiformats/go-multihash v0.2.3
 	github.com/multiformats/go-multistream v0.6.1
-	github.com/probe-lab/go-libdht v0.3.0
+	github.com/probe-lab/go-libdht v0.4.0
 	github.com/stretchr/testify v1.11.1
 	github.com/whyrusleeping/go-keyspace v0.0.0-20160322163242-5b898ac5add1
 	go.opentelemetry.io/otel v1.38.0

--- a/go.sum
+++ b/go.sum
@@ -354,8 +354,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/polydawn/refmt v0.89.0 h1:ADJTApkvkeBZsN0tBTx8QjpD9JkmxbKp0cxfr9qszm4=
 github.com/polydawn/refmt v0.89.0/go.mod h1:/zvteZs/GwLtCgZ4BL6CBsk9IKIlexP43ObX9AxTqTw=
-github.com/probe-lab/go-libdht v0.3.0 h1:Q3ZXK8wCjZvgeHSTtRrppXobXY/KHPLZJfc+cdTTyqA=
-github.com/probe-lab/go-libdht v0.3.0/go.mod h1:hamw22kI6YkPQFGy5P6BrWWDrgE9ety5Si8iWAyuDvc=
+github.com/probe-lab/go-libdht v0.4.0 h1:LAqHuko/owRW6+0cs5wmJXbHzg09EUMJEh5DI37yXqo=
+github.com/probe-lab/go-libdht v0.4.0/go.mod h1:hamw22kI6YkPQFGy5P6BrWWDrgE9ety5Si8iWAyuDvc=
 github.com/prometheus/client_golang v0.8.0/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v1.23.2 h1:Je96obch5RDVy3FDMndoUsjAhG5Edi49h0RJWRi/o0o=
 github.com/prometheus/client_golang v1.23.2/go.mod h1:Tb1a6LWHB3/SPIzCoaDXI4I8UHKeFTEQ1YCr+0Gyqmg=

--- a/provider/internal/keyspace/key.go
+++ b/provider/internal/keyspace/key.go
@@ -23,15 +23,13 @@ const KeyLen = bit256.KeyLen * 8 // 256
 // MhToBit256 converts a multihash to a its 256-bit kademlia identifier by
 // hashing it with SHA-256.
 func MhToBit256(h mh.Multihash) bit256.Key {
-	hash := sha256.Sum256(h)
-	return bit256.NewKey(hash[:])
+	return bit256.NewKeyFromArray(sha256.Sum256(h))
 }
 
 // PeerIDToBit256 converts a peer.ID to a its 256-bit kademlia identifier by
 // hashing it with SHA-256.
 func PeerIDToBit256(id peer.ID) bit256.Key {
-	hash := sha256.Sum256([]byte(id))
-	return bit256.NewKey(hash[:])
+	return bit256.NewKeyFromArray(sha256.Sum256([]byte(id)))
 }
 
 // FlipLastBit flips the last bit of the given key.

--- a/provider/internal/keyspace/key_test.go
+++ b/provider/internal/keyspace/key_test.go
@@ -68,15 +68,15 @@ func TestIsBitstrPrefix(t *testing.T) {
 
 func TestKeyToBytes(t *testing.T) {
 	nKeys := 1 << 8
-	buf := make([]byte, 32)
+	var buf [bit256.KeyLen]byte
 	for range nKeys {
-		if _, err := rand.Read(buf); err != nil {
+		if _, err := rand.Read(buf[:]); err != nil {
 			t.Fatal(err)
 		}
-		b256 := bit256.NewKey(buf)
+		b256 := bit256.NewKeyFromArray(buf)
 		bstr := bitstr.Key(key.BitString(b256))
-		require.Equal(t, buf, KeyToBytes(b256))
-		require.Equal(t, buf, KeyToBytes(bstr))
+		require.Equal(t, buf[:], KeyToBytes(b256))
+		require.Equal(t, buf[:], KeyToBytes(bstr))
 	}
 }
 
@@ -116,10 +116,10 @@ func TestKeyToBytesPadding(t *testing.T) {
 
 func TestShortestCoveredPrefix(t *testing.T) {
 	// All keys share CPL of 5, except one sharing a CPL of 4
-	var target [32]byte
+	var target [bit256.KeyLen]byte
 	_, err := rand.Read(target[:])
 	require.NoError(t, err)
-	targetBitstr := bitstr.Key(key.BitString(bit256.NewKey(target[:])))
+	targetBitstr := bitstr.Key(key.BitString(bit256.NewKeyFromArray(target)))
 
 	cpl := 5
 	nPeers := 16

--- a/provider/internal/keyspace/trie_test.go
+++ b/provider/internal/keyspace/trie_test.go
@@ -243,12 +243,12 @@ func TestNextNonEmptyLeafRandom(t *testing.T) {
 	tr := trie.New[bit256.Key, struct{}]()
 	keys := make([]bit256.Key, 0, nKeys)
 
-	var b [32]byte
+	var b [bit256.KeyLen]byte
 	for range nKeys {
 		if _, err := rand.Read(b[:]); err != nil {
 			require.NoError(t, err)
 		}
-		k := bit256.NewKey(b[:])
+		k := bit256.NewKeyFromArray(b)
 		tr.Add(k, struct{}{})
 		keys = append(keys, k)
 
@@ -986,11 +986,11 @@ func TestAllocateToKClosestSingleDest(t *testing.T) {
 }
 
 func genRandBit256() bit256.Key {
-	var b [32]byte
+	var b [bit256.KeyLen]byte
 	if _, err := rand.Read(b[:]); err != nil {
 		panic(err)
 	}
-	return bit256.NewKey(b[:])
+	return bit256.NewKeyFromArray(b)
 }
 
 func TestAllocateToKClosest(t *testing.T) {
@@ -1166,8 +1166,8 @@ func TestRegionsFromPeersSplitting(t *testing.T) {
 
 func TestExtractMinimalRegions(t *testing.T) {
 	replicationFactor := 3
-	selfID := [32]byte{}
-	order := bit256.NewKey(selfID[:])
+	selfID := [bit256.KeyLen]byte{}
+	order := bit256.NewKeyFromArray(selfID)
 
 	prefixes := []bitstr.Key{
 		"00000",

--- a/provider/keystore/keystore.go
+++ b/provider/keystore/keystore.go
@@ -138,7 +138,7 @@ func dsKey[K kad.Key[K]](k K, prefixBits int) ds.Key {
 //
 // Returns the reconstructed 256-bit key or an error if base64URL decoding fails.
 func (s *keystore) decodeKey(dsk string) (bit256.Key, error) {
-	bs := make([]byte, 32)
+	var bs [bit256.KeyLen]byte
 	// Extract individual bits from odd positions (skip '/' separators)
 	for i := range s.prefixBits {
 		if dsk[2*i+1] == '1' {
@@ -150,8 +150,11 @@ func (s *keystore) decodeKey(dsk string) (bit256.Key, error) {
 	if err != nil {
 		return bit256.Key{}, err
 	}
+	if len(decoded) != bit256.KeyLen-(s.prefixBits/8) {
+		return bit256.Key{}, fmt.Errorf("invalid decoded length: expected %d, got %d", keyspace.KeyLen-(s.prefixBits/8), len(decoded))
+	}
 	copy(bs[s.prefixBits/8:], decoded)
-	return bit256.NewKey(bs), nil
+	return bit256.NewKeyFromArray(bs), nil
 }
 
 // worker processes operations sequentially in a single goroutine

--- a/provider/keystore/keystore_test.go
+++ b/provider/keystore/keystore_test.go
@@ -269,11 +269,11 @@ func TestDsKey(t *testing.T) {
 
 	s.prefixBits = 16
 
-	b := [32]byte{}
+	b := [bit256.KeyLen]byte{}
 	for range 1024 {
 		_, err := rand.Read(b[:])
 		require.NoError(t, err)
-		k := bit256.NewKey(b[:])
+		k := bit256.NewKeyFromArray(b)
 
 		sdk := dsKey(k, s.prefixBits)
 		require.Equal(t, s.prefixBits+1, strings.Count(sdk.String(), "/"))

--- a/provider/stats_test.go
+++ b/provider/stats_test.go
@@ -453,9 +453,9 @@ func TestStats(t *testing.T) {
 			balancedKeys[i], err = multihash.FromB58String(k)
 			require.NoError(t, err)
 			// Test that the kadid of keys actually cover all prefixes
-			bs := [32]byte{}
+			bs := [bit256.KeyLen]byte{}
 			bs[0] = byte(i/keysPerPrefix + 1) // +1 because we skip prefix "00000"
-			b256 := bit256.NewKey(bs[:])
+			b256 := bit256.NewKeyFromArray(bs)
 			require.True(t, keyspace.IsPrefix(bitstr.Key(key.BitString(b256)[bitsPerByte-avgPrefixLen:bitsPerByte]), keyspace.MhToBit256(balancedKeys[i])))
 		}
 


### PR DESCRIPTION
* Update to `go-libdht` [v0.4.0](https://github.com/probe-lab/go-libdht/releases/tag/v0.4.0)
  * Memory optimization in `Trie.AddMany()`
* Replace `bit256.NewKey()` to `bit256.NewKeyFromArray()` where relevant.
  * Memory optimization introduced in `go-libdht` [v0.4.0](https://github.com/probe-lab/go-libdht/releases/tag/v0.4.0)