### PR TITLE
fix(provider): reduce provide log verbosity

### DIFF
--- a/provider/provider.go
+++ b/provider/provider.go
@@ -1085,7 +1085,7 @@ loop:
 	s.increaseProvideCounter(successfulKeys)
 
 	errCountLoaded := int(errCount.Load())
-	s.logger.Infof("sent provider records to peers in %s, errors %d/%d", time.Since(startTime), errCountLoaded, len(keysAllocations))
+	s.logger.Debugf("sent provider records to peers in %s, errors %d/%d", time.Since(startTime), errCountLoaded, len(keysAllocations))
 	reachablePeers = nPeers - errCountLoaded
 
 	if errCountLoaded == nPeers || errCountLoaded > int(float32(nPeers)*(1-minimalRegionReachablePeersRatio)) {

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -1699,6 +1699,7 @@ func (s *SweepingProvider) batchProvide(prefix bitstr.Key, keys []mh.Multihash) 
 	if keyCount == 0 {
 		return
 	}
+	s.logger.Infof("provide starting for prefix %q, %d keys", prefix, keyCount)
 	s.logger.Debugw("batchProvide called", "prefix", prefix, "count", keyCount)
 	addrInfo, ok := s.selfAddrInfo()
 	if !ok {
@@ -1710,8 +1711,10 @@ func (s *SweepingProvider) batchProvide(prefix bitstr.Key, keys []mh.Multihash) 
 	startTime := time.Now()
 	s.stats.ongoingProvides.start(keyCount)
 	defer func() {
+		elapsed := time.Since(startTime)
 		s.stats.ongoingProvides.finish(len(keys))
-		s.stats.provideDuration.Add(int64(time.Since(startTime)))
+		s.stats.provideDuration.Add(int64(elapsed))
+		s.logger.Infof("provide finished for prefix %q, %d keys in %s", prefix, keyCount, elapsed)
 	}()
 
 	if keyCount <= individualProvideThreshold {
@@ -1764,15 +1767,18 @@ func (s *SweepingProvider) batchReprovide(prefix bitstr.Key) {
 	}
 	keyCount := len(keys)
 	if keyCount == 0 {
-		s.logger.Infof("No keys to reprovide for prefix %s", prefix)
+		s.logger.Infof("no keys to reprovide for prefix %s", prefix)
 		return
 	}
 
+	s.logger.Infof("reprovide starting for prefix %q, %d keys", prefix, keyCount)
 	startTime := time.Now()
 	s.stats.ongoingReprovides.start(keyCount)
 	defer func() {
+		elapsed := time.Since(startTime)
 		s.stats.ongoingReprovides.finish(len(keys))
-		s.stats.reprovideDuration.Add(prefix, int64(time.Since(startTime)))
+		s.stats.reprovideDuration.Add(prefix, int64(elapsed))
+		s.logger.Infof("reprovide finished for prefix %q, %d keys in %s", prefix, keyCount, elapsed)
 	}()
 
 	if keyCount <= individualProvideThreshold {
@@ -1919,6 +1925,12 @@ func (s *SweepingProvider) individualProvide(prefix bitstr.Key, keys []mh.Multih
 // It iterate over supplied regions, and allocates the regions provider records
 // to the appropriate DHT servers.
 func (s *SweepingProvider) provideRegions(regions []keyspace.Region, addrInfo peer.AddrInfo, reprovide bool) bool {
+	op := "provide"
+	if reprovide {
+		op = "reprovide"
+	}
+	s.logger.Debugf("starting %s for %d region(s)", op, len(regions))
+	startTime := time.Now()
 	errCount := 0
 	for _, r := range regions {
 		if r.Keys == nil || r.Keys.IsEmptyLeaf() {
@@ -1972,6 +1984,7 @@ func (s *SweepingProvider) provideRegions(regions []keyspace.Region, addrInfo pe
 		s.increaseProvideCounter(nKeys)
 		s.logger.Debugw("sent provider records", "prefix", r.Prefix, "count", nKeys, "keys", keys)
 	}
+	s.logger.Debugf("finished %s for %d region(s) in %s, errors %d/%d", op, len(regions), time.Since(startTime), errCount, len(regions))
 	// If at least 1 regions was provided, we don't consider it a failure.
 	return errCount < len(regions)
 }


### PR DESCRIPTION
The per-batch "sent provider records to peers" message is too noisy at INFO level.


@guillaumemichel would it be ok to move it to DEBUG so we can see events like keystore rottation without being spammed by the provide heartbeat, and print some higher level region INFO instead?

### Before

Current state with `GOLOG_LOG_LEVEL=error,dht/provider=info`:

```
2026-04-11T00:22:17.384Z	INFO	dht/provider	provider/provider.go:1088	sent provider records to peers in 237.507µs, errors 2/20
2026-04-11T00:22:18.154Z	INFO	dht/provider	provider/provider.go:1088	sent provider records to peers in 778.617406ms, errors 1/20
2026-04-11T00:22:18.704Z	INFO	dht/provider	provider/provider.go:1088	sent provider records to peers in 11.005147ms, errors 0/20
2026-04-11T00:22:19.703Z	INFO	dht/provider	provider/provider.go:1088	sent provider records to peers in 235.514µs, errors 3/20
2026-04-11T00:22:22.370Z	INFO	dht/provider	provider/provider.go:1088	sent provider records to peers in 144.031µs, errors 0/20
2026-04-11T00:22:22.754Z	INFO	dht/provider	keystore/resettable_keystore.go:427	keystore: swapped active namespace to 1 (size=2975510)
2026-04-11T00:22:22.759Z	INFO	dht/provider	keystore/resettable_keystore.go:390	keystore: removing old datastore 0
2026-04-11T00:22:22.759Z	INFO	core:constructor	node/provider.go:641	provider keystore: removing datastore from disk	{"suffix": "0", "path": "/data/ipfs/provider-keystore/0"}
2026-04-11T00:22:22.759Z	INFO	dht/provider	keystore/resettable_keystore.go:471	keystore: ResetCids finished in 46.990450129s
2026-04-11T00:22:22.761Z	INFO	core:constructor	node/provider.go:854	provider keystore sync completed	{"strategy": "all"}
2026-04-11T00:22:24.569Z	INFO	dht/provider	provider/provider.go:1088	sent provider records to peers in 408.399µs, errors 2/20
2026-04-11T00:22:25.266Z	INFO	dht/provider	provider/provider.go:1088	sent provider records to peers in 236.986µs, errors 3/20
2026-04-11T00:22:26.564Z	INFO	dht/provider	provider/provider.go:1088	sent provider records to peers in 10.000339889s, errors 3/20
2026-04-11T00:22:28.388Z	INFO	dht/provider	provider/provider.go:1088	sent provider records to peers in 6.945118278s, errors 0/20
2026-04-11T00:22:28.946Z	INFO	dht/provider	provider/provider.go:1088	sent provider records to peers in 6.862113414s, errors 0/20
2026-04-11T00:22:30.320Z	INFO	dht/provider	provider/provider.go:1088	sent provider records to peers in 165.411µs, errors 1/20
```

## After

Details land in DEBUG, higher level units of work in INFO:

```
INFO  reprovide starting for prefix "0110", 140 keys
DEBUG reprovide: requested prefix '0110' (len 4), prefix covered '01' (len 2)
DEBUG starting reprovide for 3 region(s)
DEBUG sent provider records to peers in 284ms, errors 0/20
DEBUG sent provider records to peers in 5.8s, errors 0/20
DEBUG sent provider records to peers in 274µs, errors 0/20
DEBUG finished reprovide for 3 region(s) in 6.1s, errors 0/3
INFO  reprovide finished for prefix "0110", 140 keys in 6.3s
```