### PR TITLE
fix(ResettableKeystore): speed up reset process and keep worker responsive

### DIFF
--- a/provider/keystore/options.go
+++ b/provider/keystore/options.go
@@ -83,13 +83,19 @@ func WithLoggerName(name string) Option {
 	}
 }
 
+// DefaultResetBufferCapacity is the default ceiling on the worker buffer
+// that holds concurrent Put keys during a reset (~512K multihashes,
+// ~20 MiB at ~40 B/key). See WithResetBufferCapacity for details.
+const DefaultResetBufferCapacity = 1 << 19
+
 // resettableKeystoreConfig holds resettable-specific fields and the base
 // keystore config.
 type resettableKeystoreConfig struct {
 	config // base keystore config (prefixBits, batchSize, loggerName)
 
-	createDs  func(string) (ds.Batching, error) // factory to create per-namespace datastores
-	destroyDs func(string) error                // destroys a per-namespace datastore on disk
+	resetBufCap int                               // ceiling on the worker buffer during a reset
+	createDs    func(string) (ds.Batching, error) // factory to create per-namespace datastores
+	destroyDs   func(string) error                // destroys a per-namespace datastore on disk
 }
 
 // ResettableKeystoreOption configures a ResettableKeystore.
@@ -103,6 +109,24 @@ func KeystoreOption(opts ...Option) ResettableKeystoreOption {
 				return err
 			}
 		}
+		return nil
+	}
+}
+
+// WithResetBufferCapacity sets the maximum number of multihashes the worker
+// can stage in-memory for the alternate datastore during a reset. Bounds
+// memory at roughly capacity × 40 B (32 B multihash + slice overhead).
+//
+// When the buffer is full, concurrent Puts back-pressure the worker until
+// ResetCids drains it. A larger capacity absorbs longer Put bursts before
+// back-pressure kicks in; a smaller one trades responsiveness for memory.
+// Must be > 0. Default: DefaultResetBufferCapacity (~512K).
+func WithResetBufferCapacity(capacity int) ResettableKeystoreOption {
+	return func(c *resettableKeystoreConfig) error {
+		if capacity <= 0 {
+			return fmt.Errorf("invalid reset buffer capacity %d, must be > 0", capacity)
+		}
+		c.resetBufCap = capacity
 		return nil
 	}
 }
@@ -141,6 +165,7 @@ func getResettableOpts(opts []ResettableKeystoreOption) (resettableKeystoreConfi
 			batchSize:  DefaultBatchSize,
 			loggerName: DefaultLoggerName,
 		},
