### PR TITLE
fix(provider)!: bound keystore.Size in Stats with a timeout

### DIFF
--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -1158,7 +1158,8 @@ func TestNoScheduleMode(t *testing.T) {
 			require.Equal(t, int32(len(peers)), provideCount.Load(), "key should be published to every peer")
 
 			// Stats must not panic on the modulo-by-zero schedule math.
-			s := prov.Stats()
+			s, err := prov.Stats(t.Context())
+			require.NoError(t, err)
 			require.False(t, s.Closed)
 			require.Equal(t, time.Duration(0), s.Timing.ReprovidesInterval)
 			require.Equal(t, time.Duration(0), s.Timing.CurrentTimeOffset)
@@ -2305,7 +2306,9 @@ func TestConnectivityCallbacks(t *testing.T) {
 		require.Equal(t, StateOnline, trackedState)
 		stateLk.Unlock()
 		require.True(t, prov.connectivity.IsOnline())
-		require.Equal(t, "online", prov.Stats().Connectivity.Status)
+		s, err := prov.Stats(t.Context())
+		require.NoError(t, err)
+		require.Equal(t, "online", s.Connectivity.Status)
 
 		// Transition to DISCONNECTED
 		time.Sleep(checkInterval)
@@ -2319,7 +2322,9 @@ func TestConnectivityCallbacks(t *testing.T) {
 		require.Equal(t, StateDisconnected, trackedState)
 		stateLk.Unlock()
 		require.False(t, prov.connectivity.IsOnline())
-		require.Equal(t, "disconnected", prov.Stats().Connectivity.Status)
+		s, err = prov.Stats(t.Context())
+		require.NoError(t, err)
+		require.Equal(t, "disconnected", s.Connectivity.Status)
 
 		// Transition to OFFLINE after offlineDelay
 		time.Sleep(offlineDelay)
@@ -2331,7 +2336,9 @@ func TestConnectivityCallbacks(t *testing.T) {
 		require.Equal(t, StateOffline, trackedState)
 		stateLk.Unlock()
 		require.False(t, prov.connectivity.IsOnline())
-		require.Equal(t, "offline", prov.Stats().Connectivity.Status)
+		s, err = prov.Stats(t.Context())
+		require.NoError(t, err)
+		require.Equal(t, "offline", s.Connectivity.Status)
 
 		// Transition back to ONLINE
 		online.Store(true)
@@ -2343,7 +2350,9 @@ func TestConnectivityCallbacks(t *testing.T) {
 		require.Equal(t, StateOnline, trackedState)
 		stateLk.Unlock()
 		require.True(t, prov.connectivity.IsOnline())
-		require.Equal(t, "online", prov.Stats().Connectivity.Status)
+		s, err = prov.Stats(t.Context())
+		require.NoError(t, err)
+		require.Equal(t, "online", s.Connectivity.Status)
 	})
 }
 

--- a/provider/stats.go
+++ b/provider/stats.go
@@ -14,12 +14,14 @@ import (
 
 // Stats returns a snapshot of the provider's current operational metrics.
 //
-// Stats honours ctx for cancellation: if ctx is done, it returns a zero
-// stats.Stats and ctx.Err(). Callers should pass a deadline-bearing ctx
-// because the keystore key count lookup is serialised through the keystore
-// worker and may block on a slow datastore operation. Non-context errors
-// from that lookup are reported as Schedule.Keys == -1 in the returned
-// snapshot with a nil error.
+// Pass a ctx with a deadline. The key count is fetched through the
+// keystore worker, which processes operations one at a time, so Stats
+// can stall behind a slow datastore op queued ahead of it. If ctx is
+// canceled before the key count returns, Stats returns stats.Stats{}
+// and ctx.Err().
+//
+// If the key count lookup fails for a non-ctx reason, the snapshot's
+// Schedule.Keys is -1 and the returned error is nil.
 func (s *SweepingProvider) Stats(ctx context.Context) (stats.Stats, error) {
 	if err := ctx.Err(); err != nil {
 		return stats.Stats{}, err
@@ -88,7 +90,7 @@ func (s *SweepingProvider) Stats(ctx context.Context) (stats.Stats, error) {
 		nextReprovideAt = now.Add(s.timeUntil(nextReprovideOffset))
 	}
 
-	var keys int64 = -1 // sentinel if keystore.Size() fails (non-ctx error)
+	var keys int64 = -1 // -1 sentinel when keystore.Size fails without a ctx error
 	if keyCount, err := s.keystore.Size(ctx); err == nil {
 		keys = int64(keyCount)
 	} else if ctxErr := ctx.Err(); ctxErr != nil {

--- a/provider/stats.go
+++ b/provider/stats.go
@@ -12,14 +12,25 @@ import (
 	"github.com/libp2p/go-libp2p-kad-dht/provider/stats"
 )
 
-func (s *SweepingProvider) Stats() stats.Stats {
+// Stats returns a snapshot of the provider's current operational metrics.
+//
+// Stats honours ctx for cancellation: if ctx is done, it returns a zero
+// stats.Stats and ctx.Err(). Callers should pass a deadline-bearing ctx
+// because the keystore key count lookup is serialised through the keystore
+// worker and may block on a slow datastore operation. Non-context errors
+// from that lookup are reported as Schedule.Keys == -1 in the returned
+// snapshot with a nil error.
+func (s *SweepingProvider) Stats(ctx context.Context) (stats.Stats, error) {
+	if err := ctx.Err(); err != nil {
+		return stats.Stats{}, err
+	}
 	now := time.Now()
 	snapshot := stats.Stats{
 		Closed: s.closed(),
 	}
 
 	if snapshot.Closed {
-		return snapshot
+		return snapshot, nil
 	}
 
 	// Queue metrics
@@ -77,9 +88,11 @@ func (s *SweepingProvider) Stats() stats.Stats {
 		nextReprovideAt = now.Add(s.timeUntil(nextReprovideOffset))
 	}
 
-	var keys int64 = -1 // Default value if keyStore.Size() fails
-	if keyCount, err := s.keystore.Size(context.Background()); err == nil {
+	var keys int64 = -1 // sentinel if keystore.Size() fails (non-ctx error)
+	if keyCount, err := s.keystore.Size(ctx); err == nil {
 		keys = int64(keyCount)
+	} else if ctxErr := ctx.Err(); ctxErr != nil {
+		return stats.Stats{}, ctxErr
 	}
 	snapshot.Schedule = stats.Schedule{
 		Keys:                keys,
@@ -193,7 +206,7 @@ func (s *SweepingProvider) Stats() stats.Stats {
 		ReplicationFactor:        s.replicationFactor,
 	}
 
-	return snapshot
+	return snapshot, nil
 }
 
 // operationStats tracks provider operation metrics over time windows.

--- a/provider/stats_test.go
+++ b/provider/stats_test.go
@@ -17,6 +17,7 @@ import (
 
 	pb "github.com/libp2p/go-libp2p-kad-dht/pb"
 	"github.com/libp2p/go-libp2p-kad-dht/provider/internal/keyspace"
+	"github.com/libp2p/go-libp2p-kad-dht/provider/keystore"
 	kb "github.com/libp2p/go-libp2p-kbucket"
 
 	"github.com/stretchr/testify/require"
@@ -115,7 +116,8 @@ func TestStats(t *testing.T) {
 		avgPrefixLenFloat := float64(avgPrefixLen)
 
 		// Initial stats check
-		stats := prov.Stats()
+		stats, err := prov.Stats(t.Context())
+		require.NoError(t, err)
 		require.False(t, stats.Closed)
 		require.Equal(t, "online", stats.Connectivity.Status)
 		require.Equal(t, startTime, stats.Connectivity.Since)
@@ -182,7 +184,8 @@ func TestStats(t *testing.T) {
 		require.Empty(t, workersBlocked)
 
 		// Check stats during a provide operation (blocked)
-		stats = prov.Stats()
+		stats, err = prov.Stats(t.Context())
+		require.NoError(t, err)
 
 		require.False(t, stats.Closed)
 		require.Equal(t, "online", stats.Connectivity.Status)
@@ -238,7 +241,8 @@ func TestStats(t *testing.T) {
 		synctest.Wait()
 
 		// Check stats after the provide operation
-		stats = prov.Stats()
+		stats, err = prov.Stats(t.Context())
+		require.NoError(t, err)
 
 		// Count to how many peers the record was actually provided
 		recordsProvided := 0
@@ -323,7 +327,8 @@ func TestStats(t *testing.T) {
 		}
 		require.Empty(t, workersBlocked)
 
-		stats = prov.Stats()
+		stats, err = prov.Stats(t.Context())
+		require.NoError(t, err)
 
 		reprovidedKeys := len(newKeys) + 1
 
@@ -385,7 +390,8 @@ func TestStats(t *testing.T) {
 		synctest.Wait()
 
 		// Check stats after the reprovide operation
-		stats = prov.Stats()
+		stats, err = prov.Stats(t.Context())
+		require.NoError(t, err)
 
 		newKeysProvidedRecords := 0
 		for _, k := range newKeys {
@@ -481,7 +487,8 @@ func TestStats(t *testing.T) {
 		}
 		require.Empty(t, workersBlocked)
 
-		stats = prov.Stats()
+		stats, err = prov.Stats(t.Context())
+		require.NoError(t, err)
 
 		require.False(t, stats.Closed)
 		require.Equal(t, "online", stats.Connectivity.Status)
@@ -536,7 +543,8 @@ func TestStats(t *testing.T) {
 		synctest.Wait()
 
 		// Provide of all balanced keys is complete
-		stats = prov.Stats()
+		stats, err = prov.Stats(t.Context())
+		require.NoError(t, err)
 
 		balancedKeysRecords := 0
 		for _, k := range balancedKeys {
@@ -596,7 +604,8 @@ func TestStats(t *testing.T) {
 		time.Sleep(reprovideInterval)
 
 		// Check stats after all regions have been reprovided
-		stats = prov.Stats()
+		stats, err = prov.Stats(t.Context())
+		require.NoError(t, err)
 
 		require.False(t, stats.Closed)
 		require.Equal(t, "online", stats.Connectivity.Status)
@@ -648,16 +657,99 @@ func TestStats(t *testing.T) {
 		prov.connectivity.TriggerCheck()
 		synctest.Wait()
 
-		require.Equal(t, "disconnected", prov.Stats().Connectivity.Status)
+		stats, err = prov.Stats(t.Context())
+		require.NoError(t, err)
+		require.Equal(t, "disconnected", stats.Connectivity.Status)
 
 		// Switch to offline
 		time.Sleep(offlineDelay)
 		synctest.Wait()
 
-		require.Equal(t, "offline", prov.Stats().Connectivity.Status)
+		stats, err = prov.Stats(t.Context())
+		require.NoError(t, err)
+		require.Equal(t, "offline", stats.Connectivity.Status)
 
 		prov.Close()
-		require.True(t, prov.Stats().Closed)
+		stats, err = prov.Stats(t.Context())
+		require.NoError(t, err)
+		require.True(t, stats.Closed)
+	})
+}
+
+// blockingSizeKeystore is a Keystore implementation whose Size method blocks
+// until the context is cancelled. All other methods return zero values. Used
+// to verify Stats honours the caller's context when the keystore worker is
+// stuck (e.g. behind a slow datastore op).
+type blockingSizeKeystore struct{}
+
+var _ keystore.Keystore = (*blockingSizeKeystore)(nil)
+
+func (b *blockingSizeKeystore) Size(ctx context.Context) (int, error) {
+	<-ctx.Done()
+	return 0, ctx.Err()
+}
+
+func (b *blockingSizeKeystore) Put(_ context.Context, _ ...multihash.Multihash) ([]multihash.Multihash, error) {
+	return nil, nil
+}
+
+func (b *blockingSizeKeystore) Get(_ context.Context, _ bitstr.Key) ([]multihash.Multihash, error) {
+	return nil, nil
+}
+
+func (b *blockingSizeKeystore) ContainsPrefix(_ context.Context, _ bitstr.Key) (bool, error) {
+	return false, nil
+}
+
+func (b *blockingSizeKeystore) Delete(_ context.Context, _ ...multihash.Multihash) error {
+	return nil
+}
+
+func (b *blockingSizeKeystore) Empty(_ context.Context) error { return nil }
+
+func (b *blockingSizeKeystore) BatchSize() int { return 256 }
+
+func (b *blockingSizeKeystore) Close() error { return nil }
+
+// TestStatsContextDeadline verifies that Stats honours the caller's context
+// when keystore.Size is stuck (e.g. because the keystore worker is blocked on
+// a slow datastore op). Stats must unblock when the deadline elapses and
+// return a zero stats.Stats together with the context error.
+func TestStatsContextDeadline(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		pid, err := peer.Decode("12D3KooWCPQTeFYCDkru8nza3Af6u77aoVLA71Vb74eHxeR91Gka")
+		require.NoError(t, err)
+
+		router := &mockRouter{
+			getClosestPeersFunc: func(_ context.Context, _ string) ([]peer.ID, error) {
+				return nil, nil
+			},
+		}
+		msgSender := &mockMsgSender{}
+
+		prov, err := New(
+			WithPeerID(pid),
+			WithRouter(router),
+			WithMessageSender(msgSender),
+			WithSelfAddrs(getMockAddrs(t)),
+			WithKeystore(&blockingSizeKeystore{}),
+		)
+		require.NoError(t, err)
+		synctest.Wait()
+		defer prov.Close()
+
+		const deadline = 5 * time.Second
+		ctx, cancel := context.WithTimeout(t.Context(), deadline)
+		defer cancel()
+
+		start := time.Now()
+		s, err := prov.Stats(ctx)
+		elapsed := time.Since(start)
+
+		require.ErrorIsf(t, err, context.DeadlineExceeded, "Stats should return ctx.Err when keystore.Size blocks past the deadline")
+		require.Emptyf(t, s, "Stats should return a zero snapshot when ctx is done")
+		require.GreaterOrEqualf(t, elapsed, deadline, "Stats should not return before the deadline elapses")
+		require.Lessf(t, elapsed, deadline+time.Second, "Stats should return shortly after the deadline elapses")
 	})
 }
 

--- a/provider/stats_test.go
+++ b/provider/stats_test.go
@@ -676,10 +676,10 @@ func TestStats(t *testing.T) {
 	})
 }
 
-// blockingSizeKeystore is a Keystore implementation whose Size method blocks
-// until the context is cancelled. All other methods return zero values. Used
-// to verify Stats honours the caller's context when the keystore worker is
-// stuck (e.g. behind a slow datastore op).
+// blockingSizeKeystore is a keystore.Keystore whose Size method blocks
+// until ctx is canceled. Other methods return zero values. Used to verify
+// that Stats unblocks when the caller's deadline elapses while the
+// keystore worker is stuck (e.g. behind a slow datastore op).
 type blockingSizeKeystore struct{}
 
 var _ keystore.Keystore = (*blockingSizeKeystore)(nil)
@@ -711,10 +711,9 @@ func (b *blockingSizeKeystore) BatchSize() int { return 256 }
 
 func (b *blockingSizeKeystore) Close() error { return nil }
 
-// TestStatsContextDeadline verifies that Stats honours the caller's context
-// when keystore.Size is stuck (e.g. because the keystore worker is blocked on
-// a slow datastore op). Stats must unblock when the deadline elapses and
-// return a zero stats.Stats together with the context error.
+// TestStatsContextDeadline verifies that Stats returns stats.Stats{} and
+// ctx.Err() when keystore.Size is stuck (e.g. the keystore worker is
+// blocked on a slow datastore op) and the caller's deadline elapses.
 func TestStatsContextDeadline(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		pid, err := peer.Decode("12D3KooWCPQTeFYCDkru8nza3Af6u77aoVLA71Vb74eHxeR91Gka")


### PR DESCRIPTION
## Summary

`SweepingProvider.Stats()` could hang forever when the keystore worker was stuck behind a slow datastore op (`pebble.Has` inside `ResettableKeystore.altPut` was seen blocking `ipfs provide stat` for >1h in production).

This changes the signature to `Stats(ctx) (Stats, error)` so the caller owns the deadline:
- ctx done → returns `(Stats{}, ctx.Err())`; Ctrl-C and HTTP request cancellation now propagate.
- non-ctx `keystore.Size` failure → keeps the existing `Schedule.Keys = -1` sentinel.

**Breaking:** public API signature change on `SweepingProvider.Stats`.