### PR TITLE
fix(provider): rename metric to follow OpenTelemetry conventions

### DIFF
--- a/provider/provider.go
+++ b/provider/provider.go
@@ -241,7 +241,7 @@ func New(opts ...Option) (*SweepingProvider, error) {
 	logger := log.Logger(cfg.loggerName)
 	meter := otel.Meter("github.com/libp2p/go-libp2p-kad-dht/provider")
 	providerCounter, err := meter.Int64Counter(
-		"total_provide_count",
+		"provider.provides",
 		metric.WithDescription("Number of successful provides since node is running"),
 	)
 	if err != nil {

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -387,7 +387,7 @@ func noopConnectivityChecker() *connectivity.ConnectivityChecker {
 func provideCounter() metric.Int64Counter {
 	meter := otel.Meter("github.com/libp2p/go-libp2p-kad-dht/provider")
 	provideCounter, err := meter.Int64Counter(
-		"total_provide_count",
+		"provider.provides",
 		metric.WithDescription("Number of successful provides since node is running"),
 	)
 	if err != nil {


### PR DESCRIPTION
Rename `total_provide_count` to `provider.provides` to follow:
- OpenTelemetry's dot notation convention for hierarchical metrics
- Pattern used by all other kad-dht metrics (`rpc.inbound.*`, `rpc.outbound.*`, `network.size`)
- Prometheus naming best practices (no redundant `total` in metric name as flagged by @gammazero  in https://github.com/ipfs/kubo/pull/10955#discussion_r2483006660)


OpenTelemtry→Prometheus behavior:
- Before: `total_provide_count` → exports as `total_provide_count_total` (redundant)
- After: `provider.provides` → exports as `provider_provides_total` (clean, following conventions)

> [!WARNING]
> This is a breaking change for anyone monitoring the old metric name, but sweep is still experimental feature in Kubo and this is last chance to clean this up before people start using this in production dashboards.