### PR TITLE
feat(provider): connectivity callbacks

### DIFF
--- a/provider/internal/connectivity/options.go
+++ b/provider/internal/connectivity/options.go
@@ -11,8 +11,9 @@ type config struct {
 	onlineCheckInterval time.Duration // minimum check interval when online
 	offlineDelay        time.Duration
 
-	onOffline func()
-	onOnline  func()
+	onOnline       func()
+	onDisconnected func()
+	onOffline      func()
 }
 
 type Option func(opt *config) error
@@ -55,16 +56,23 @@ func WithOfflineDelay(d time.Duration) Option {
 	}
 }
 
-func WithOnOffline(f func()) Option {
+func WithOnOnline(f func()) Option {
 	return func(cfg *config) error {
-		cfg.onOffline = f
+		cfg.onOnline = f
 		return nil
 	}
 }
 
-func WithOnOnline(f func()) Option {
+func WithOnDisconnected(f func()) Option {
 	return func(cfg *config) error {
-		cfg.onOnline = f
+		cfg.onDisconnected = f
+		return nil
+	}
+}
+
+func WithOnOffline(f func()) Option {
+	return func(cfg *config) error {
+		cfg.onOffline = f
 		return nil
 	}
 }

--- a/provider/options.go
+++ b/provider/options.go
@@ -42,6 +42,7 @@ type config struct {
 
 	offlineDelay                    time.Duration
 	connectivityCheckOnlineInterval time.Duration
+	connectivityCallbacks           [3]func()
 
 	peerid peer.ID
 	host   host.Host
@@ -375,6 +376,38 @@ func WithDhtType(dhtType string) Option {
 func WithSkipBootstrapReprovide(skip bool) Option {
 	return func(cfg *config) error {
 		cfg.skipBootstrapReprovide = skip
+		return nil
+	}
+}
+
+// WithConnectivityCallbacks sets the connectivity state change callbacks for
+// the provider's internal connectivity checker state machine.
+//
+// The connectivity checker tracks three states: OFFLINE, DISCONNECTED, and
+// ONLINE. The callbacks are invoked during state transitions:
+//
+//   - onOnline: Called when the node transitions to ONLINE state (from either
+//     OFFLINE or DISCONNECTED). After this callback, the provider measures the
+//     network prefix length and refreshes the reprovide schedule.
+//
+//   - onDisconnected: Called when the node transitions from ONLINE to
+//     DISCONNECTED state (i.e., connectivity check failed while online). No
+//     provider action is triggered for this transition.
+//
+//   - onOffline: Called when the node transitions from DISCONNECTED to OFFLINE
+//     state (after remaining disconnected for OfflineDelay duration). After
+//     this callback, the provider clears the provide queue and invalidates
+//     cached metrics.
+//
+// User-supplied callbacks are invoked before the provider's internal actions.
+// All callbacks should be fast and non-blocking to avoid delaying state
+// transitions and provider operations. Long-running operations should be
+// dispatched to separate goroutines.
+func WithConnectivityCallbacks(onOnline, onDisconnected, onOffline func()) Option {
+	return func(cfg *config) error {
+		cfg.connectivityCallbacks[0] = onOnline
+		cfg.connectivityCallbacks[1] = onDisconnected
+		cfg.connectivityCallbacks[2] = onOffline
 		return nil
 	}
 }


### PR DESCRIPTION
Closes https://github.com/libp2p/go-libp2p-kad-dht/issues/1171

## Summary

Adding user defined callbacks to the `ConnectivityChecker`, so that `SweepingProvider` users can be notified when the connectivity status of the provider changes.

In the end, it was easier to let users define connectivity callbacks rather than extracting the package, and making a new interface. IIUC this should be enough for the requested use case (https://github.com/libp2p/go-libp2p-kad-dht/issues/1171). 

The connectivity state can be tracked using the callbacks, as demonstrated in [this test](https://github.com/libp2p/go-libp2p-kad-dht/blob/257c90f14fe3e155e3c1682f00d41dd4366a1759/provider/provider_test.go#L2004-L2124).

@phillebaba let me know if this satisfies your needs.