### PR TITLE
fix: data race on AddrInfo.Addrs in queryPeer

### DIFF
--- a/query.go
+++ b/query.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"slices"
 	"sync"
 	"time"
 
@@ -451,17 +452,20 @@ func (q *query) queryPeer(ctx context.Context, ch chan<- *queryUpdate, p peer.ID
 			continue
 		}
 
-		// add any other know addresses for the candidate peer.
+		// Combine addresses from the response with any we already know
+		// for this peer. Build a fresh slice: next may be aliased by the
+		// caller (e.g. routing.QueryEvent.Responses) and mutating its
+		// Addrs races with consumers that serialize events.
 		curInfo := q.dht.peerstore.PeerInfo(next.ID)
-		next.Addrs = append(next.Addrs, curInfo.Addrs...)
+		addrs := slices.Concat(next.Addrs, curInfo.Addrs)
 
 		// add their addresses to the dialer's peerstore
 		//
 		// add the next peer to the query if matches the query target even if it would otherwise fail the query filter
 		// TODO: this behavior is really specific to how FindPeer works and not GetClosestPeers or any other function
 		isTarget := string(next.ID) == q.key
-		if isTarget || q.dht.queryPeerFilter(q.dht, *next) {
-			q.dht.maybeAddAddrs(next.ID, next.Addrs, pstore.TempAddrTTL)
+		if isTarget || q.dht.queryPeerFilter(q.dht, peer.AddrInfo{ID: next.ID, Addrs: addrs}) {
+			q.dht.maybeAddAddrs(next.ID, addrs, pstore.TempAddrTTL)
 			saw = append(saw, next.ID)
 		}
 	}