+		resetBufCap: DefaultResetBufferCapacity,
 	}
 	for i, opt := range opts {
 		if err := opt(&cfg); err != nil {

--- a/provider/keystore/resettable_keystore.go
+++ b/provider/keystore/resettable_keystore.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/ipfs/go-cid"
 	ds "github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-datastore/namespace"
+	"github.com/ipfs/go-datastore/query"
 	"github.com/ipfs/go-log/v2"
 	"github.com/libp2p/go-libp2p-kad-dht/provider/internal/keyspace"
 	mh "github.com/multiformats/go-multihash"
@@ -19,15 +21,23 @@ import (
 
 var ErrResetInProgress = errors.New("reset already in progress")
 
+// phaseADrainInterval bounds how long the worker buffer can grow between
+// drains during Phase A when keysChan delivers too slowly to trigger drains
+// via batch flushes. Caps buf growth at concurrent_put_rate × interval,
+// independent of keysChan throughput.
+const phaseADrainInterval = 100 * time.Millisecond
+
 const (
 	opStart opType = iota
 	opCleanup
 )
 
-// activeNamespaceKey is the key used to persist which namespace (0 or 1) is currently active
+// activeNamespaceKey is the key used to persist which namespace (0 or 1) is
+// currently active.
 var activeNamespaceKey = ds.NewKey("active")
 
 type resetOp struct {
+	ctx      context.Context
 	op       opType
 	success  bool
 	response chan<- error
@@ -52,18 +62,32 @@ type resetOp struct {
 // metaDs stores only the active-namespace marker and persisted size.
 //
 // Reset Operation Flow:
-//  1. The alternate datastore is prepared (created or emptied)
-//  2. New keys from the reset are written to the alternate datastore
-//  3. Concurrent Put operations are duplicated to both datastores to maintain
-//     consistency during the transition
-//  4. Once all reset keys are written, the datastores are atomically swapped
-//  5. The active namespace marker is updated and persisted
-//  6. The old datastore (now alternate) is torn down (destroyed or emptied)
+//  1. opStart prepares an empty alternate datastore.
+//  2. ResetCids runs in three phases, all altDs writes happening on its own
+//     goroutine (the worker is never the one calling altDs):
+//     a. bulk     — blindly Put keysChan batches into altDs, no Has check.
+//     Periodically blind-drain the worker buffer.
+//     b. refresh  — run refreshSize on the now-quiesced altDs to establish
+//     the exact key count. The worker may continue buffering during this
+//     phase but does not write to altDs.
+//     c. catch-up — drain whatever the worker buffered during refresh, this
+//     time with Has-before-Put so altSize is incremented once per unique
+//     new key.
+//  3. opCleanup drains any tail of the buffer that arrived after Phase C
+//     (worker has been idle for at most a few Puts), then atomically swaps
+//     primary and altDs and persists the active namespace marker.
+//  4. The old datastore (now alternate) is torn down (destroyed or emptied).
 //
 // Thread Safety:
-//   - All operations are processed sequentially by a single worker goroutine
-//   - Reset operations are non-blocking for concurrent reads and writes
-//   - Only one reset operation can be active at a time
+//   - All keystore operations (Put/Get/...) are processed sequentially by a
+//     single worker goroutine.
+//   - During a reset, the worker's Put does not synchronously write to
+//     altDs; it appends to an in-memory buffer. This is what keeps the
+//     worker responsive when altDs is slow
+//   - bufferKeys back-pressures the worker if the buffer is full. This can
+//     only happen if a reset is unusually slow at draining; preferred over
+//     silently dropping keys, which would desynchronise altDs from primary.
+//   - Only one reset operation can be active at a time.
 type ResettableKeystore struct {
 	keystore
 
@@ -72,8 +96,32 @@ type ResettableKeystore struct {
 	altSize         atomic.Int64
 	resetInProgress bool
 	activeNamespace byte
-	resetOps        chan resetOp  // reset operations that must be run in main go routine
-	altPutSem       chan struct{} // binary semaphore: empty when altPut running, has token when idle
+	resetOps        chan resetOp
+	// resetBufCap bounds the in-memory buffer of concurrent Put keys
+	// duplicated to altDs during a reset. ResetCids drains the buffer in
+	// three phases (bulk, refresh, catch-up); if the worker fills the
+	// buffer faster than the current phase can drain it, bufferKeys
+	// back-pressures the worker instead of dropping keys. Configurable via
+	// WithResetBufferCapacity.
+	resetBufCap int
+
+	// Worker-buffered keys staged for altDs during a reset. The worker
+	// appends here (under bufMu) instead of writing to altDs synchronously;
+	// ResetCids drains here in Phases A and C and opCleanup drains it one
+	// final time before the swap.
+	//
+	// bufDrained is the channel-as-condition idiom: every drain replaces it
+	// with a fresh empty channel, closing the previous one to wake any
+	// goroutines blocked in bufferKeys waiting for the buffer to have room.
+	bufMu      sync.Mutex
+	buf        []mh.Multihash
+	bufDrained chan struct{}
+
+	// altDsBusy is a binary semaphore (1-deep channel, token present when
+	// altDs is idle) that serialises Close with in-flight altDs writes from
+	// ResetCids. Close acquires the token after the worker exits and never
+	// releases it, so any later altDs caller falls through on <-s.done.
+	altDsBusy chan struct{}
 
 	createDs  func(string) (ds.Batching, error) // nil in shared-datastore mode
 	destroyDs func(string) error                // nil in shared-datastore mode
@@ -196,20 +244,21 @@ func NewResettableKeystore(d ds.Batching, opts ...ResettableKeystoreOption) (*Re
 		altDs:           altDs,
 		activeNamespace: activeIdx,
 		resetOps:        make(chan resetOp),
-		altPutSem:       make(chan struct{}, 1),
+		resetBufCap:     rcfg.resetBufCap,
+		bufDrained:      make(chan struct{}),
+		altDsBusy:       make(chan struct{}, 1),
 		createDs:        createDs,
 		destroyDs:       destroyDs,
 	}
-	// Initialize semaphore with token (altPut not running)
-	rks.altPutSem <- struct{}{}
+	// Initialise the altDsBusy semaphore with a token (altDs is idle).
+	rks.altDsBusy <- struct{}{}
 
-	// start worker goroutine
 	go rks.worker()
 
 	return rks, nil
 }
 
-// worker processes operations sequentially in a single goroutine for ResettableKeystore
+// worker processes operations sequentially in a single goroutine.
 func (s *ResettableKeystore) worker() {
 	defer close(s.done)
 	s.loadSize()
@@ -224,10 +273,10 @@ func (s *ResettableKeystore) worker() {
 				newKeys, err := s.put(op.ctx, op.keys)
 				op.response <- operationResponse{multihashes: newKeys, err: err}
 				if err != nil {
-					if size, err := refreshSize(op.ctx, s.ds); err == nil {
+					if size, refreshErr := refreshSize(op.ctx, s.ds); refreshErr == nil {
 						s.size = size
 					} else {
-						s.logger.Error("keystore: failed to refresh size after put: ", err)
+						s.logger.Error("keystore: failed to refresh size after put: ", refreshErr)
 					}
 				}
 
@@ -243,10 +292,10 @@ func (s *ResettableKeystore) worker() {
 				err := s.delete(op.ctx, op.keys)
 				op.response <- operationResponse{err: err}
 				if err != nil {
-					if size, err := refreshSize(op.ctx, s.ds); err == nil {
+					if size, refreshErr := refreshSize(op.ctx, s.ds); refreshErr == nil {
 						s.size = size
 					} else {
-						s.logger.Error("keystore: failed to refresh size after delete: ", err)
+						s.logger.Error("keystore: failed to refresh size after delete: ", refreshErr)
 					}
 				}
 
@@ -256,10 +305,10 @@ func (s *ResettableKeystore) worker() {
 				if err == nil {
 					s.size = 0
 				} else {
-					if size, err := refreshSize(op.ctx, s.ds); err == nil {
+					if size, refreshErr := refreshSize(op.ctx, s.ds); refreshErr == nil {
 						s.size = size
 					} else {
-						s.logger.Error("keystore: failed to refresh size after empty: ", err)
+						s.logger.Error("keystore: failed to refresh size after empty: ", refreshErr)
 					}
 				}
 
@@ -272,28 +321,105 @@ func (s *ResettableKeystore) worker() {
 	}
 }
 
-// put handles put operations for ResettableKeystore. During a reset, writes are
-// duplicated to the alternate datastore to maintain consistency.
+// put handles put operations for ResettableKeystore. During a reset the keys
+// are buffered for later duplication to altDs; the worker never calls altDs
+// directly. If the buffer is at capacity, bufferKeys blocks until ResetCids
+// drains it, applying back-pressure rather than dropping keys.
 func (s *ResettableKeystore) put(ctx context.Context, keys []mh.Multihash) ([]mh.Multihash, error) {
 	if s.resetInProgress {
-		// Reset is in progress, write to alternate datastore in addition to
-		// current datastore
-		<-s.altPutSem
-		if err := s.altPut(ctx, keys); err != nil {
-			if size, err := refreshSize(ctx, s.altDs); err == nil {
-				s.altSize.Store(int64(size))
-			} else {
-				s.logger.Error("keystore: failed to refresh size after alt put: ", err)
-			}
+		if err := s.bufferKeys(ctx, keys); err != nil {
+			return nil, err
 		}
-		s.altPutSem <- struct{}{}
 	}
 	return s.keystore.put(ctx, keys)
 }
 
-// altPut writes the given multihashes to the alternate datastore.
-// The caller must hold the altPutSem token.
-func (s *ResettableKeystore) altPut(ctx context.Context, keys []mh.Multihash) error {
+// bufferKeys appends keys to the reset buffer. When the buffer fills, it
+// blocks until a drain creates room and then resumes. Inputs larger than
+// resetBufCap are buffered across multiple drain cycles rather than waiting
+// for room they could never obtain in a single pass. Returns early if the
+// keystore is closed or the request's context is cancelled.
+func (s *ResettableKeystore) bufferKeys(ctx context.Context, keys []mh.Multihash) error {
+	s.bufMu.Lock()
+	for len(keys) > 0 {
+		if room := s.resetBufCap - len(s.buf); room > 0 {
+			n := min(room, len(keys))
+			s.buf = append(s.buf, keys[:n]...)
+			keys = keys[n:]
+			continue
+		}
+		ch := s.bufDrained
+		s.bufMu.Unlock()
+		select {
+		case <-ch:
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-s.close:
+			return ErrClosed
+		}
+		s.bufMu.Lock()
+	}
+	s.bufMu.Unlock()
+	return nil
+}
+
+// takeBuf atomically swaps the buffer with a fresh empty slice and returns
+// the old contents. It wakes any goroutines blocked in bufferKeys.
+func (s *ResettableKeystore) takeBuf() []mh.Multihash {
+	s.bufMu.Lock()
+	out := s.buf
+	s.buf = nil
+	drained := s.bufDrained
+	s.bufDrained = make(chan struct{})
+	s.bufMu.Unlock()
+	close(drained)
+	return out
+}
+
+// bufEmpty reports whether the worker-buffered keys staging area is
+// currently empty. Used by Phase A's ticker to skip the drainBuf round-trip
+// (takeBuf channel swap + altDsBusy semaphore op) when there's no work.
+func (s *ResettableKeystore) bufEmpty() bool {
+	s.bufMu.Lock()
+	defer s.bufMu.Unlock()
+	return len(s.buf) == 0
+}
+
+// altPutBlind writes keys to altDs without checking for prior existence.
+// Used by Phase A (bulk). altSize is NOT updated here; Phase B's refreshSize
+// establishes the authoritative count over the entire altDs. Duplicate Puts
+// — within a single batch or across batches — are idempotent in pebble, so
+// no per-call dedupe is performed.
+func (s *ResettableKeystore) altPutBlind(ctx context.Context, keys []mh.Multihash) error {
+	if len(keys) == 0 {
+		return nil
+	}
+	b, err := s.altDs.Batch(ctx)
+	if err != nil {
+		return err
+	}
+	for _, h := range keys {
+		k := keyspace.MhToBit256(h)
+		if err := b.Put(ctx, dsKey(k, s.prefixBits), h); err != nil {
+			return err
+		}
+	}
+	if err := b.Commit(ctx); err != nil {
+		return fmt.Errorf("cannot commit keystore updates: %w", err)
+	}
+	if err := s.altDs.Sync(ctx, ds.NewKey("")); err != nil {
+		s.logger.Warnf("keystore: failed to sync datastore after alt put: %v", err)
+	}
+	return nil
+}
+
+// altPutChecked writes keys to altDs after a Has check on each, and
+// increments altSize for each unique addition. Used by Phase C (catch-up)
+// and by opCleanup's final drain.
+func (s *ResettableKeystore) altPutChecked(ctx context.Context, keys []mh.Multihash) error {
+	if len(keys) == 0 {
+		return nil
+	}
 	b, err := s.altDs.Batch(ctx)
 	if err != nil {
 		return err
@@ -302,12 +428,10 @@ func (s *ResettableKeystore) altPut(ctx context.Context, keys []mh.Multihash) er
 	var added int64
 	for _, h := range keys {
 		k := keyspace.MhToBit256(h)
-		// Skip duplicates within this batch
 		if _, ok := seen[k]; ok {
 			continue
 		}
 		seen[k] = struct{}{}
-
 		dsk := dsKey(k, s.prefixBits)
 		ok, err := s.altDs.Has(ctx, dsk)
 		if err != nil {
@@ -324,39 +448,44 @@ func (s *ResettableKeystore) altPut(ctx context.Context, keys []mh.Multihash) er
 		return fmt.Errorf("cannot commit keystore updates: %w", err)
 	}
 	s.altSize.Add(added)
-	if err = s.altDs.Sync(ctx, ds.NewKey("")); err != nil {
+	if err := s.altDs.Sync(ctx, ds.NewKey("")); err != nil {
 		s.logger.Warnf("keystore: failed to sync datastore after alt put: %v", err)
 	}
 	return nil
 }
 
-// tryAltPut is a concurrency-safe wrapper around altPut that coordinates with
-// both the worker goroutine and Close() to prevent data races during reset
-// operations.
-//
-// This method is called exclusively by ResetCids(), which runs outside the
-// worker goroutine. The binary semaphore (altPutSem) provides mutual exclusion
-// between this method, the worker's put() (which also acquires the semaphore
-// during reset), and Close():
-//   - tryAltPut blocks until the semaphore token is available or the worker
-//     exits (s.done closed), in which case it returns ErrClosed
-//   - Close() acquires the token after the worker exits, ensuring no
-//     concurrent altPut during persistSize()
-func (s *ResettableKeystore) tryAltPut(ctx context.Context, keys []mh.Multihash) error {
+// drainBuf takes the current buffer and writes it to altDs in batchSize chunks
+// using the supplied put function.
+func (s *ResettableKeystore) drainBuf(ctx context.Context, put func(context.Context, []mh.Multihash) error) error {
+	keys := s.takeBuf()
+	for i := 0; i < len(keys); i += s.batchSize {
+		end := min(i+s.batchSize, len(keys))
+		if err := put(ctx, keys[i:end]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// withAltDs runs fn while holding the altDsBusy token. Returns ErrClosed
+// if the worker has exited or ctx.Err() if the caller's context is done.
+// The token is released even when fn returns an error.
+func (s *ResettableKeystore) withAltDs(ctx context.Context, fn func() error) error {
 	select {
-	case <-s.altPutSem:
+	case <-s.altDsBusy:
 	case <-s.done:
 		return ErrClosed
+	case <-ctx.Done():
+		return ctx.Err()
 	}
-	err := s.altPut(ctx, keys)
-	s.altPutSem <- struct{}{}
-	return err
+	defer func() { s.altDsBusy <- struct{}{} }()
+	return fn()
 }
 
 // prepareAltDs sets up an empty alternate datastore before a reset.
 // In factory mode it creates a fresh datastore. In shared-datastore mode
 // it empties the existing one.
-func (s *ResettableKeystore) prepareAltDs() error {
+func (s *ResettableKeystore) prepareAltDs(ctx context.Context) error {
 	if s.createDs != nil {
 		altSuffix := fmt.Sprintf("%d", 1-s.activeNamespace)
 		// Remove any stale data left by a prior crash or incomplete teardown.
@@ -369,14 +498,65 @@ func (s *ResettableKeystore) prepareAltDs() error {
 		s.logger.Infof("keystore: created new datastore %s", altSuffix)
 		return nil
 	}
-	return s.empty(context.Background(), s.altDs)
+	return s.emptySharedAltDs(ctx)
+}
+
+// emptySharedAltDs deletes every key in the alternate namespace in
+// shared-datastore mode by iterating the underlying datastore directly.
+// This bypasses a quirk of namespace.Wrap's keytransform: ConvertKey
+// returns the key unchanged when it already starts with the namespace
+// prefix, so the round-trip iterate-then-delete misses any key whose
+// keystore path collides with that prefix (e.g. with namespace "/0",
+// keystore keys "/0/0/...").
+//
+// Only valid in shared-datastore mode, where metaDs is the un-wrapped
+// underlying datastore that altDs is namespace.Wrap'd over. In factory
+// mode altDs is a physically separate datastore and metaDs holds only
+// the active-namespace marker, so this function must not be called —
+// callers gate on s.createDs == nil.
+func (s *ResettableKeystore) emptySharedAltDs(ctx context.Context) error {
+	altPrefix := fmt.Sprintf("/%d", 1-s.activeNamespace)
+	q := query.Query{Prefix: altPrefix, KeysOnly: true}
+	b, err := s.metaDs.Batch(ctx)
+	if err != nil {
+		return err
+	}
+	var n int
+	for res, err := range ds.QueryIter(ctx, s.metaDs, q) {
+		if err != nil {
+			return err
+		}
+		if n >= s.batchSize {
+			if err := b.Commit(ctx); err != nil {
+				return fmt.Errorf("cannot commit keystore updates: %w", err)
+			}
+			b, err = s.metaDs.Batch(ctx)
+			if err != nil {
+				return err
+			}
+			n = 0
+		}
+		if err := b.Delete(ctx, ds.RawKey(res.Key)); err != nil {
+			return err
+		}
+		n++
+	}
+	if n > 0 {
+		if err := b.Commit(ctx); err != nil {
+			return fmt.Errorf("cannot commit keystore updates: %w", err)
+		}
+	}
+	if err := s.metaDs.Sync(ctx, ds.NewKey(altPrefix)); err != nil {
+		s.logger.Warnf("keystore: failed to sync after emptying alt namespace: %v", err)
+	}
+	return nil
 }
 
 // teardownAltDs cleans up the alternate datastore after a reset completes
 // (or fails). In factory mode it closes and destroys the datastore, setting
 // altDs to nil so no disk space is wasted between resets. In shared-datastore
 // mode it empties the existing namespace.
-func (s *ResettableKeystore) teardownAltDs() error {
+func (s *ResettableKeystore) teardownAltDs(ctx context.Context) error {
 	if s.createDs != nil {
 		if s.altDs == nil {
 			return nil
@@ -393,19 +573,20 @@ func (s *ResettableKeystore) teardownAltDs() error {
 		}
 		return errors.Join(errs...)
 	}
-	return s.empty(context.Background(), s.altDs)
+	return s.emptySharedAltDs(ctx)
 }
 
-// handleResetOp processes reset operations that need to happen synchronously.
+// handleResetOp processes reset operations on the worker goroutine.
 func (s *ResettableKeystore) handleResetOp(op resetOp) {
-	ctx := context.Background()
+	ctx := op.ctx
 	if op.op == opStart {
 		if s.resetInProgress {
 			op.response <- ErrResetInProgress
 			return
 		}
 		s.altSize.Store(0)
-		if err := s.prepareAltDs(); err != nil {
+		s.buf = nil
+		if err := s.prepareAltDs(ctx); err != nil {
 			op.response <- err
 			return
 		}
@@ -414,7 +595,19 @@ func (s *ResettableKeystore) handleResetOp(op resetOp) {
 		return
 	}
 
-	// Cleanup operation
+	// Cleanup. The worker is the sole goroutine that writes to buf, and we
+	// are running on the worker now, so no new keys can arrive while this
+	// drain runs. We drain anything ResetCids' Phase C drain missed
+	// (writes that arrived between Phase C's takeBuf and opCleanup).
+	// withAltDs keeps the altDs serialisation invariant uniform: every
+	// altDs write goes through the altDsBusy token.
+	if op.success {
+		if err := s.withAltDs(ctx, func() error { return s.drainBuf(ctx, s.altPutChecked) }); err != nil {
+			s.logger.Errorf("keystore: aborting swap, final buf drain failed: %v", err)
+			op.success = false
+		}
+	}
+
 	if op.success {
 		// Swap the active datastore.
 		oldDs := s.ds
@@ -440,19 +633,26 @@ func (s *ResettableKeystore) handleResetOp(op resetOp) {
 	// Tear down the unused datastore (old active after swap, or partial
 	// alt on failure).
 	s.resetInProgress = false
-	op.response <- s.teardownAltDs()
+	s.buf = nil
+	op.response <- s.teardownAltDs(ctx)
 }
 
 // ResetCids atomically replaces all stored keys with the CIDs received from
 // keysChan. The operation is thread-safe and non-blocking for concurrent reads
-// and writes.
+// and writes against the primary namespace.
 //
 // During the reset:
 //   - New keys from keysChan are written to an alternate storage location
-//   - Concurrent Put operations are duplicated to both current and alternate
-//     locations
-//   - Once all keys are processed, storage locations are atomically swapped
-//   - The old storage location is cleaned up
+//     without per-key Has checks (Phase A).
+//   - Concurrent Puts go to an in-memory buffer; bufferKeys back-pressures
+//     the caller if the buffer is full.
+//   - refreshSize establishes the exact key count on the now-quiesced
+//     alternate datastore (Phase B).
+//   - Buffered keys are drained into the alternate datastore with
+//     Has-before-Put so altSize is incremented exactly once per unique
+//     addition (Phase C).
+//   - opCleanup performs a final small drain (anything that arrived after
+//     Phase C) and atomically swaps the datastores.
 //
 // Returns ErrResetInProgress if another reset operation is already running.
 // The operation can be cancelled via context, which will clean up partial
@@ -474,13 +674,30 @@ func (s *ResettableKeystore) ResetCids(ctx context.Context, keysChan <-chan cid.
 		}
 	}()
 
+	// Cancel altDs operations when the keystore is closed (s.done), so
+	// pebble calls that honor ctx return promptly and Close can acquire
+	// altDsBusy. The goroutine exits on the first of {s.done closed,
+	// user ctx done, ResetCids' defer running cancelCtx}; if it observes
+	// user cancellation before s.done it stops watching s.done — which is
+	// fine because the user-cancelled ctx will already unblock any altDs
+	// caller below.
+	ctx, cancelCtx := context.WithCancel(ctx)
+	defer cancelCtx()
+	go func() {
+		select {
+		case <-s.done:
+			cancelCtx()
+		case <-ctx.Done():
+		}
+	}()
+
 	opsChan := make(chan error)
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
 	case <-s.done:
 		return ErrClosed
-	case s.resetOps <- resetOp{op: opStart, response: opsChan}:
+	case s.resetOps <- resetOp{ctx: ctx, op: opStart, response: opsChan}:
 		select {
 		case err := <-opsChan:
 			if err != nil {
@@ -492,21 +709,23 @@ func (s *ResettableKeystore) ResetCids(ctx context.Context, keysChan <-chan cid.
 	}
 
 	defer func() {
-		// Cleanup before returning on success and failure
+		// Cleanup before returning on success and failure.
 		select {
-		case s.resetOps <- resetOp{op: opCleanup, success: success, response: opsChan}:
+		case s.resetOps <- resetOp{ctx: ctx, op: opCleanup, success: success, response: opsChan}:
 			<-opsChan
 		case <-s.done:
-			// Worker is done, which means the keystore is closing or has closed.
-			// The underlying datastore may already be closed, so attempting to
-			// empty it could cause a panic. Skip cleanup since the datastore
-			// will be cleaned up during normal shutdown.
+			// Worker is done; underlying datastore may already be closed,
+			// so we cannot run the swap. Close() handles altDs teardown.
 		}
 	}()
 
-	keys := make([]mh.Multihash, 0)
-
-	// Read all the keys from the channel and write them to the altDs
+	// Phase A — bulk. Blind-write keysChan batches; periodically drain the
+	// worker buffer with blind writes too. No per-key Has check.
+	// A phaseADrainInterval ticker bounds buf growth when keysChan delivers
+	// too slowly to trigger drains via batch flushes.
+	batch := make([]mh.Multihash, 0, s.batchSize)
+	ticker := time.NewTicker(phaseADrainInterval)
+	defer ticker.Stop()
 loop:
 	for {
 		select {
@@ -514,44 +733,73 @@ loop:
 			return ctx.Err()
 		case <-s.done:
 			return ErrClosed
+		case <-ticker.C:
+			if s.bufEmpty() {
+				continue
+			}
+			if err := s.withAltDs(ctx, func() error { return s.drainBuf(ctx, s.altPutBlind) }); err != nil {
+				return err
+			}
 		case c, ok := <-keysChan:
 			if !ok {
 				break loop
 			}
-			keys = append(keys, c.Hash())
-			if len(keys) >= s.batchSize {
-				if err := s.tryAltPut(ctx, keys); err != nil {
+			batch = append(batch, c.Hash())
+			if len(batch) >= s.batchSize {
+				if err := s.withAltDs(ctx, func() error { return s.altPutBlind(ctx, batch) }); err != nil {
 					return err
 				}
-				keys = keys[:0]
+				batch = batch[:0]
+				if err := s.withAltDs(ctx, func() error { return s.drainBuf(ctx, s.altPutBlind) }); err != nil {
+					return err
+				}
 			}
 		}
 	}
-	// Put final batch
-	if err := s.tryAltPut(ctx, keys); err != nil {
+	if len(batch) > 0 {
+		if err := s.withAltDs(ctx, func() error { return s.altPutBlind(ctx, batch) }); err != nil {
+			return err
+		}
+	}
+	if err := s.withAltDs(ctx, func() error { return s.drainBuf(ctx, s.altPutBlind) }); err != nil {
 		return err
 	}
-	success = true
 
+	// Phase B — refresh. altDs is naturally quiesced: the worker buffers,
+	// it doesn't write to altDs, and ResetCids is the only altDs writer.
+	var size int
+	if err := s.withAltDs(ctx, func() (e error) { size, e = refreshSize(ctx, s.altDs); return }); err != nil {
+		return err
+	}
+	s.altSize.Store(int64(size))
+
+	// Phase C — catch-up. One Has-checked drain of whatever the worker
+	// buffered during Phase B (or between Phase A's final drain and now).
+	// opCleanup will drain any tail that arrives after this.
+	if err := s.withAltDs(ctx, func() error { return s.drainBuf(ctx, s.altPutChecked) }); err != nil {
+		return err
+	}
+
+	success = true
 	return nil
 }
 
-// Close shuts down the ResettableKeystore. It waits for any ongoing altPut
-// operations to complete before persisting state to avoid race conditions.
-// In factory mode, the primary and (if mid-reset) alternate datastores are
-// closed since they are owned by the keystore. The metaDs is not closed
-// because it is owned by the caller.
+// Close shuts down the ResettableKeystore. It waits for the worker to exit
+// and for any in-flight altDs write from ResetCids to finish before
+// persisting state. In factory mode, the primary and (if mid-reset)
+// alternate datastores are closed since they are owned by the keystore.
+// The metaDs is not closed because it is owned by the caller.
 func (s *ResettableKeystore) Close() (err error) {
 	select {
 	case <-s.close:
 		// Already closed
 	default:
 		close(s.close)
-		<-s.done // Wait for worker to exit
-		// Wait for any ongoing altPut operations to complete by acquiring the
-		// semaphore token. This blocks if altPut is running, succeeds immediately
-		// if idle.
-		<-s.altPutSem
+		<-s.done // Wait for worker to exit (no new buffer appends after this).
+		// Wait for any in-flight altDs write from ResetCids to finish.
+		// We never release the token, so subsequent ResetCids callers fall
+		// through on <-s.done.
+		<-s.altDsBusy
 
 		// In factory mode, defer closing owned datastores (primary and alt)
 		// so they are closed even if persistSize/Sync fails. The metaDs

--- a/provider/keystore/resettable_keystore.go
+++ b/provider/keystore/resettable_keystore.go
@@ -113,9 +113,17 @@ type ResettableKeystore struct {
 	// bufDrained is the channel-as-condition idiom: every drain replaces it
 	// with a fresh empty channel, closing the previous one to wake any
 	// goroutines blocked in bufferKeys waiting for the buffer to have room.
-	bufMu      sync.Mutex
-	buf        []mh.Multihash
-	bufDrained chan struct{}
+	//
+	// resetDrainCanceled is closed by ResetCids' defer when no further drain
+	// will arrive (success or failure) and the worker must be free to
+	// receive opCleanup. bufferKeys observes it as an escape, appending the
+	// remainder unconditionally so opCleanup can still drain (success path)
+	// or discard (failure path) those keys. Allocated by opStart; only
+	// meaningful while resetInProgress is true.
+	bufMu              sync.Mutex
+	buf                []mh.Multihash
+	bufDrained         chan struct{}
+	resetDrainCanceled chan struct{}
 
 	// altDsBusy is a binary semaphore (1-deep channel, token present when
 	// altDs is idle) that serialises Close with in-flight altDs writes from
@@ -338,8 +346,14 @@ func (s *ResettableKeystore) put(ctx context.Context, keys []mh.Multihash) ([]mh
 // blocks until a drain creates room and then resumes. Inputs larger than
 // resetBufCap are buffered across multiple drain cycles rather than waiting
 // for room they could never obtain in a single pass. Returns early if the
-// keystore is closed or the request's context is cancelled.
+// keystore is closed or the request's context is cancelled. If ResetCids
+// signals resetDrainCanceled (no more drains coming, e.g. the reset's ctx
+// was cancelled mid-Phase-A with no tail drain), bufferKeys appends the
+// remainder unconditionally and returns nil; this prevents the worker from
+// being wedged while opCleanup is queued. The temporary over-cap is bounded
+// by one Put's worth and is cleared by opCleanup.
 func (s *ResettableKeystore) bufferKeys(ctx context.Context, keys []mh.Multihash) error {
+	canceled := s.resetDrainCanceled
 	s.bufMu.Lock()
 	for len(keys) > 0 {
 		if room := s.resetBufCap - len(s.buf); room > 0 {
@@ -356,6 +370,11 @@ func (s *ResettableKeystore) bufferKeys(ctx context.Context, keys []mh.Multihash
 			return ctx.Err()
 		case <-s.close:
 			return ErrClosed
+		case <-canceled:
+			s.bufMu.Lock()
+			s.buf = append(s.buf, keys...)
+			s.bufMu.Unlock()
+			return nil
 		}
 		s.bufMu.Lock()
 	}
@@ -590,6 +609,7 @@ func (s *ResettableKeystore) handleResetOp(op resetOp) {
 			op.response <- err
 			return
 		}
+		s.resetDrainCanceled = make(chan struct{})
 		s.resetInProgress = true
 		op.response <- nil
 		return
@@ -709,6 +729,11 @@ func (s *ResettableKeystore) ResetCids(ctx context.Context, keysChan <-chan cid.
 	}
 
 	defer func() {
+		// Wake any worker parked in bufferKeys: no further drain will
+		// arrive before opCleanup, and the worker must be free to receive
+		// it. Without this, a Phase-A ctx cancel with the buffer at
+		// capacity deadlocks (worker blocked, opCleanup send blocked).
+		close(s.resetDrainCanceled)
 		// Cleanup before returning on success and failure.
 		select {
 		case s.resetOps <- resetOp{ctx: ctx, op: opCleanup, success: success, response: opsChan}:

--- a/provider/keystore/resettable_keystore.go
+++ b/provider/keystore/resettable_keystore.go
@@ -73,9 +73,9 @@ type resetOp struct {
 //     c. catch-up — drain whatever the worker buffered during refresh, this
 //     time with Has-before-Put so altSize is incremented once per unique
 //     new key.
-//  3. opCleanup drains any tail of the buffer that arrived after Phase C
-//     (worker has been idle for at most a few Puts), then atomically swaps
-//     primary and altDs and persists the active namespace marker.
+//  3. opCleanup drains any tail of the buffer that arrived after Phase C,
+//     Syncs altDs (durability boundary), then atomically swaps primary and
+//     altDs and persists the active namespace marker.
 //  4. The old datastore (now alternate) is torn down (destroyed or emptied).
 //
 // Thread Safety:
@@ -408,7 +408,8 @@ func (s *ResettableKeystore) bufEmpty() bool {
 // Used by Phase A (bulk). altSize is NOT updated here; Phase B's refreshSize
 // establishes the authoritative count over the entire altDs. Duplicate Puts
 // — within a single batch or across batches — are idempotent in pebble, so
-// no per-call dedupe is performed.
+// no per-call dedupe is performed. No per-call Sync; see ResetCids for the
+// durability boundary.
 func (s *ResettableKeystore) altPutBlind(ctx context.Context, keys []mh.Multihash) error {
 	if len(keys) == 0 {
 		return nil
@@ -426,15 +427,13 @@ func (s *ResettableKeystore) altPutBlind(ctx context.Context, keys []mh.Multihas
 	if err := b.Commit(ctx); err != nil {
 		return fmt.Errorf("cannot commit keystore updates: %w", err)
 	}
-	if err := s.altDs.Sync(ctx, ds.NewKey("")); err != nil {
-		s.logger.Warnf("keystore: failed to sync datastore after alt put: %v", err)
-	}
 	return nil
 }
 
 // altPutChecked writes keys to altDs after a Has check on each, and
 // increments altSize for each unique addition. Used by Phase C (catch-up)
-// and by opCleanup's final drain.
+// and by opCleanup's final drain. No per-call Sync; Has-before-Put only
+// needs Commit visibility, not Sync.
 func (s *ResettableKeystore) altPutChecked(ctx context.Context, keys []mh.Multihash) error {
 	if len(keys) == 0 {
 		return nil
@@ -467,9 +466,6 @@ func (s *ResettableKeystore) altPutChecked(ctx context.Context, keys []mh.Multih
 		return fmt.Errorf("cannot commit keystore updates: %w", err)
 	}
 	s.altSize.Add(added)
-	if err := s.altDs.Sync(ctx, ds.NewKey("")); err != nil {
-		s.logger.Warnf("keystore: failed to sync datastore after alt put: %v", err)
-	}
 	return nil
 }
 
@@ -624,6 +620,13 @@ func (s *ResettableKeystore) handleResetOp(op resetOp) {
 	if op.success {
 		if err := s.withAltDs(ctx, func() error { return s.drainBuf(ctx, s.altPutChecked) }); err != nil {
 			s.logger.Errorf("keystore: aborting swap, final buf drain failed: %v", err)
+			op.success = false
+		}
+	}
+	if op.success {
+		// Durability boundary: altDs must be on disk before the marker flips.
+		if err := s.withAltDs(ctx, func() error { return s.altDs.Sync(ctx, ds.NewKey("")) }); err != nil {
+			s.logger.Errorf("keystore: aborting swap, altDs sync failed: %v", err)
 			op.success = false
 		}
 	}
@@ -788,6 +791,11 @@ loop:
 	}
 	if err := s.withAltDs(ctx, func() error { return s.drainBuf(ctx, s.altPutBlind) }); err != nil {
 		return err
+	}
+	// Off-worker fsync of the bulk write, so opCleanup's Sync (which runs
+	// on the worker) only has to flush Phase C's small drain.
+	if err := s.withAltDs(ctx, func() error { return s.altDs.Sync(ctx, ds.NewKey("")) }); err != nil {
+		return fmt.Errorf("phase A altDs sync: %w", err)
 	}
 
 	// Phase B — refresh. altDs is naturally quiesced: the worker buffers,

--- a/provider/keystore/resettable_keystore_test.go
+++ b/provider/keystore/resettable_keystore_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/ipfs/go-cid"
 	ds "github.com/ipfs/go-datastore"
+	"github.com/ipfs/go-datastore/query"
 	dssync "github.com/ipfs/go-datastore/sync"
 	pebble "github.com/ipfs/go-ds-pebble"
 	"github.com/libp2p/go-libp2p-kad-dht/provider/internal/keyspace"
@@ -1314,4 +1315,86 @@ func TestKeystoreResetNoHasInBulkPhase(t *testing.T) {
 	size, err := store.Size(ctx)
 	require.NoError(t, err)
 	require.Equal(t, n, size, "reset must still produce the correct size")
+}
+
+// pickMhsWithBit0 returns n multihashes whose first sha256 bit equals
+// targetBit. Used to construct keys whose dsKey path collides with the
+// shared-mode namespace prefix (namespace "/1" + dsKey "/1/...").
+func pickMhsWithBit0(t *testing.T, targetBit int, n int) []mh.Multihash {
+	t.Helper()
+	out := make([]mh.Multihash, 0, n)
+	for tries := 0; tries < 4096 && len(out) < n; tries++ {
+		h := random.Multihashes(1)[0]
+		if int(keyspace.MhToBit256(h).Bit(0)) == targetBit {
+			out = append(out, h)
+		}
+	}
+	require.Lenf(t, out, n,
+		"failed to find %d multihashes whose first sha256 bit is %d",
+		n, targetBit)
+	return out
+}
+
+// TestKeystoreResetEmptiesNamespaceCollidingKeys is a tripwire for the
+// emptySharedAltDs fix. If a future caller replaces it with the obvious
+// wrapped iterate-then-Delete path, the bug below returns silently and
+// this test catches it.
+//
+// Background: in shared-datastore mode the alt slot is "/0" or "/1",
+// and inside the slot each key is filed under "/<bit0>/<bit1>/...". So
+// a key whose first hash bit is 1, stored in slot "/1", lives at the
+// underlying path "/1/1/...".
+//
+// Bug: namespace.Wrap.Delete runs the key through ConvertKey, which
+// only adds the namespace prefix when it isn't already an ancestor. For
+// "/1/..." it isn't added, so Delete targets "/1/..." instead of
+// "/1/1/...". The real key stays behind on every reset.
+//
+// Fix: emptySharedAltDs talks to the unwrapped datastore directly and
+// deletes everything under the "/1" prefix as stored, with no rewrite.
+func TestKeystoreResetEmptiesNamespaceCollidingKeys(t *testing.T) {
+	base := dssync.MutexWrap(ds.NewMapDatastore())
+	store, err := NewResettableKeystore(base)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+
+	// Active namespace defaults to 0, so the first reset writes into
+	// altDs = "/1". Pick multihashes whose dsKey starts with "/1/...",
+	// so the underlying keys collide with the namespace prefix.
+	require.Equal(t, byte(0), store.activeNamespace,
+		"test assumes initial active namespace is 0")
+	const n = 8
+	mhs := pickMhsWithBit0(t, 1, n)
+
+	ctx := t.Context()
+	ch := make(chan cid.Cid, n)
+	for _, h := range mhs {
+		ch <- cid.NewCidV1(cid.Raw, h)
+	}
+	close(ch)
+	require.NoError(t, store.ResetCids(ctx, ch))
+
+	// After the first reset, primary is "/1" and holds n colliding keys.
+	size, err := store.Size(ctx)
+	require.NoError(t, err)
+	require.Equal(t, n, size)
+
+	// Second reset with an empty channel swaps "/1" back into altDs and
+	// triggers teardownAltDs("/1"), which runs emptySharedAltDs. This is
+	// the path under test.
+	ch2 := make(chan cid.Cid)
+	close(ch2)
+	require.NoError(t, store.ResetCids(ctx, ch2))
+
+	// No "/1/..." keys must remain in the underlying datastore. With the
+	// old wrapped-delete path, the colliding "/1/1/..." underlying keys
+	// would still be present here.
+	var leftover []string
+	for res, err := range ds.QueryIter(ctx, base, query.Query{Prefix: "/1", KeysOnly: true}) {
+		require.NoError(t, err)
+		leftover = append(leftover, res.Key)
+	}
+	require.Emptyf(t, leftover,
+		"teardown must remove all alt-namespace keys; %d orphaned: %v",
+		len(leftover), leftover)
 }

--- a/provider/keystore/resettable_keystore_test.go
+++ b/provider/keystore/resettable_keystore_test.go
@@ -3,12 +3,19 @@ package keystore
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"testing/synctest"
+	"time"
 
 	"github.com/ipfs/go-cid"
 	ds "github.com/ipfs/go-datastore"
+	dssync "github.com/ipfs/go-datastore/sync"
 	pebble "github.com/ipfs/go-ds-pebble"
 	"github.com/libp2p/go-libp2p-kad-dht/provider/internal/keyspace"
 	mh "github.com/multiformats/go-multihash"
@@ -902,4 +909,409 @@ func TestKeystoreOptionAdapter(t *testing.T) {
 	}
 
 	require.NoError(t, store.Close())
+}
+
+// slowSyncDatastore wraps a ds.Batching and blocks Sync() calls whose key
+// path starts with slowPrefix until release is closed. The first skipN
+// matching calls are allowed through unblocked — this lets the test pass
+// through the Sync that prepareAltDs.empty issues during opStart, so the
+// wedge lands on the Phase-A altPutBlind Sync instead. If wedged is
+// non-nil, it is closed when the first call actually blocks, letting tests
+// synchronise around the wedge taking effect.
+type slowSyncDatastore struct {
+	ds.Batching
+	slowPrefix string
+	skipN      int
+	count      atomic.Int64
+	release    <-chan struct{}
+	wedged     chan struct{}
+	wedgedOnce sync.Once
+}
+
+func (s *slowSyncDatastore) Sync(ctx context.Context, k ds.Key) error {
+	if !strings.HasPrefix(k.String(), s.slowPrefix) {
+		return s.Batching.Sync(ctx, k)
+	}
+	if s.count.Add(1) <= int64(s.skipN) {
+		return s.Batching.Sync(ctx, k)
+	}
+	s.wedgedOnce.Do(func() {
+		if s.wedged != nil {
+			close(s.wedged)
+		}
+	})
+	select {
+	case <-s.release:
+		return s.Batching.Sync(ctx, k)
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// TestKeystoreWorkerResponsiveWhileAltDsWedged verifies the core property of
+// the altPut-decoupling design: while a reset's altDs write is blocked inside
+// a slow underlying datastore, the keystore worker continues to serve Size/Put
+// on the primary namespace without delay.
+//
+// Regression test for the production hang where a single pebble call stayed in
+// flight for >1h, freezing every keystore operation. The fix moves all altDs
+// I/O off the worker: worker Puts go to an in-memory buffer; ResetCids' own
+// goroutine owns altDs writes. So even when altDs wedges, the worker stays
+// responsive.
+func TestKeystoreWorkerResponsiveWhileAltDsWedged(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		release := make(chan struct{})
+		defer func() {
+			select {
+			case <-release:
+			default:
+				close(release)
+			}
+		}()
+
+		base := dssync.MutexWrap(ds.NewMapDatastore())
+		// Block Sync on the alternate namespace only, so primary-side worker
+		// operations stay fast while ResetCids' altPutBlind wedges in altDs.Sync.
+		slow := &slowSyncDatastore{Batching: base, release: release, skipN: 1}
+
+		store, err := NewResettableKeystore(slow)
+		require.NoError(t, err)
+		defer store.Close()
+
+		// Derive the alt namespace prefix from the freshly-initialised store
+		// rather than hard-coding "/1". Safe to set after NewResettableKeystore
+		// because the constructor performs no Sync calls itself (the loadSize
+		// path only Gets/Deletes the size key).
+		slow.slowPrefix = fmt.Sprintf("/%d", 1-store.activeNamespace)
+
+		ctx := t.Context()
+
+		// Pre-populate primary so Size has a non-zero baseline.
+		const initial = 10
+		_, err = store.Put(ctx, random.Multihashes(initial)...)
+		require.NoError(t, err)
+
+		// Start a reset. ResetCids' first altPutBlind reaches altDs.Sync,
+		// which blocks until release is closed.
+		resetChan := make(chan cid.Cid, 1)
+		resetChan <- cid.NewCidV1(cid.Raw, random.Multihashes(1)[0])
+		close(resetChan)
+		resetDone := make(chan error, 1)
+		go func() {
+			resetDone <- store.ResetCids(ctx, resetChan)
+		}()
+
+		// Wait until ResetCids is parked inside altDs.Sync. After this,
+		// the worker must be idle in its select — any subsequent probe
+		// that hangs proves the worker was stuck behind altDs.
+		synctest.Wait()
+
+		// Probes use a short synthetic deadline so a wedged worker fails
+		// cleanly with ctx.Err() rather than deadlocking the bubble. On
+		// the happy path the deadline never fires — Size/Put round-trip
+		// through the worker in zero synthetic time.
+		expected := initial
+		probe := func() {
+			probeCtx, cancel := context.WithTimeout(ctx, time.Second)
+			defer cancel()
+			size, err := store.Size(probeCtx)
+			require.NoError(t, err, "Size must return while altDs is wedged")
+			require.Equal(t, expected, size)
+
+			const probePuts = 3
+			_, err = store.Put(probeCtx, random.Multihashes(probePuts)...)
+			require.NoError(t, err, "Put must return while altDs is wedged")
+			expected += probePuts
+		}
+		for range 5 {
+			probe()
+		}
+
+		// Sanity check: ResetCids is still in flight (its altPut is wedged).
+		select {
+		case err := <-resetDone:
+			t.Fatalf("ResetCids returned unexpectedly while altDs wedged: %v", err)
+		default:
+		}
+
+		// Release the wedge; reset must complete cleanly.
+		close(release)
+		synctest.Wait()
+		require.NoError(t, <-resetDone)
+	})
+}
+
+// TestKeystoreResetBufferBackpressure verifies that when the worker's reset
+// buffer is at capacity, additional Puts block until ResetCids drains the
+// buffer — keys are never dropped silently.
+func TestKeystoreResetBufferBackpressure(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		// Shrink the cap so we can hit it without writing millions of keys.
+		const bufCap = 10
+
+		release := make(chan struct{})
+		defer func() {
+			select {
+			case <-release:
+			default:
+				close(release)
+			}
+		}()
+
+		base := dssync.MutexWrap(ds.NewMapDatastore())
+		slow := &slowSyncDatastore{
+			Batching: base,
+			release:  release,
+			skipN:    1,
+			wedged:   make(chan struct{}),
+		}
+		store, err := NewResettableKeystore(slow, WithResetBufferCapacity(bufCap))
+		require.NoError(t, err)
+		defer store.Close()
+		slow.slowPrefix = fmt.Sprintf("/%d", 1-store.activeNamespace)
+
+		ctx := t.Context()
+
+		// Start a reset that wedges in Phase A's altDs.Sync so it can't drain
+		// the buffer.
+		resetChan := make(chan cid.Cid, 1)
+		resetChan <- cid.NewCidV1(cid.Raw, random.Multihashes(1)[0])
+		close(resetChan)
+		resetDone := make(chan error, 1)
+		go func() {
+			resetDone <- store.ResetCids(ctx, resetChan)
+		}()
+
+		// Wait until ResetCids is wedged in Phase A's Sync. Without this,
+		// the test's Puts could race ahead of opStart and bypass the buffer.
+		synctest.Wait()
+		select {
+		case <-slow.wedged:
+		default:
+			t.Fatal("ResetCids never reached the wedged altDs.Sync")
+		}
+
+		// Fill the buffer exactly to capacity.
+		_, err = store.Put(ctx, random.Multihashes(bufCap)...)
+		require.NoError(t, err, "filling the buffer to capacity should succeed")
+
+		// The next Put must block; it cannot be accepted without dropping
+		// keys, which the design forbids. synctest.Wait returns once the
+		// goroutine is durably parked in bufferKeys — a stronger guarantee
+		// than any wall-clock delay.
+		blocked := make(chan error, 1)
+		go func() {
+			_, err := store.Put(ctx, random.Multihashes(1)...)
+			blocked <- err
+		}()
+		synctest.Wait()
+		select {
+		case err := <-blocked:
+			t.Fatalf("Put should have blocked on full buffer, got err=%v", err)
+		default:
+		}
+
+		// Release the reset wedge. Phase A's drainBufBlind drains the buffer,
+		// the blocked Put wakes up and completes; ResetCids then progresses
+		// through Phase B/C and opCleanup.
+		close(release)
+		synctest.Wait()
+		require.NoError(t, <-blocked, "blocked Put must succeed after buffer drains")
+		require.NoError(t, <-resetDone)
+	})
+}
+
+// TestKeystoreResetBufferLargerThanCap verifies that a single Put larger
+// than the configured reset buffer capacity completes by buffering in
+// chunks across multiple drain cycles. Without the chunking fix in
+// bufferKeys, the old condition len(s.buf)+len(keys) > cap stayed
+// permanently true once len(keys) > cap and the worker deadlocked.
+func TestKeystoreResetBufferLargerThanCap(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		const bufCap = 10
+
+		release := make(chan struct{})
+		defer func() {
+			select {
+			case <-release:
+			default:
+				close(release)
+			}
+		}()
+
+		base := dssync.MutexWrap(ds.NewMapDatastore())
+		slow := &slowSyncDatastore{
+			Batching: base,
+			release:  release,
+			skipN:    1,
+			wedged:   make(chan struct{}),
+		}
+		store, err := NewResettableKeystore(slow, WithResetBufferCapacity(bufCap))
+		require.NoError(t, err)
+		defer store.Close()
+		slow.slowPrefix = fmt.Sprintf("/%d", 1-store.activeNamespace)
+
+		ctx := t.Context()
+
+		resetChan := make(chan cid.Cid, 1)
+		resetMh := random.Multihashes(1)[0]
+		resetChan <- cid.NewCidV1(cid.Raw, resetMh)
+		close(resetChan)
+		resetDone := make(chan error, 1)
+		go func() {
+			resetDone <- store.ResetCids(ctx, resetChan)
+		}()
+
+		// Wait until ResetCids is wedged inside altDs.Sync so the buffer
+		// cannot drain while we issue the large Put.
+		synctest.Wait()
+		select {
+		case <-slow.wedged:
+		default:
+			t.Fatal("ResetCids never reached the wedged altDs.Sync")
+		}
+
+		// Put 2x bufCap keys in a single call. The first bufCap keys fill
+		// the buffer; the remainder cannot be appended until ResetCids
+		// drains.
+		const factor = 2
+		putN := factor * bufCap
+		putMhs := random.Multihashes(putN)
+		putDone := make(chan error, 1)
+		go func() {
+			_, err := store.Put(ctx, putMhs...)
+			putDone <- err
+		}()
+
+		synctest.Wait()
+		select {
+		case err := <-putDone:
+			t.Fatalf("Put should have blocked while buffer was full, got err=%v", err)
+		default:
+		}
+
+		// Release the wedge. Phase A's final drainBuf takes the first chunk;
+		// bufferKeys wakes and appends the remaining chunk.
+		close(release)
+		synctest.Wait()
+		require.NoError(t, <-putDone, "Put must complete after enough drains")
+		require.NoError(t, <-resetDone)
+
+		// All keys (1 reset key + putN concurrent Put keys) must be present
+		// in the swapped-in primary.
+		size, err := store.Size(ctx)
+		require.NoError(t, err)
+		require.Equalf(t, putN+1, size,
+			"size should reflect reset key plus concurrent Put keys (got %d)",
+			size)
+	})
+}
+
+// TestKeystoreResetPhaseATickerDrainsSlowKeysChan verifies that Phase A's
+// periodic ticker drains the worker buffer even when keysChan stops
+// delivering, so no batch-flush drain ever fires. Without the ticker the
+// worker would block in bufferKeys forever on any concurrent Put larger
+// than the buffer capacity, because the only remaining drains would be
+// Phase A's tail drain (after keysChan closes) and Phase C's drain — at
+// most enough for 3x capacity.
+func TestKeystoreResetPhaseATickerDrainsSlowKeysChan(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		const bufCap = 5
+
+		base := dssync.MutexWrap(ds.NewMapDatastore())
+		store, err := NewResettableKeystore(base, WithResetBufferCapacity(bufCap))
+		require.NoError(t, err)
+		defer func() { require.NoError(t, store.Close()) }()
+
+		ctx := t.Context()
+
+		resetChan := make(chan cid.Cid)
+		resetDone := make(chan error, 1)
+		go func() {
+			resetDone <- store.ResetCids(ctx, resetChan)
+		}()
+
+		// Deliver one key so the channel send unblocks once Phase A picks it
+		// up — guarantees opStart finished and resetInProgress is true before
+		// the concurrent Put fires.
+		syncMh := random.Multihashes(1)[0]
+		resetChan <- cid.NewCidV1(cid.Raw, syncMh)
+
+		// Concurrent Put of 5x capacity keys, more than the 3x ceiling
+		// covered by Phase A's tail drain + Phase C's drain alone. Under
+		// synctest the Phase A ticker fires at synthetic 100ms intervals
+		// the moment all goroutines park; without the ticker the buffer
+		// would never drain and the Put would block until close(resetChan).
+		const factor = 5
+		putN := factor * bufCap
+		putMhs := random.Multihashes(putN)
+		putDone := make(chan error, 1)
+		go func() {
+			_, err := store.Put(ctx, putMhs...)
+			putDone <- err
+		}()
+		require.NoError(t, <-putDone, "Put must complete via ticker-driven drains")
+
+		close(resetChan)
+		require.NoError(t, <-resetDone)
+
+		size, err := store.Size(ctx)
+		require.NoError(t, err)
+		require.Equalf(t, putN+1, size,
+			"size should reflect sync key + concurrent Put keys (got %d)", size)
+	})
+}
+
+// hasCountingDatastore counts the number of Has() calls made against keys
+// whose path starts with the configured prefix. Used to assert that the
+// new design's Phase A never calls Has on altDs.
+type hasCountingDatastore struct {
+	ds.Batching
+	prefix string
+	count  atomic.Int64
+}
+
+func (h *hasCountingDatastore) Has(ctx context.Context, k ds.Key) (bool, error) {
+	if strings.HasPrefix(k.String(), h.prefix) {
+		h.count.Add(1)
+	}
+	return h.Batching.Has(ctx, k)
+}
+
+// TestKeystoreResetNoHasInBulkPhase verifies that a reset without
+// concurrent Puts performs zero Has() calls on altDs. This is the key
+// property that prevents the pebble.Has wedge from blocking Phase A,
+// which is by far the bulk of a reset's altDs work.
+func TestKeystoreResetNoHasInBulkPhase(t *testing.T) {
+	base := dssync.MutexWrap(ds.NewMapDatastore())
+	counter := &hasCountingDatastore{Batching: base}
+
+	store, err := NewResettableKeystore(counter)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+
+	counter.prefix = fmt.Sprintf("/%d", 1-store.activeNamespace)
+
+	ctx := t.Context()
+
+	// Reset with N keys, no concurrent Puts. Phase A blind-puts all of
+	// them; Phase B counts via Query (not Has); Phase C / opCleanup find
+	// the buffer empty. Total Has calls on altDs should be zero.
+	const n = 200
+	mhs := random.Multihashes(n)
+	ch := make(chan cid.Cid, n)
+	for _, h := range mhs {
+		ch <- cid.NewCidV1(cid.Raw, h)
+	}
+	close(ch)
+
+	require.NoError(t, store.ResetCids(ctx, ch))
+
+	require.Zero(t, counter.count.Load(),
+		"Phase A bulk reset must not call Has on altDs (got %d calls)",
+		counter.count.Load())
+
+	size, err := store.Size(ctx)
+	require.NoError(t, err)
+	require.Equal(t, n, size, "reset must still produce the correct size")
 }

--- a/provider/keystore/resettable_keystore_test.go
+++ b/provider/keystore/resettable_keystore_test.go
@@ -1208,6 +1208,108 @@ func TestKeystoreResetBufferLargerThanCap(t *testing.T) {
 	})
 }
 
+// TestKeystoreResetCtxCancelDoesNotDeadlock verifies that cancelling
+// ResetCids' context while the worker is parked in bufferKeys (buffer at
+// capacity, altDs wedged) does not deadlock the keystore.
+//
+// Pre-fix: Phase A returned ctx.Err() without running its tail drain, the
+// defer tried to send opCleanup on s.resetOps, but the worker was wedged
+// in bufferKeys waiting for a drain that would never come — and Put's own
+// ctx was independent of the reset's ctx, so nothing unblocked the worker
+// until Close().
+//
+// Post-fix: the defer closes s.resetDrainCanceled before sending opCleanup;
+// bufferKeys observes it, appends the remainder unconditionally, and the
+// worker returns to its select in time to receive opCleanup.
+func TestKeystoreResetCtxCancelDoesNotDeadlock(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		const bufCap = 10
+
+		release := make(chan struct{})
+		defer func() {
+			select {
+			case <-release:
+			default:
+				close(release)
+			}
+		}()
+
+		base := dssync.MutexWrap(ds.NewMapDatastore())
+		slow := &slowSyncDatastore{
+			Batching: base,
+			release:  release,
+			skipN:    1,
+			wedged:   make(chan struct{}),
+		}
+		store, err := NewResettableKeystore(slow, WithResetBufferCapacity(bufCap))
+		require.NoError(t, err)
+		defer store.Close()
+		slow.slowPrefix = fmt.Sprintf("/%d", 1-store.activeNamespace)
+
+		// Reset gets its own cancellable ctx so we can cancel it without
+		// also cancelling the probe Put contexts.
+		resetCtx, resetCancel := context.WithCancel(t.Context())
+		defer resetCancel()
+
+		resetChan := make(chan cid.Cid, 1)
+		resetChan <- cid.NewCidV1(cid.Raw, random.Multihashes(1)[0])
+		close(resetChan)
+		resetDone := make(chan error, 1)
+		go func() {
+			resetDone <- store.ResetCids(resetCtx, resetChan)
+		}()
+
+		// Wait until ResetCids is wedged in Phase A's altDs.Sync.
+		synctest.Wait()
+		select {
+		case <-slow.wedged:
+		default:
+			t.Fatal("ResetCids never reached the wedged altDs.Sync")
+		}
+
+		ctx := t.Context()
+
+		// Fill the buffer exactly to capacity.
+		_, err = store.Put(ctx, random.Multihashes(bufCap)...)
+		require.NoError(t, err, "filling the buffer to capacity should succeed")
+
+		// One more Put must block in bufferKeys: buffer is full, no drain
+		// is coming (altDs.Sync wedged, no Phase-A flush will fire because
+		// keysChan is already drained).
+		blocked := make(chan error, 1)
+		go func() {
+			_, err := store.Put(ctx, random.Multihashes(1)...)
+			blocked <- err
+		}()
+		synctest.Wait()
+		select {
+		case err := <-blocked:
+			t.Fatalf("Put should have blocked on full buffer, got err=%v", err)
+		default:
+		}
+
+		// Cancel the reset's ctx. Pre-fix this deadlocked: ResetCids' defer
+		// sent opCleanup on s.resetOps but the worker was wedged in
+		// bufferKeys, and the Put's own ctx (t.Context()) was still alive.
+		resetCancel()
+		synctest.Wait()
+
+		require.ErrorIs(t, <-resetDone, context.Canceled)
+		require.NoError(t, <-blocked,
+			"blocked Put must unblock once the reset's ctx is cancelled")
+
+		// Keystore must remain responsive after the cancelled reset.
+		const post = 3
+		_, err = store.Put(ctx, random.Multihashes(post)...)
+		require.NoError(t, err)
+		size, err := store.Size(ctx)
+		require.NoError(t, err)
+		require.Equalf(t, bufCap+1+post, size,
+			"primary should hold bufCap fill + blocked Put + post-cancel Puts (got %d)",
+			size)
+	})
+}
+
 // TestKeystoreResetPhaseATickerDrainsSlowKeysChan verifies that Phase A's
 // periodic ticker drains the worker buffer even when keysChan stops
 // delivering, so no batch-flush drain ever fires. Without the ticker the


### PR DESCRIPTION
## Unresponsive worker during reset

Previously a slow `altDs` could block `Put()` operations to the main Keystore during a reset.

This PR addresses that by having a dedicated go routine write to `altDs` during resets.

## Slow `Reset()`

In addition, the `Reset()` operation was slow because it was checking `Has`-before-`Write` to keep the `altDs` size up-to-date.

This PR changes how `Reset()` works by having the following phases:
1. Read from `keyChan` and put unconditionally to `altDs`, also put unconditionally to `altDs` newly added keys.
2. Compute `altDs` size (by iterating on all keys), and buffer any newly added keys
3. Conditionally (Has-before-Write) add buffered keys to `altDs` and update size accordingly
4. Swap active datastore with `altDs`, which completes the reset operation