### PR TITLE
fix(provider): per-peer timeout on ADD_PROVIDER sends

### DIFF
--- a/provider/dual/options.go
+++ b/provider/dual/options.go
@@ -37,6 +37,8 @@ type config struct {
 	connectivityCheckOnlineInterval  [2]time.Duration
 	connectivityCheckOfflineInterval [2]time.Duration
 
+	sendProviderRecordTimeout [2]time.Duration
+
 	maxWorkers               [2]int
 	dedicatedPeriodicWorkers [2]int
 	dedicatedBurstWorkers    [2]int
@@ -57,6 +59,7 @@ func getOpts(opts []Option, d *dual.DHT) (config, error) {
 
 		offlineDelay:                    [2]time.Duration{provider.DefaultOfflineDelay, provider.DefaultOfflineDelay},
 		connectivityCheckOnlineInterval: [2]time.Duration{provider.DefaultConnectivityCheckOnlineInterval, provider.DefaultConnectivityCheckOnlineInterval},
+		sendProviderRecordTimeout:       [2]time.Duration{provider.DefaultSendProviderRecordTimeout, provider.DefaultSendProviderRecordTimeout},
 		loggerNames:                     [2]string{DefaultLoggerNameLAN, DefaultLoggerNameWAN},
 
 		maxWorkers:               [2]int{4, 4},
@@ -282,6 +285,37 @@ func WithConnectivityCheckOfflineIntervalLAN(offlineInterval time.Duration) Opti
 
 func WithConnectivityCheckOfflineIntervalWAN(offlineInterval time.Duration) Option {
 	return withConnectivityCheckOfflineInterval(offlineInterval, wanID)
+}
+
+func withSendProviderRecordTimeout(timeout time.Duration, dhts ...uint8) Option {
+	return func(cfg *config) error {
+		if timeout <= 0 {
+			return fmt.Errorf("send provider record timeout must be greater than 0, got %s", timeout)
+		}
+		for _, dht := range dhts {
+			cfg.sendProviderRecordTimeout[dht] = timeout
+		}
+		return nil
+	}
+}
+
+// WithSendProviderRecordTimeout sets the per-peer ADD_PROVIDER RPC timeout
+// for both the LAN and WAN providers. See
+// [provider.WithSendProviderRecordTimeout].
+func WithSendProviderRecordTimeout(timeout time.Duration) Option {
+	return withSendProviderRecordTimeout(timeout, lanID, wanID)
+}
+
+// WithSendProviderRecordTimeoutLAN sets the per-peer ADD_PROVIDER RPC timeout
+// for the LAN provider. See [provider.WithSendProviderRecordTimeout].
+func WithSendProviderRecordTimeoutLAN(timeout time.Duration) Option {
+	return withSendProviderRecordTimeout(timeout, lanID)
+}
+
+// WithSendProviderRecordTimeoutWAN sets the per-peer ADD_PROVIDER RPC timeout
+// for the WAN provider. See [provider.WithSendProviderRecordTimeout].
+func WithSendProviderRecordTimeoutWAN(timeout time.Duration) Option {
+	return withSendProviderRecordTimeout(timeout, wanID)
 }
 
 func withMaxWorkers(maxWorkers int, dhts ...uint8) Option {

--- a/provider/dual/provider.go
+++ b/provider/dual/provider.go
@@ -70,6 +70,7 @@ func New(d *dual.DHT, opts ...Option) (*SweepingProvider, error) {
 			provider.WithMaxReprovideDelay(cfg.maxReprovideDelay[i]),
 			provider.WithOfflineDelay(cfg.offlineDelay[i]),
 			provider.WithConnectivityCheckOnlineInterval(cfg.connectivityCheckOnlineInterval[i]),
+			provider.WithSendProviderRecordTimeout(cfg.sendProviderRecordTimeout[i]),
 			provider.WithMaxWorkers(cfg.maxWorkers[i]),
 			provider.WithDedicatedPeriodicWorkers(cfg.dedicatedPeriodicWorkers[i]),
 			provider.WithDedicatedBurstWorkers(cfg.dedicatedBurstWorkers[i]),

--- a/provider/options.go
+++ b/provider/options.go
@@ -32,6 +32,12 @@ const (
 	// how often such a check is performed.
 	DefaultConnectivityCheckOnlineInterval = 1 * time.Minute
 
+	// DefaultSendProviderRecordTimeout is the default per-peer timeout applied
+	// to a single ADD_PROVIDER RPC. Healthy peers complete the round-trip in
+	// well under a second; this leaves significant headroom for slow links
+	// while still bounding the time a hung peer can pin a provide worker.
+	DefaultSendProviderRecordTimeout = 10 * time.Second
+
 	// DefaultLoggerName is the default logger name for the DHT provider.
 	DefaultLoggerName = internal.DefaultLoggerName
 )
@@ -44,6 +50,8 @@ type config struct {
 	offlineDelay                    time.Duration
 	connectivityCheckOnlineInterval time.Duration
 	connectivityCallbacks           [3]func()
+
+	sendProviderRecordTimeout time.Duration
 
 	peerid peer.ID
 	host   host.Host
@@ -77,6 +85,7 @@ func getOpts(opts []Option) (config, error) {
 		maxReprovideDelay:               DefaultMaxReprovideDelay,
 		offlineDelay:                    DefaultOfflineDelay,
 		connectivityCheckOnlineInterval: DefaultConnectivityCheckOnlineInterval,
+		sendProviderRecordTimeout:       DefaultSendProviderRecordTimeout,
 		loggerName:                      DefaultLoggerName,
 
 		maxWorkers:               4,
@@ -197,6 +206,20 @@ func WithOfflineDelay(d time.Duration) Option {
 func WithConnectivityCheckOnlineInterval(d time.Duration) Option {
 	return func(cfg *config) error {
 		cfg.connectivityCheckOnlineInterval = d
+		return nil
+	}
+}
+
+// WithSendProviderRecordTimeout sets the per-peer timeout applied to a single
+// ADD_PROVIDER RPC. A peer that accepts the libp2p stream but never reads the
+// request must not pin a provide worker goroutine indefinitely; this timeout
+// bounds the wait. Defaults to [DefaultSendProviderRecordTimeout].
+func WithSendProviderRecordTimeout(d time.Duration) Option {
+	return func(cfg *config) error {
+		if d <= 0 {
+			return errors.New("provider config: send provider record timeout must be greater than 0")
+		}
+		cfg.sendProviderRecordTimeout = d
 		return nil
 	}
 }

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -177,8 +177,9 @@ type SweepingProvider struct {
 	reprovideQueue       *queue.ReprovideQueue
 	lateReprovideRunning sync.Mutex
 
-	workerPool               *pool.Pool[workerType]
-	maxProvideConnsPerWorker int
+	workerPool                *pool.Pool[workerType]
+	maxProvideConnsPerWorker  int
+	sendProviderRecordTimeout time.Duration
 
 	startedAt         time.Time
 	cycleStart        time.Time
@@ -313,7 +314,8 @@ func New(opts ...Option) (*SweepingProvider, error) {
 			periodicWorker: cfg.dedicatedPeriodicWorkers,
 			burstWorker:    cfg.dedicatedBurstWorkers,
 		}),
-		maxProvideConnsPerWorker: cfg.maxProvideConnsPerWorker,
+		maxProvideConnsPerWorker:  cfg.maxProvideConnsPerWorker,
+		sendProviderRecordTimeout: cfg.sendProviderRecordTimeout,
 
 		avgPrefixLenValidity: defaultPrefixLenValidity,
 		cachedAvgPrefixLen:   cachedAvgPrefixLen,
@@ -1145,7 +1147,9 @@ func (s *SweepingProvider) provideKeysToPeer(p peer.ID, batches [][]mh.Multihash
 				return ErrClosed
 			}
 			pmes.Key = mh
-			err := s.msgSender.SendMessage(s.ctx, p, pmes)
+			sendCtx, cancel := context.WithTimeout(s.ctx, s.sendProviderRecordTimeout)
+			err := s.msgSender.SendMessage(sendCtx, p, pmes)
+			cancel()
 			sentKeys++
 			if err != nil {
 				errStreak++

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -145,7 +145,9 @@ func TestProvideKeysToPeer(t *testing.T) {
 		},
 	}
 	prov := SweepingProvider{
-		msgSender: msgSender,
+		ctx:                       context.Background(),
+		msgSender:                 msgSender,
+		sendProviderRecordTimeout: DefaultSendProviderRecordTimeout,
 	}
 
 	nKeys := 16
@@ -171,6 +173,66 @@ func TestProvideKeysToPeer(t *testing.T) {
 	err = prov.provideKeysToPeer(pid, mhs, pmes)
 	require.NoError(t, err)
 	require.Equal(t, nKeys, msgCount)
+}
+
+// TestProvideKeysToPeerSendMessageTimeout verifies that a peer which accepts
+// the libp2p stream but never replies cannot pin the provideKeysToPeer worker
+// indefinitely. Each ADD_PROVIDER send is bounded by sendProviderRecordTimeout;
+// after maxConsecutiveProvideFailuresAllowed+1 consecutive timeouts the call
+// returns the underlying error.
+func TestProvideKeysToPeerSendMessageTimeout(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		var sendCount atomic.Int32
+		msgSender := &mockMsgSender{
+			sendMessageFunc: func(ctx context.Context, _ peer.ID, _ *pb.Message) error {
+				sendCount.Add(1)
+				<-ctx.Done()
+				return ctx.Err()
+			},
+		}
+		prov := SweepingProvider{
+			ctx:                       context.Background(),
+			msgSender:                 msgSender,
+			sendProviderRecordTimeout: DefaultSendProviderRecordTimeout,
+		}
+
+		nKeys := 16
+		pid, err := peer.Decode("12BoooooPEER")
+		require.NoError(t, err)
+		mhs := [][]mh.Multihash{genMultihashes(nKeys)}
+		pmes := &pb.Message{}
+
+		done := make(chan error, 1)
+		start := time.Now()
+		go func() {
+			done <- prov.provideKeysToPeer(pid, mhs, pmes)
+		}()
+		synctest.Wait()
+
+		var providerErr error
+		select {
+		case providerErr = <-done:
+		case <-time.After(time.Hour):
+			t.Fatal("provideKeysToPeer did not return within a synthetic hour")
+		}
+		elapsed := time.Since(start)
+
+		require.Error(t, providerErr)
+		require.Contains(t, providerErr.Error(), "failed to provide")
+
+		// We expect exactly maxConsecutiveProvideFailuresAllowed+1 send attempts:
+		// the first 1+maxConsecutiveProvideFailuresAllowed each time out, then the
+		// next attempt would exceed the streak and the call bails. No additional
+		// sends should leak after the bail.
+		require.Equal(t, int32(maxConsecutiveProvideFailuresAllowed+1), sendCount.Load(),
+			"expected %d send attempts before bailing on streak", maxConsecutiveProvideFailuresAllowed+1)
+
+		// Total elapsed time must be bounded by per-send timeout × attempts and
+		// must not approach the unbounded behaviour we are fixing.
+		maxElapsed := prov.sendProviderRecordTimeout*time.Duration(maxConsecutiveProvideFailuresAllowed+1) + time.Second
+		require.Less(t, elapsed, maxElapsed,
+			"provideKeysToPeer should complete in at most per-send timeout × attempts")
+	})
 }
 
 func TestKeysAllocationsToPeers(t *testing.T) {
@@ -512,19 +574,21 @@ func TestIndividualProvideSingle(t *testing.T) {
 		},
 	}
 	r := SweepingProvider{
-		router:                   router,
-		msgSender:                msgSender,
-		reprovideInterval:        time.Hour,
-		maxProvideConnsPerWorker: 2,
-		provideQueue:             queue.NewProvideQueue(),
-		reprovideQueue:           queue.NewReprovideQueue(),
-		connectivity:             noopConnectivityChecker(),
-		schedule:                 trie.New[bitstr.Key, time.Duration](),
-		scheduleTimer:            time.NewTimer(time.Hour),
-		getSelfAddrs:             func() []ma.Multiaddr { return nil },
-		addLocalRecord:           func(mh mh.Multihash) error { return nil },
-		provideCounter:           provideCounter(),
-		logger:                   defaultLogger,
+		ctx:                       context.Background(),
+		router:                    router,
+		msgSender:                 msgSender,
+		reprovideInterval:         time.Hour,
+		maxProvideConnsPerWorker:  2,
+		sendProviderRecordTimeout: DefaultSendProviderRecordTimeout,
+		provideQueue:              queue.NewProvideQueue(),
+		reprovideQueue:            queue.NewReprovideQueue(),
+		connectivity:              noopConnectivityChecker(),
+		schedule:                  trie.New[bitstr.Key, time.Duration](),
+		scheduleTimer:             time.NewTimer(time.Hour),
+		getSelfAddrs:              func() []ma.Multiaddr { return nil },
+		addLocalRecord:            func(mh mh.Multihash) error { return nil },
+		provideCounter:            provideCounter(),
+		logger:                    defaultLogger,
 	}
 
 	assertAdvertisementCount := func(n int) {
@@ -601,22 +665,24 @@ func TestIndividualProvideMultiple(t *testing.T) {
 	maxDelay := time.Minute
 	ds := datastore.NewMapDatastore()
 	r := SweepingProvider{
-		router:                   router,
-		msgSender:                msgSender,
-		reprovideInterval:        reprovideInterval,
-		maxReprovideDelay:        maxDelay,
-		maxProvideConnsPerWorker: 2,
-		provideQueue:             queue.NewProvideQueue(),
-		reprovideQueue:           queue.NewReprovideQueue(),
-		connectivity:             noopConnectivityChecker(),
-		schedule:                 trie.New[bitstr.Key, time.Duration](),
-		scheduleTimer:            time.NewTimer(time.Hour),
-		getSelfAddrs:             func() []ma.Multiaddr { return nil },
-		addLocalRecord:           func(mh mh.Multihash) error { return nil },
-		provideCounter:           provideCounter(),
-		stats:                    newOperationStats(reprovideInterval, maxDelay),
-		datastore:                ds,
-		logger:                   defaultLogger,
+		ctx:                       context.Background(),
+		router:                    router,
+		msgSender:                 msgSender,
+		reprovideInterval:         reprovideInterval,
+		maxReprovideDelay:         maxDelay,
+		maxProvideConnsPerWorker:  2,
+		sendProviderRecordTimeout: DefaultSendProviderRecordTimeout,
+		provideQueue:              queue.NewProvideQueue(),
+		reprovideQueue:            queue.NewReprovideQueue(),
+		connectivity:              noopConnectivityChecker(),
+		schedule:                  trie.New[bitstr.Key, time.Duration](),
+		scheduleTimer:             time.NewTimer(time.Hour),
+		getSelfAddrs:              func() []ma.Multiaddr { return nil },
+		addLocalRecord:            func(mh mh.Multihash) error { return nil },
+		provideCounter:            provideCounter(),
+		stats:                     newOperationStats(reprovideInterval, maxDelay),
+		datastore:                 ds,
+		logger:                    defaultLogger,
 	}
 
 	assertAdvertisementCount := func(n int) {


### PR DESCRIPTION
Previously we didn't have a per-peer timeout when sending `ADD_PROVIDER` RPC, which could make providing to really slow peers painful.

This PR is adding configurable timeout (default: 10s) for `ADD_PROVIDER` RPC.