### PR TITLE
feat(provider): allow WithReprovideInterval(0) for burst-only mode

### DIFF
--- a/provider/dual/options.go
+++ b/provider/dual/options.go
@@ -157,8 +157,8 @@ func WithDatastoreWAN(ds datastore.Batching) Option {
 
 func withReprovideInterval(reprovideInterval time.Duration, dhts ...uint8) Option {
 	return func(cfg *config) error {
-		if reprovideInterval <= 0 {
-			return fmt.Errorf("reprovide interval must be positive, got %s", reprovideInterval)
+		if reprovideInterval < 0 {
+			return fmt.Errorf("reprovide interval must be >= 0 (use 0 to disable the schedule), got %s", reprovideInterval)
 		}
 		for _, dht := range dhts {
 			cfg.reprovideInterval[dht] = reprovideInterval
@@ -167,14 +167,23 @@ func withReprovideInterval(reprovideInterval time.Duration, dhts ...uint8) Optio
 	}
 }
 
+// WithReprovideInterval sets the reprovide interval for both the LAN and
+// WAN providers. See [provider.WithReprovideInterval] for the no-schedule
+// (burst-only) semantics when set to 0.
 func WithReprovideInterval(reprovideInterval time.Duration) Option {
 	return withReprovideInterval(reprovideInterval, lanID, wanID)
 }
 
+// WithReprovideIntervalLAN sets the reprovide interval for the LAN
+// provider. See [provider.WithReprovideInterval] for the no-schedule
+// (burst-only) semantics when set to 0.
 func WithReprovideIntervalLAN(reprovideInterval time.Duration) Option {
 	return withReprovideInterval(reprovideInterval, lanID)
 }
 
+// WithReprovideIntervalWAN sets the reprovide interval for the WAN
+// provider. See [provider.WithReprovideInterval] for the no-schedule
+// (burst-only) semantics when set to 0.
 func WithReprovideIntervalWAN(reprovideInterval time.Duration) Option {
 	return withReprovideInterval(reprovideInterval, wanID)
 }

--- a/provider/options.go
+++ b/provider/options.go
@@ -132,10 +132,28 @@ func WithReplicationFactor(n int) Option {
 }
 
 // WithReprovideInterval sets the interval at which regions are reprovided.
+//
+// Set to 0 to disable the periodic reprovide schedule entirely. In that
+// no-schedule mode the SweepingProvider runs in burst-only operation:
+//
+//   - ProvideOnce and StartProviding continue to publish provider records
+//     to the DHT immediately, via the burst worker pool.
+//   - StartProviding collapses to ProvideOnce semantics: keys are
+//     published immediately but NOT persisted in the keystore. Without a
+//     schedule, persisting keys would only grow the keystore on disk
+//     without any reader to consume them.
+//   - No schedule is constructed, no periodic reprovide loop runs, and
+//     AddToSchedule and RefreshSchedule become no-ops.
+//
+// Use the no-schedule mode when an external system is responsible for
+// driving reprovides (for example, by calling ProvideOnce on a custom
+// schedule), or when only one-shot ad-hoc announcements are wanted.
+//
+// Negative durations are rejected.
 func WithReprovideInterval(d time.Duration) Option {
 	return func(cfg *config) error {
-		if d <= 0 {
-			return errors.New("provider config: reprovide interval must be greater than 0")
+		if d < 0 {
+			return errors.New("provider config: reprovide interval must be >= 0 (use 0 to disable the schedule)")
 		}
 		cfg.reprovideInterval = d
 		return nil

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -572,10 +572,6 @@ func (s *SweepingProvider) reschedulePrefix(prefix bitstr.Key) {
 // If the supplied prefix is the next prefix to be reprovided, update the
 // schedule cursor and timer.
 func (s *SweepingProvider) schedulePrefixNoLock(prefix bitstr.Key, justReprovided bool) {
-	if !s.scheduleEnabled() {
-		// No-schedule mode: do not build or maintain a schedule.
-		return
-	}
 	nextReprovideTime := s.reprovideTimeForPrefix(prefix)
 	if justReprovided {
 		// Schedule next reprovide given that the prefix was just reprovided on
@@ -638,11 +634,8 @@ func (s *SweepingProvider) currentTimeOffset() time.Duration {
 }
 
 // timeOffset returns the time offset in the reprovide cycle for the given
-// time. In no-schedule mode there is no cycle, so this returns 0.
+// time.
 func (s *SweepingProvider) timeOffset(t time.Time) time.Duration {
-	if !s.scheduleEnabled() {
-		return 0
-	}
 	return t.Sub(s.cycleStart) % s.reprovideInterval
 }
 
@@ -652,12 +645,8 @@ func (s *SweepingProvider) timeUntil(d time.Duration) time.Duration {
 }
 
 // timeBetween returns the duration between the two provided offsets, assuming
-// it is no more than s.reprovideInterval. In no-schedule mode there is no
-// cycle so this returns 0.
+// it is no more than s.reprovideInterval.
 func (s *SweepingProvider) timeBetween(from, to time.Duration) time.Duration {
-	if !s.scheduleEnabled() {
-		return 0
-	}
 	return (to-from+s.reprovideInterval-1)%s.reprovideInterval + 1
 }
 

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -1305,13 +1305,6 @@ func (s *SweepingProvider) handleProvide(force, reprovide bool, keys ...mh.Multi
 	if len(keys) == 0 {
 		return
 	}
-	if reprovide && !s.scheduleEnabled() {
-		// No-schedule mode: persisting keys to the keystore would only grow
-		// disk state with no reader to consume it (no schedule, no reprovide
-		// cycle). Collapse to ProvideOnce semantics: publish now, do not
-		// persist.
-		reprovide = false
-	}
 	if reprovide {
 		// Add keys to list of keys to be reprovided. Returned keys are deduplicated
 		// newly added keys.
@@ -2082,7 +2075,7 @@ func (s *SweepingProvider) StartProviding(force bool, keys ...mh.Multihash) erro
 	if s.closed() {
 		return ErrClosed
 	}
-	s.handleProvide(force, true, keys...)
+	s.handleProvide(force, s.scheduleEnabled(), keys...)
 	return nil
 }
 

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -2075,11 +2075,15 @@ func (s *SweepingProvider) StopProviding(keys ...mh.Multihash) error {
 	if s.closed() {
 		return ErrClosed
 	}
+	s.provideQueue.Remove(keys...)
+	if !s.scheduleEnabled() {
+		// No-schedule mode: keystore is empty, nothing to remove.
+		return nil
+	}
 	err := s.keystore.Delete(s.ctx, keys...)
 	if err != nil {
 		err = fmt.Errorf("failed to stop providing keys: %w", err)
 	}
-	s.provideQueue.Remove(keys...)
 	return err
 }
 

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -214,6 +214,11 @@ type SweepingProvider struct {
 }
 
 // New creates a new SweepingProvider instance with the supplied options.
+//
+// When [WithReprovideInterval] is set to 0, the provider operates in
+// no-schedule (burst-only) mode: ProvideOnce and StartProviding still
+// publish records to the DHT, but no schedule is built and no periodic
+// reprovide loop runs. See [WithReprovideInterval] for details.
 func New(opts ...Option) (*SweepingProvider, error) {
 	cfg, err := getOpts(opts)
 	if err != nil {
@@ -534,6 +539,15 @@ func (s *SweepingProvider) closed() bool {
 	}
 }
 
+// scheduleEnabled reports whether the periodic reprovide schedule is
+// active. It is false when the provider was constructed with
+// WithReprovideInterval(0); in that no-schedule mode immediate provides
+// (StartProviding, ProvideOnce) still publish records, but no schedule
+// is built and no periodic reprovide loop runs.
+func (s *SweepingProvider) scheduleEnabled() bool {
+	return s.reprovideInterval > 0
+}
+
 // scheduleNextReprovideNoLock makes sure the scheduler wakes up in
 // `timeUntilReprovide` to reprovide the region identified by `prefix`.
 func (s *SweepingProvider) scheduleNextReprovideNoLock(prefix bitstr.Key, timeUntilReprovide time.Duration) {
@@ -558,6 +572,10 @@ func (s *SweepingProvider) reschedulePrefix(prefix bitstr.Key) {
 // If the supplied prefix is the next prefix to be reprovided, update the
 // schedule cursor and timer.
 func (s *SweepingProvider) schedulePrefixNoLock(prefix bitstr.Key, justReprovided bool) {
+	if !s.scheduleEnabled() {
+		// No-schedule mode: do not build or maintain a schedule.
+		return
+	}
 	nextReprovideTime := s.reprovideTimeForPrefix(prefix)
 	if justReprovided {
 		// Schedule next reprovide given that the prefix was just reprovided on
@@ -620,8 +638,11 @@ func (s *SweepingProvider) currentTimeOffset() time.Duration {
 }
 
 // timeOffset returns the time offset in the reprovide cycle for the given
-// time.
+// time. In no-schedule mode there is no cycle, so this returns 0.
 func (s *SweepingProvider) timeOffset(t time.Time) time.Duration {
+	if !s.scheduleEnabled() {
+		return 0
+	}
 	return t.Sub(s.cycleStart) % s.reprovideInterval
 }
 
@@ -631,8 +652,12 @@ func (s *SweepingProvider) timeUntil(d time.Duration) time.Duration {
 }
 
 // timeBetween returns the duration between the two provided offsets, assuming
-// it is no more than s.reprovideInterval.
+// it is no more than s.reprovideInterval. In no-schedule mode there is no
+// cycle so this returns 0.
 func (s *SweepingProvider) timeBetween(from, to time.Duration) time.Duration {
+	if !s.scheduleEnabled() {
+		return 0
+	}
 	return (to-from+s.reprovideInterval-1)%s.reprovideInterval + 1
 }
 
@@ -1279,6 +1304,13 @@ func (s *SweepingProvider) handleReprovide() {
 func (s *SweepingProvider) handleProvide(force, reprovide bool, keys ...mh.Multihash) {
 	if len(keys) == 0 {
 		return
+	}
+	if reprovide && !s.scheduleEnabled() {
+		// No-schedule mode: persisting keys to the keystore would only grow
+		// disk state with no reader to consume it (no schedule, no reprovide
+		// cycle). Collapse to ProvideOnce semantics: publish now, do not
+		// persist.
+		reprovide = false
 	}
 	if reprovide {
 		// Add keys to list of keys to be reprovided. Returned keys are deduplicated
@@ -2037,6 +2069,10 @@ func (s *SweepingProvider) ProvideOnce(keys ...mh.Multihash) error {
 // StopProviding is called for the same keys or user defined garbage collection
 // deletes the keys.
 //
+// When the provider is in no-schedule mode ([WithReprovideInterval] = 0),
+// StartProviding behaves identically to ProvideOnce: keys are published
+// to the DHT immediately but NOT persisted in the keystore.
+//
 // Returns an error if the keys could not be added to the provide queue. This
 // can happen if the provider is closed or if the node is currently Offline
 // (either never bootstrapped, or disconnected since more than `OfflineDelay`).
@@ -2080,6 +2116,9 @@ func (s *SweepingProvider) Clear() int {
 // AddToSchedule makes sure the prefixes associated with the supplied keys are
 // scheduled to be reprovided.
 //
+// In no-schedule mode ([WithReprovideInterval] = 0) this is a no-op and
+// returns nil.
+//
 // Returns an error if the provider is closed or if the node is currently
 // Offline (either never bootstrapped, or disconnected since more than
 // `OfflineDelay`). The schedule depends on the network size, hence recent
@@ -2087,6 +2126,10 @@ func (s *SweepingProvider) Clear() int {
 func (s *SweepingProvider) AddToSchedule(keys ...mh.Multihash) error {
 	if s.closed() {
 		return ErrClosed
+	}
+	if !s.scheduleEnabled() {
+		// No-schedule mode: nothing to schedule.
+		return nil
 	}
 	if !s.isOffline() {
 		// If node is offline, the schedule will be refreshed when the node
@@ -2104,6 +2147,9 @@ func (s *SweepingProvider) AddToSchedule(keys ...mh.Multihash) error {
 // This is done automatically during the reprovide operation if a region has no
 // keys.
 //
+// In no-schedule mode ([WithReprovideInterval] = 0) this is a no-op and
+// returns nil.
+//
 // Returns an error if the provider is closed or if the node is currently
 // Offline (either never bootstrapped, or disconnected since more than
 // `OfflineDelay`). The schedule depends on the network size, hence recent
@@ -2111,6 +2157,10 @@ func (s *SweepingProvider) AddToSchedule(keys ...mh.Multihash) error {
 func (s *SweepingProvider) RefreshSchedule() error {
 	if s.closed() {
 		return ErrClosed
+	}
+	if !s.scheduleEnabled() {
+		// No-schedule mode: nothing to refresh.
+		return nil
 	}
 	// Look for prefixes not included in the schedule
 	s.scheduleLk.Lock()

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -1057,6 +1057,134 @@ func TestStartProvidingSingle(t *testing.T) {
 	})
 }
 
+func TestNoScheduleMode(t *testing.T) {
+	t.Run("WithReprovideInterval(0) constructs successfully", func(t *testing.T) {
+		pid, err := peer.Decode("12BoooooPEER")
+		require.NoError(t, err)
+
+		prov, err := New(
+			WithPeerID(pid),
+			WithRouter(&mockRouter{
+				getClosestPeersFunc: func(_ context.Context, _ string) ([]peer.ID, error) {
+					return []peer.ID{pid}, nil
+				},
+			}),
+			WithMessageSender(&mockMsgSender{
+				sendMessageFunc: func(_ context.Context, _ peer.ID, _ *pb.Message) error { return nil },
+			}),
+			WithSelfAddrs(getMockAddrs(t)),
+			WithReprovideInterval(0),
+		)
+		require.NoError(t, err)
+		require.NotNil(t, prov)
+		require.False(t, prov.scheduleEnabled(), "scheduleEnabled should report false with interval=0")
+		require.NoError(t, prov.Close())
+	})
+
+	t.Run("WithReprovideInterval(-1) is rejected", func(t *testing.T) {
+		pid, err := peer.Decode("12BoooooPEER")
+		require.NoError(t, err)
+		_, err = New(
+			WithPeerID(pid),
+			WithRouter(&mockRouter{}),
+			WithMessageSender(&mockMsgSender{}),
+			WithSelfAddrs(getMockAddrs(t)),
+			WithReprovideInterval(-1),
+		)
+		require.Error(t, err)
+	})
+
+	t.Run("StartProviding publishes records and skips schedule in no-schedule mode", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			pid, err := peer.Decode("12BoooooPEER")
+			require.NoError(t, err)
+			replicationFactor := 4
+			h := genMultihashes(1)[0]
+
+			prefixLen := 4
+			peers := make([]peer.ID, replicationFactor)
+			seen := make(map[peer.ID]struct{}, replicationFactor)
+			peers[0], err = peer.Decode("12BooooPEER1")
+			require.NoError(t, err)
+			kbKey := keyspace.KeyToBytes(keyspace.PeerIDToBit256(peers[0]))
+			for i := range peers[1:] {
+				p, err := kb.GenRandPeerIDWithCPL(kbKey, uint(prefixLen))
+				require.NoError(t, err)
+				if _, ok := seen[p]; ok {
+					continue
+				}
+				seen[p] = struct{}{}
+				peers[i+1] = p
+			}
+
+			router := &mockRouter{
+				getClosestPeersFunc: func(_ context.Context, _ string) ([]peer.ID, error) {
+					return peers, nil
+				},
+			}
+			provideCount := atomic.Int32{}
+			msgSender := &mockMsgSender{
+				sendMessageFunc: func(_ context.Context, _ peer.ID, _ *pb.Message) error {
+					provideCount.Add(1)
+					return nil
+				},
+			}
+
+			checkInterval := time.Second
+			offlineDelay := time.Minute
+			prov, err := New(
+				WithReplicationFactor(replicationFactor),
+				WithReprovideInterval(0),
+				WithPeerID(pid),
+				WithRouter(router),
+				WithMessageSender(msgSender),
+				WithSelfAddrs(getMockAddrs(t)),
+				WithOfflineDelay(offlineDelay),
+				WithConnectivityCheckOnlineInterval(checkInterval),
+			)
+			require.NoError(t, err)
+			defer prov.Close()
+
+			synctest.Wait()
+			require.True(t, prov.connectivity.IsOnline())
+
+			err = prov.StartProviding(true, h)
+			require.NoError(t, err)
+			synctest.Wait()
+			require.Equal(t, int32(len(peers)), provideCount.Load(), "key should be published to every peer")
+
+			// Stats must not panic on the modulo-by-zero schedule math.
+			s := prov.Stats()
+			require.False(t, s.Closed)
+			require.Equal(t, time.Duration(0), s.Timing.ReprovidesInterval)
+			require.Equal(t, time.Duration(0), s.Timing.CurrentTimeOffset)
+
+			// Schedule must remain empty in no-schedule mode.
+			prov.scheduleLk.Lock()
+			require.Equal(t, 0, prov.schedule.Size(), "schedule should be empty in no-schedule mode")
+			prov.scheduleLk.Unlock()
+
+			// Keystore must stay empty: StartProviding collapses to
+			// ProvideOnce semantics in no-schedule mode.
+			ksSize, err := prov.keystore.Size(t.Context())
+			require.NoError(t, err)
+			require.Equal(t, 0, ksSize, "keystore should be empty when StartProviding runs in no-schedule mode")
+
+			// AddToSchedule and RefreshSchedule are no-ops.
+			require.NoError(t, prov.AddToSchedule(h))
+			require.NoError(t, prov.RefreshSchedule())
+			prov.scheduleLk.Lock()
+			require.Equal(t, 0, prov.schedule.Size(), "no-op AddToSchedule/RefreshSchedule should leave schedule empty")
+			prov.scheduleLk.Unlock()
+
+			// No periodic reprovide ever fires.
+			time.Sleep(time.Hour)
+			synctest.Wait()
+			require.Equal(t, int32(len(peers)), provideCount.Load(), "no reprovide should have fired in no-schedule mode")
+		})
+	})
+}
+
 const bitsPerByte = 8
 
 func TestStartProvidingMany(t *testing.T) {

--- a/provider/stats.go
+++ b/provider/stats.go
@@ -68,7 +68,10 @@ func (s *SweepingProvider) Stats() stats.Stats {
 	}
 	s.scheduleLk.Unlock()
 
-	currentOffset := s.currentTimeOffset()
+	var currentOffset time.Duration
+	if s.scheduleEnabled() {
+		currentOffset = s.currentTimeOffset()
+	}
 	nextReprovideAt := time.Time{}
 	if ok {
 		nextReprovideAt = now.Add(s.timeUntil(nextReprovideOffset))


### PR DESCRIPTION


## Summary

This PR is necessary for 
- https://github.com/ipfs/kubo/pull/11321

It lets `WithReprovideInterval` accept `0` as a valid value. With `0`, the `SweepingProvider` runs in **burst-only mode**: `ProvideOnce` and `StartProviding` continue to publish provider records, but no schedule is built and no periodic reprovide loop runs.



## Motivation

Some consumers want to use the sweep provider for ad-hoc announcements without committing to a periodic schedule e.g. kubo's `Provide.DHT.Interval=0` configuration, or any setup where an external system drives reprovides. The validator on `WithReprovideInterval` was the only thing preventing this; the burst pipeline already exists and is independent of the schedule.

## Behavior

See `WithReprovideInterval` godoc

## Tests

See `TestNoScheduleMode`