--- a/query.go
+++ b/query.go
@@ -25,10 +25,19 @@ import (
 // ErrNoPeersQueried is returned when we failed to connect to any peers.
 var ErrNoPeersQueried = errors.New("failed to query any peers")
 
-type (
-	queryFn func(context.Context, peer.ID) ([]*peer.AddrInfo, error)
-	stopFn  func(*qpeerset.QueryPeerset) bool
-)
+// queryFn runs once per peer visited in a DHT lookup. The returned
+// slice is the "heard" set the worker follows up on, and is commonly
+// also published via routing.QueryEvent.Responses.
+//
+// The returned slice and the AddrInfo values it points at are
+// read-only: mutating them (e.g. appending to AddrInfo.Addrs) races
+// with any RegisterForQueryEvents consumer reading the published
+// event.
+type queryFn func(context.Context, peer.ID) ([]*peer.AddrInfo, error)
+
+// stopFn decides whether a lookup has collected enough results and
+// can terminate early.
+type stopFn func(*qpeerset.QueryPeerset) bool
 
 // query represents a single DHT query.
 type query struct {
@@ -452,10 +461,15 @@ func (q *query) queryPeer(ctx context.Context, ch chan<- *queryUpdate, p peer.ID
 			continue
 		}
 
-		// Combine addresses from the response with any we already know
-		// for this peer. Build a fresh slice: next may be aliased by the
-		// caller (e.g. routing.QueryEvent.Responses) and mutating its
-		// Addrs races with consumers that serialize events.
+		// A RegisterForQueryEvents consumer may be reading next.Addrs
+		// right now: the same *peer.AddrInfo is published on
+		// routing.QueryEvent.Responses. Don't use append:
+		//   - with spare capacity, append writes into next.Addrs's
+		//     backing array, which the consumer still holds.
+		//   - writing the result back to next.Addrs races on the slice
+		//     header (three words, torn read/write).
+		// slices.Concat always allocates a fresh backing array, so our
+		// addrs don't share memory with the consumer's view.
 		curInfo := q.dht.peerstore.PeerInfo(next.ID)
 		addrs := slices.Concat(next.Addrs, curInfo.Addrs)
 

--- a/query_event_race_test.go
+++ b/query_event_race_test.go
@@ -31,6 +31,10 @@ import (
 // Under -race the test reports a read/write race on AddrInfo.Addrs.
 // Without -race the torn slice header can crash inside go-multiaddr.
 func TestFindProvidersAsyncQueryEventResponsesRace(t *testing.T) {
+	if testing.Short() {
+		// Hammers FindProvidersAsync for several seconds to expose a data race.
+		t.SkipNow()
+	}
 	ctx := t.Context()
 	dhts := setupDHTS(t, ctx, 2)
 	connect(t, ctx, dhts[0], dhts[1])

--- a/query_event_race_test.go
+++ b/query_event_race_test.go
@@ -1,0 +1,112 @@
+package dht
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/ipfs/go-cid"
+	"github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/peerstore"
+	"github.com/libp2p/go-libp2p/core/routing"
+	ma "github.com/multiformats/go-multiaddr"
+	"github.com/multiformats/go-multihash"
+	"github.com/stretchr/testify/require"
+
+	pb "github.com/libp2p/go-libp2p-kad-dht/pb"
+)
+
+// TestFindProvidersAsyncQueryEventResponsesRace reproduces the race
+// reported in ipfs/kubo#11287 and ipfs/kubo#11116.
+//
+// The same []*peer.AddrInfo is both:
+//  1. published as routing.QueryEvent.Responses by findProvidersAsyncRoutine
+//     in routing.go (read by any RegisterForQueryEvents consumer, e.g.
+//     kubo's findprovs HTTP handler which json-marshals events); and
+//  2. returned to the query worker which, in queryPeer (query.go), does
+//     next.Addrs = append(next.Addrs, dht.peerstore.PeerInfo(next.ID).Addrs...)
+//
+// Under -race the test reports a read/write race on AddrInfo.Addrs.
+// Without -race the torn slice header can crash inside go-multiaddr.
+func TestFindProvidersAsyncQueryEventResponsesRace(t *testing.T) {
+	ctx := t.Context()
+	dhts := setupDHTS(t, ctx, 2)
+	connect(t, ctx, dhts[0], dhts[1])
+
+	// Build fake "closer" peers. Each arrives on the wire with a small
+	// Addrs slice; dhts[0]'s peerstore carries additional addresses for
+	// the same peer IDs so queryPeer's append triggers a realloc and
+	// rewrites each AddrInfo.Addrs header (the data being raced on).
+	const numCloser = 16
+	fakeCloser := make([]peer.AddrInfo, numCloser)
+	extra := []ma.Multiaddr{
+		ma.StringCast("/ip4/10.0.0.1/tcp/4001"),
+		ma.StringCast("/ip4/10.0.0.2/udp/4001/quic-v1"),
+		ma.StringCast("/ip4/10.0.0.3/tcp/4001"),
+		ma.StringCast("/ip4/10.0.0.4/udp/4001/quic-v1"),
+	}
+	for i := range fakeCloser {
+		_, pub, err := crypto.GenerateKeyPair(crypto.Ed25519, 256)
+		require.NoError(t, err)
+		pid, err := peer.IDFromPublicKey(pub)
+		require.NoError(t, err)
+		fakeCloser[i] = peer.AddrInfo{
+			ID: pid,
+			Addrs: []ma.Multiaddr{
+				ma.StringCast("/ip4/1.2.3.4/tcp/4001"),
+				ma.StringCast("/ip4/5.6.7.8/udp/4001/quic-v1"),
+			},
+		}
+		dhts[0].peerstore.AddAddrs(pid, extra, peerstore.TempAddrTTL)
+	}
+
+	// Make every GET_PROVIDERS return fakeCloser as CloserPeers. This
+	// removes dependence on dhts[1]'s real routing table and ensures the
+	// queryFn closure always has a non-trivial slice to publish.
+	dhts[0].protoMessenger, _ = pb.NewProtocolMessenger(&testMessageSender{
+		sendRequest: func(_ context.Context, _ peer.ID, req *pb.Message) (*pb.Message, error) {
+			require.Equal(t, pb.Message_GET_PROVIDERS, req.Type)
+			resp := pb.NewMessage(req.Type, req.Key, 0)
+			resp.CloserPeers = pb.RawPeerInfosToPBPeers(fakeCloser)
+			return resp, nil
+		},
+	})
+
+	mh, err := multihash.Sum([]byte("race-me"), multihash.SHA2_256, -1)
+	require.NoError(t, err)
+	key := cid.NewCidV1(cid.Raw, mh)
+
+	// Subscribe to query events on the context we pass into
+	// FindProvidersAsync, then marshal every PeerResponse to mimic the
+	// kubo findprovs handler.
+	subCtx, events := routing.RegisterForQueryEvents(ctx)
+	consumerDone := make(chan struct{})
+	go func() {
+		defer close(consumerDone)
+		for ev := range events {
+			if ev.Type != routing.PeerResponse {
+				continue
+			}
+			for _, pi := range ev.Responses {
+				_, _ = json.Marshal(pi)
+			}
+		}
+	}()
+
+	// Hammer FindProvidersAsync for a few seconds; each call emits at
+	// least one PeerResponse whose Responses slice queryPeer mutates.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		callCtx, cancel := context.WithTimeout(subCtx, 500*time.Millisecond)
+		for range dhts[0].FindProvidersAsync(callCtx, key, 0) {
+		}
+		cancel()
+	}
+
+	// Cancelling the parent context closes the event channel; wait for
+	// the consumer so t.Cleanup sees a quiet goroutine set.
+	// (The routing package closes the channel when subCtx is done.)
+	t.Cleanup(func() { <-consumerDone })
+}


### PR DESCRIPTION
## The race

`findProvidersAsyncRoutine` (and the `GetValue` / `FindPeer`) hand the same `[]*peer.AddrInfo` to two places:

1. `routing.QueryEvent.Responses`, observed by any `RegisterForQueryEvents` subscriber (e.g. handlers that `json.Marshal` the event).
2. `queryPeer` in `query.go`, which did `next.Addrs = append(next.Addrs, ...)`.

Two goroutines end up writing and reading the same `AddrInfo.Addrs` slice header. Under `-race` the detector flags the conflict; without `-race`, a torn slice header can crash inside `go-multiaddr` when the consumer walks `Addrs`.

Refs: ipfs/kubo#11287, ipfs/kubo#11116

## The fix

> [!NOTE]
> This class of errors could be fixed by upstream https://github.com/libp2p/go-libp2p/pull/3490, but I also believe we should do this PR (belt-and-suspenders) so we don't wait for go-libp2p release or are hit by a future refactor there.

In `queryPeer`, build a fresh slice with `slices.Concat(next.Addrs, curInfo.Addrs)` instead of mutating `next.Addrs`. The combined addresses are passed to `queryPeerFilter` and `maybeAddAddrs`; the published `*peer.AddrInfo` is no longer touched.

`slices.Concat` is preferred over `append`: with spare capacity, `append` would reuse `next.Addrs`'s backing array, which the consumer still references. `slices.Concat` always allocates a fresh array, so no memory is shared with the published event.

Also documents the read-only contract on the `queryFn` type so LLMs and humans avoid introducing regressions that mutate.

## Tests

- [x] New `TestFindProvidersAsyncQueryEventResponsesRace` drives real `FindProvidersAsync` against an intercepted `protoMessenger`. 
  - [x] Fails on `master` under `-race`, 
  - [x] passes on this branch.
- [x] Full package suite passes under `-race`.