### PR TITLE
fix: cut reprovide peak memory with key count

### DIFF
--- a/provider/keystore/keystore.go
+++ b/provider/keystore/keystore.go
@@ -40,10 +40,12 @@ var (
 type Keystore interface {
 	Put(context.Context, ...mh.Multihash) ([]mh.Multihash, error)
 	Get(context.Context, bitstr.Key) ([]mh.Multihash, error)
-	// KeyCount returns how many stored multihashes match the prefix without
-	// materialising them, so callers can size or split a region before loading
-	// it with Get.
-	KeyCount(context.Context, bitstr.Key) (int, error)
+	// CountKeysUpTo returns how many stored multihashes match the prefix, capped
+	// at limit, without materialising them. It stops scanning once limit matches
+	// are found, so callers can cheaply decide whether a region exceeds a
+	// threshold before loading it with Get. The result is min(matches, limit) for
+	// a positive limit; a non-positive limit counts every match.
+	CountKeysUpTo(context.Context, bitstr.Key, int) (int, error)
 	ContainsPrefix(context.Context, bitstr.Key) (bool, error)
 	Delete(context.Context, ...mh.Multihash) error
 	Empty(context.Context) error
@@ -72,6 +74,7 @@ type operation struct {
 	ctx      context.Context
 	keys     []mh.Multihash
 	prefix   bitstr.Key
+	limit    int
 	response chan<- operationResponse
 }
 
@@ -239,7 +242,7 @@ func (s *keystore) worker() {
 				op.response <- operationResponse{size: s.size}
 
 			case opCount:
-				n, err := s.count(op.ctx, op.prefix)
+				n, err := s.countUpTo(op.ctx, op.prefix, op.limit)
 				op.response <- operationResponse{size: n, err: err}
 
 			default:
@@ -349,14 +352,23 @@ func (s *keystore) get(ctx context.Context, prefix bitstr.Key) ([]mh.Multihash, 
 	return out, nil
 }
 
-// count returns the number of stored multihashes whose bit256 representation
-// matches the provided prefix. It runs a keys-only datastore query and never
-// materialises the multihash values, so its memory use is bounded regardless of
-// how many keys match (unlike get, which builds a slice of all matches).
-func (s *keystore) count(ctx context.Context, prefix bitstr.Key) (int, error) {
+// countUpTo returns the number of stored multihashes whose bit256
+// representation matches the provided prefix, capped at limit. It runs a
+// keys-only datastore query and never materialises the multihash values, so its
+// memory use is bounded regardless of how many keys match (unlike get, which
+// builds a slice of all matches). When limit is positive it stops scanning once
+// limit matches are found, so it never iterates a large region just to learn it
+// is large; a non-positive limit counts every match.
+func (s *keystore) countUpTo(ctx context.Context, prefix bitstr.Key, limit int) (int, error) {
 	longPrefix := prefix.BitLen() > s.prefixBits
 	dsk := dsKey(prefix, s.prefixBits).String()
 	q := query.Query{Prefix: dsk, KeysOnly: true}
+	if limit > 0 && !longPrefix {
+		// Every key under the datastore prefix matches, so the datastore can stop
+		// once it has returned enough. Long prefixes still need per-key filtering
+		// below, so they can't delegate the cap to the query.
+		q.Limit = limit
+	}
 	n := 0
 	for r, err := range ds.QueryIter(ctx, s.ds, q) {
 		if err != nil {
@@ -373,6 +385,9 @@ func (s *keystore) count(ctx context.Context, prefix bitstr.Key) (int, error) {
 			}
 		}
 		n++
+		if limit > 0 && n >= limit {
+			break
+		}
 	}
 	return n, nil
 }
@@ -500,7 +515,7 @@ func refreshSize(ctx context.Context, d ds.Datastore) (size int, err error) {
 // executeOperation sends an operation request to the worker goroutine and
 // waits for the response. It handles the communication protocol and returns
 // the results based on the operation type.
-func (s *keystore) executeOperation(op opType, ctx context.Context, keys []mh.Multihash, prefix bitstr.Key) ([]mh.Multihash, int, bool, error) {
+func (s *keystore) executeOperation(op opType, ctx context.Context, keys []mh.Multihash, prefix bitstr.Key, limit int) ([]mh.Multihash, int, bool, error) {
 	response := make(chan operationResponse, 1)
 	select {
 	case s.requests <- operation{
@@ -508,6 +523,7 @@ func (s *keystore) executeOperation(op opType, ctx context.Context, keys []mh.Mu
 		ctx:      ctx,
 		keys:     keys,
 		prefix:   prefix,
+		limit:    limit,
 		response: response,
 	}:
 	case <-ctx.Done():
@@ -536,23 +552,25 @@ func (s *keystore) Put(ctx context.Context, keys ...mh.Multihash) ([]mh.Multihas
 	if len(keys) == 0 {
 		return nil, nil
 	}
-	newKeys, _, _, err := s.executeOperation(opPut, ctx, keys, "")
+	newKeys, _, _, err := s.executeOperation(opPut, ctx, keys, "", 0)
 	return newKeys, err
 }
 
 // Get returns all keys whose bit256 representation matches the provided
 // prefix.
 func (s *keystore) Get(ctx context.Context, prefix bitstr.Key) ([]mh.Multihash, error) {
-	keys, _, _, err := s.executeOperation(opGet, ctx, nil, prefix)
+	keys, _, _, err := s.executeOperation(opGet, ctx, nil, prefix, 0)
 	return keys, err
 }
 
-// KeyCount returns the number of stored multihashes whose bit256 key matches
-// the provided prefix, without materialising the multihashes. This lets callers
-// size a region (e.g. to decide whether to split a very large one) before
-// loading it into memory with Get.
-func (s *keystore) KeyCount(ctx context.Context, prefix bitstr.Key) (int, error) {
-	_, n, _, err := s.executeOperation(opCount, ctx, nil, prefix)
+// CountKeysUpTo returns the number of stored multihashes whose bit256 key
+// matches the provided prefix, capped at limit, without materialising the
+// multihashes. For a positive limit it stops scanning once limit matches are
+// found, letting callers cheaply decide e.g. whether a region exceeds a
+// threshold before loading it with Get; a non-positive limit counts every
+// match. The result is min(matches, limit) for a positive limit.
+func (s *keystore) CountKeysUpTo(ctx context.Context, prefix bitstr.Key, limit int) (int, error) {
+	_, n, _, err := s.executeOperation(opCount, ctx, nil, prefix, limit)
 	return n, err
 }
 
@@ -560,13 +578,13 @@ func (s *keystore) KeyCount(ctx context.Context, prefix bitstr.Key) (int, error)
 // multihash whose kademlia identifier (bit256.Key) starts with the provided
 // bit-prefix.
 func (s *keystore) ContainsPrefix(ctx context.Context, prefix bitstr.Key) (bool, error) {
-	_, _, found, err := s.executeOperation(opContainsPrefix, ctx, nil, prefix)
+	_, _, found, err := s.executeOperation(opContainsPrefix, ctx, nil, prefix, 0)
 	return found, err
 }
 
 // Empty deletes all entries under the datastore prefix.
 func (s *keystore) Empty(ctx context.Context) error {
-	_, _, _, err := s.executeOperation(opEmpty, ctx, nil, "")
+	_, _, _, err := s.executeOperation(opEmpty, ctx, nil, "", 0)
 	return err
 }
 
@@ -575,7 +593,7 @@ func (s *keystore) Delete(ctx context.Context, keys ...mh.Multihash) error {
 	if len(keys) == 0 {
 		return nil
 	}
-	_, _, _, err := s.executeOperation(opDelete, ctx, keys, "")
+	_, _, _, err := s.executeOperation(opDelete, ctx, keys, "", 0)
 	return err
 }
 
@@ -584,7 +602,7 @@ func (s *keystore) Delete(ctx context.Context, keys ...mh.Multihash) error {
 // The size is obtained by iterating over all keys in the underlying
 // datastore, so it may be expensive for large stores.
 func (s *keystore) Size(ctx context.Context) (int, error) {
-	_, size, _, err := s.executeOperation(opSize, ctx, nil, "")
+	_, size, _, err := s.executeOperation(opSize, ctx, nil, "", 0)
 	return size, err
 }
 

--- a/provider/keystore/keystore.go
+++ b/provider/keystore/keystore.go
@@ -40,6 +40,10 @@ var (
 type Keystore interface {
 	Put(context.Context, ...mh.Multihash) ([]mh.Multihash, error)
 	Get(context.Context, bitstr.Key) ([]mh.Multihash, error)
+	// KeyCount returns how many stored multihashes match the prefix without
+	// materialising them, so callers can size or split a region before loading
+	// it with Get.
+	KeyCount(context.Context, bitstr.Key) (int, error)
 	ContainsPrefix(context.Context, bitstr.Key) (bool, error)
 	Delete(context.Context, ...mh.Multihash) error
 	Empty(context.Context) error
@@ -58,6 +62,7 @@ const (
 	opDelete
 	opEmpty
 	opSize
+	opCount
 	lastOp
 )
 
@@ -233,6 +238,10 @@ func (s *keystore) worker() {
 			case opSize:
 				op.response <- operationResponse{size: s.size}
 
+			case opCount:
+				n, err := s.count(op.ctx, op.prefix)
+				op.response <- operationResponse{size: n, err: err}
+
 			default:
 				op.response <- operationResponse{err: fmt.Errorf("unknown operation %d", op.op)}
 			}
@@ -338,6 +347,34 @@ func (s *keystore) get(ctx context.Context, prefix bitstr.Key) ([]mh.Multihash, 
 	}
 
 	return out, nil
+}
+
+// count returns the number of stored multihashes whose bit256 representation
+// matches the provided prefix. It runs a keys-only datastore query and never
+// materialises the multihash values, so its memory use is bounded regardless of
+// how many keys match (unlike get, which builds a slice of all matches).
+func (s *keystore) count(ctx context.Context, prefix bitstr.Key) (int, error) {
+	longPrefix := prefix.BitLen() > s.prefixBits
+	dsk := dsKey(prefix, s.prefixBits).String()
+	q := query.Query{Prefix: dsk, KeysOnly: true}
+	n := 0
+	for r, err := range ds.QueryIter(ctx, s.ds, q) {
+		if err != nil {
+			return 0, err
+		}
+		// Depending on prefix length, filter out non matching keys
+		if longPrefix {
+			k, err := s.decodeKey(r.Key)
+			if err != nil {
+				return 0, err
+			}
+			if !keyspace.IsPrefix(prefix, k) {
+				continue
+			}
+		}
+		n++
+	}
+	return n, nil
 }
 
 // containsPrefix reports whether the Keystore currently holds at least one
@@ -508,6 +545,15 @@ func (s *keystore) Put(ctx context.Context, keys ...mh.Multihash) ([]mh.Multihas
 func (s *keystore) Get(ctx context.Context, prefix bitstr.Key) ([]mh.Multihash, error) {
 	keys, _, _, err := s.executeOperation(opGet, ctx, nil, prefix)
 	return keys, err
+}
+
+// KeyCount returns the number of stored multihashes whose bit256 key matches
+// the provided prefix, without materialising the multihashes. This lets callers
+// size a region (e.g. to decide whether to split a very large one) before
+// loading it into memory with Get.
+func (s *keystore) KeyCount(ctx context.Context, prefix bitstr.Key) (int, error) {
+	_, n, _, err := s.executeOperation(opCount, ctx, nil, prefix)
+	return n, err
 }
 
 // ContainsPrefix reports whether the Keystore currently holds at least one

--- a/provider/keystore/keystore_test.go
+++ b/provider/keystore/keystore_test.go
@@ -3,6 +3,7 @@ package keystore
 import (
 	"context"
 	"crypto/rand"
+	"errors"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -205,14 +206,22 @@ func TestKeystoreCountKeysUpTo(t *testing.T) {
 		testKeystoreCountKeysUpToImpl(t, store, bucket, bucketKeys, otherKeys)
 	})
 
-	// Exercise the ResettableKeystore in factory mode, matching how Kubo
-	// constructs it (keystore.WithDatastoreFactory). Factory mode keeps each
-	// namespace in its own datastore with no namespace.Wrap, so keys whose path
-	// starts with the active-namespace digit (e.g. bit 0 under namespace "/0")
-	// still decode correctly for prefixes longer than prefixBits. The default
-	// shared-datastore constructor has a namespace.Wrap round-trip bug on that
-	// path; Kubo sidesteps it by using factory mode, and so does this test.
-	t.Run("ResettableKeystore", func(t *testing.T) {
+	// Exercise the ResettableKeystore in both storage modes. They take
+	// different datastore paths that countUpTo's long-prefix decodeKey/IsPrefix
+	// filter must round-trip correctly: shared mode wraps both reset slots under
+	// the non-colliding "/k0" and "/k1" prefixes via namespace.Wrap (see
+	// sharedSlotPrefix), while factory mode (how Kubo runs it, for full disk
+	// reclamation) keeps each namespace in its own datastore.
+	t.Run("ResettableKeystore/shared", func(t *testing.T) {
+		store, err := NewResettableKeystore(ds.NewMapDatastore(),
+			KeystoreOption(WithPrefixBits(prefixBits)))
+		require.NoError(t, err)
+		defer store.Close()
+
+		testKeystoreCountKeysUpToImpl(t, store, bucket, bucketKeys, otherKeys)
+	})
+
+	t.Run("ResettableKeystore/factory", func(t *testing.T) {
 		create, destroy := mapDatastoreFactory()
 		store, err := NewResettableKeystore(ds.NewMapDatastore(),
 			WithDatastoreFactory(create, destroy),
@@ -381,6 +390,70 @@ func TestKeystoreCountKeysUpToStopsEarly(t *testing.T) {
 				"short-prefix count read %d entries for cap %d", c.reads.Load(), limit)
 		}
 	})
+}
+
+// failingQueryDatastore makes every datastore query fail once armed. It lets a
+// test drive countUpTo's query down its error path without disturbing the size
+// scan that the keystore runs at startup.
+type failingQueryDatastore struct {
+	ds.Batching
+	fail atomic.Bool
+	err  error
+}
+
+func (d *failingQueryDatastore) Query(ctx context.Context, q query.Query) (query.Results, error) {
+	if d.fail.Load() {
+		return nil, d.err
+	}
+	return d.Batching.Query(ctx, q)
+}
+
+// TestKeystoreCountKeysUpToPropagatesQueryError checks that CountKeysUpTo
+// surfaces a datastore query failure to its caller. The provider reschedules a
+// region when this count fails, so a swallowed error would silently skip that
+// reschedule.
+func TestKeystoreCountKeysUpToPropagatesQueryError(t *testing.T) {
+	ctx := context.Background()
+	wantErr := errors.New("datastore query failed")
+	d := &failingQueryDatastore{Batching: ds.NewMapDatastore(), err: wantErr}
+
+	store, err := NewKeystore(d)
+	require.NoError(t, err)
+	defer store.Close()
+
+	// Size completes the startup size scan, so arming the failure now affects
+	// only the count query that follows.
+	_, err = store.Size(ctx)
+	require.NoError(t, err)
+	d.fail.Store(true)
+
+	n, err := store.CountKeysUpTo(ctx, bitstr.Key("1"), 0)
+	require.ErrorIs(t, err, wantErr)
+	require.Zero(t, n)
+}
+
+// TestKeystoreCountKeysUpToPropagatesDecodeError checks that CountKeysUpTo
+// surfaces a key it cannot decode. A prefix longer than prefixBits makes
+// countUpTo decode every matching datastore key to filter it, so a stored key
+// with a corrupt suffix must turn into an error rather than a wrong count.
+func TestKeystoreCountKeysUpToPropagatesDecodeError(t *testing.T) {
+	ctx := context.Background()
+	const prefixBits = 8
+	d := ds.NewMapDatastore()
+
+	// A key in the all-zero bucket whose final component is not valid base64url.
+	// decodeKey base64-decodes that suffix, so it fails on this key.
+	corrupt := ds.NewKey("/0/0/0/0/0/0/0/0/!not-base64")
+	require.NoError(t, d.Put(ctx, corrupt, []byte("v")))
+
+	store, err := NewKeystore(d, WithPrefixBits(prefixBits))
+	require.NoError(t, err)
+	defer store.Close()
+
+	// A 9-bit prefix exceeds prefixBits, so countUpTo decodes each matching key.
+	n, err := store.CountKeysUpTo(ctx, bitstr.Key(strings.Repeat("0", prefixBits+1)), 0)
+	require.Error(t, err)
+	require.Zero(t, n)
 }
 
 func TestKeystoreDelete(t *testing.T) {

--- a/provider/keystore/keystore_test.go
+++ b/provider/keystore/keystore_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"crypto/rand"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	ds "github.com/ipfs/go-datastore"
+	"github.com/ipfs/go-datastore/query"
 	"github.com/libp2p/go-libp2p-kad-dht/provider/internal/keyspace"
 	mh "github.com/multiformats/go-multihash"
 
@@ -182,10 +184,10 @@ func testKeystoreContainsPrefixImpl(t *testing.T, store Keystore) {
 	require.False(t, ok)
 }
 
-func TestKeystoreKeyCount(t *testing.T) {
-	// A small prefixBits keeps the "long" prefixes that exercise count's per-key
-	// decodeKey/IsPrefix filter (those exceeding prefixBits) only a few bits
-	// long, so the rejection sampling below stays cheap.
+func TestKeystoreCountKeysUpTo(t *testing.T) {
+	// A small prefixBits keeps the "long" prefixes that exercise countUpTo's
+	// per-key decodeKey/IsPrefix filter (those exceeding prefixBits) only a few
+	// bits long, so the rejection sampling below stays cheap.
 	const prefixBits = 8
 	bucket := bitstr.Key(strings.Repeat("0", prefixBits))      // "00000000"
 	otherBucket := bitstr.Key(strings.Repeat("1", prefixBits)) // "11111111"
@@ -200,7 +202,7 @@ func TestKeystoreKeyCount(t *testing.T) {
 		require.NoError(t, err)
 		defer store.Close()
 
-		testKeystoreKeyCountImpl(t, store, bucket, bucketKeys, otherKeys)
+		testKeystoreCountKeysUpToImpl(t, store, bucket, bucketKeys, otherKeys)
 	})
 
 	// Exercise the ResettableKeystore in factory mode, matching how Kubo
@@ -218,20 +220,20 @@ func TestKeystoreKeyCount(t *testing.T) {
 		require.NoError(t, err)
 		defer store.Close()
 
-		testKeystoreKeyCountImpl(t, store, bucket, bucketKeys, otherKeys)
+		testKeystoreCountKeysUpToImpl(t, store, bucket, bucketKeys, otherKeys)
 	})
 }
 
-func testKeystoreKeyCountImpl(t *testing.T, store Keystore, bucket bitstr.Key, bucketKeys, otherKeys []mh.Multihash) {
+func testKeystoreCountKeysUpToImpl(t *testing.T, store Keystore, bucket bitstr.Key, bucketKeys, otherKeys []mh.Multihash) {
 	ctx := context.Background()
 
-	// Empty keystore counts zero.
-	n, err := store.KeyCount(ctx, bitstr.Key("1"))
+	// Empty keystore counts zero (limit 0 means no cap).
+	n, err := store.CountKeysUpTo(ctx, bitstr.Key("1"), 0)
 	require.NoError(t, err)
 	require.Zero(t, n)
 
 	// bucketKeys share the bucket prefix (prefixBits), so they land in one
-	// datastore bucket. A prefix longer than prefixBits then exercises count's
+	// datastore bucket. A prefix longer than prefixBits then exercises countUpTo's
 	// per-key filter (decodeKey and IsPrefix), the path that differs from a
 	// plain datastore prefix scan. otherKeys live in a different bucket so counts
 	// must filter rather than just total the keystore.
@@ -245,29 +247,140 @@ func testKeystoreKeyCountImpl(t *testing.T, store Keystore, bucket bitstr.Key, b
 	// that diverge in the extra bits.
 	longPrefix := bitstr.Key(key.BitString(keyspace.MhToBit256(bucketKeys[0]))[:len(bucket)+4])
 
-	// KeyCount must agree with len(Get) for every prefix, across the short
-	// (<=prefixBits) and long (>prefixBits) branches.
+	// With no cap (limit 0), CountKeysUpTo must agree with len(Get) for every
+	// prefix, across the short (<=prefixBits) and long (>prefixBits) branches.
 	for _, prefix := range []bitstr.Key{"0", "1", bucket, longPrefix} {
 		got, err := store.Get(ctx, prefix)
 		require.NoError(t, err)
-		n, err := store.KeyCount(ctx, prefix)
+		n, err := store.CountKeysUpTo(ctx, prefix, 0)
 		require.NoError(t, err)
-		require.Equal(t, len(got), n, "KeyCount disagrees with Get for prefix %q", prefix)
+		require.Equalf(t, len(got), n, "CountKeysUpTo disagrees with Get for prefix %q", prefix)
 	}
 
-	// Exact counts: the full bucket, empty prefix and a prefix matching neither
-	// bucket in a non-empty keystore.
-	n, err = store.KeyCount(ctx, bucket)
+	// Exact uncapped counts: the full bucket, empty prefix and a prefix matching
+	// neither bucket in a non-empty keystore.
+	n, err = store.CountKeysUpTo(ctx, bucket, 0)
 	require.NoError(t, err)
 	require.Equal(t, len(bucketKeys), n)
 
-	n, err = store.KeyCount(ctx, "")
+	n, err = store.CountKeysUpTo(ctx, "", 0)
 	require.NoError(t, err)
 	require.Equal(t, len(bucketKeys)+len(otherKeys), n)
 
-	n, err = store.KeyCount(ctx, bitstr.Key("01"))
+	n, err = store.CountKeysUpTo(ctx, bitstr.Key("01"), 0)
 	require.NoError(t, err)
 	require.Zero(t, n)
+
+	// A negative limit means no cap, just like 0.
+	n, err = store.CountKeysUpTo(ctx, "", -1)
+	require.NoError(t, err)
+	require.Equal(t, len(bucketKeys)+len(otherKeys), n)
+
+	// A positive limit caps the result at min(total, limit). Sweep limits below,
+	// at and above the total for the short branch (bucket, ""), the long branch
+	// (longPrefix), and a non-matching prefix, so the early-exit and cap hold on
+	// every path.
+	for _, prefix := range []bitstr.Key{bucket, "", longPrefix, bitstr.Key("01")} {
+		total, err := store.CountKeysUpTo(ctx, prefix, 0)
+		require.NoError(t, err)
+		for limit := 1; limit <= total+2; limit++ {
+			n, err := store.CountKeysUpTo(ctx, prefix, limit)
+			require.NoError(t, err)
+			require.Equalf(t, min(total, limit), n, "CountKeysUpTo(%q, %d)", prefix, limit)
+		}
+	}
+}
+
+// countingDatastore wraps a datastore and counts how many query entries are
+// pulled through it, so a test can assert that CountKeysUpTo stops scanning once
+// it has enough matches instead of reading the whole match set.
+type countingDatastore struct {
+	ds.Batching
+	reads atomic.Int64
+}
+
+func (c *countingDatastore) Query(ctx context.Context, q query.Query) (query.Results, error) {
+	res, err := c.Batching.Query(ctx, q)
+	if err != nil {
+		return nil, err
+	}
+	// Re-serve the underlying entries through an iterator that counts each one
+	// the consumer pulls. The inner datastore still applies q (prefix, limit,
+	// keys-only), so a short-prefix count delegating its cap to query.Limit reads
+	// only that many entries here.
+	entries, err := res.Rest()
+	if err != nil {
+		return nil, err
+	}
+	i := 0
+	return query.ResultsFromIterator(q, query.Iterator{
+		Next: func() (query.Result, bool) {
+			if i >= len(entries) {
+				return query.Result{}, false
+			}
+			e := entries[i]
+			i++
+			c.reads.Add(1)
+			return query.Result{Entry: e}, true
+		},
+	}), nil
+}
+
+func TestKeystoreCountKeysUpToStopsEarly(t *testing.T) {
+	// prefixBits 0 keeps every key under a single datastore path, so a non-empty
+	// prefix always takes countUpTo's per-key filter branch (BitLen > prefixBits)
+	// while the empty prefix takes the query.Limit-delegation branch. Every key
+	// matches the 1-bit prefix "0", so they are cheap to generate yet numerous
+	// enough that a full scan is plainly distinguishable from an early exit.
+	const total = 512
+	keys := genMultihashesMatchingPrefix("0", total)
+
+	newStore := func(t *testing.T) (Keystore, *countingDatastore) {
+		c := &countingDatastore{Batching: ds.NewMapDatastore()}
+		store, err := NewKeystore(c, WithPrefixBits(0))
+		require.NoError(t, err)
+		_, err = store.Put(context.Background(), keys...)
+		require.NoError(t, err)
+		c.reads.Store(0) // discard reads from setup
+		t.Cleanup(func() { _ = store.Close() })
+		return store, c
+	}
+
+	t.Run("filter branch breaks at the cap", func(t *testing.T) {
+		// "0" matches every key but is longer than prefixBits, so countUpTo filters
+		// per key and relies on its own break to stop. A small cap returns the cap
+		// and reads far fewer than total entries (the cap plus the datastore's
+		// keys-only read-ahead buffer, not the whole bucket).
+		const limit = 3
+		store, c := newStore(t)
+		n, err := store.CountKeysUpTo(context.Background(), "0", limit)
+		require.NoError(t, err)
+		require.Equal(t, limit, n)
+		require.Lessf(t, c.reads.Load(), int64(total),
+			"capped count read %d of %d entries instead of stopping early", c.reads.Load(), total)
+	})
+
+	t.Run("filter branch scans everything when uncapped", func(t *testing.T) {
+		store, c := newStore(t)
+		n, err := store.CountKeysUpTo(context.Background(), "0", 0)
+		require.NoError(t, err)
+		require.Equal(t, total, n)
+		require.Equalf(t, int64(total), c.reads.Load(),
+			"uncapped count read %d entries, expected every one of %d", c.reads.Load(), total)
+	})
+
+	t.Run("short prefix delegates the cap to the query", func(t *testing.T) {
+		// The empty prefix has BitLen 0 (<= prefixBits), so countUpTo sets
+		// query.Limit and the datastore hands back exactly the cap entries.
+		for _, limit := range []int{1, 3, 50} {
+			store, c := newStore(t)
+			n, err := store.CountKeysUpTo(context.Background(), "", limit)
+			require.NoError(t, err)
+			require.Equal(t, limit, n)
+			require.Equalf(t, int64(limit), c.reads.Load(),
+				"short-prefix count read %d entries for cap %d", c.reads.Load(), limit)
+		}
+	})
 }
 
 func TestKeystoreDelete(t *testing.T) {

--- a/provider/keystore/keystore_test.go
+++ b/provider/keystore/keystore_test.go
@@ -100,6 +100,26 @@ func genMultihashesMatchingPrefix(prefix bitstr.Key, n int) []mh.Multihash {
 	return mhs
 }
 
+// mapDatastoreFactory returns an in-memory WithDatastoreFactory pair, mirroring
+// how Kubo runs the ResettableKeystore in factory mode (separate per-namespace
+// datastores) but without touching the filesystem.
+func mapDatastoreFactory() (func(string) (ds.Batching, error), func(string) error) {
+	stores := map[string]ds.Batching{}
+	create := func(suffix string) (ds.Batching, error) {
+		d := ds.NewMapDatastore()
+		stores[suffix] = d
+		return d, nil
+	}
+	destroy := func(suffix string) error {
+		if d, ok := stores[suffix]; ok {
+			_ = d.Close()
+			delete(stores, suffix)
+		}
+		return nil
+	}
+	return create, destroy
+}
+
 func TestKeyStoreContainsPrefix(t *testing.T) {
 	t.Run("Keystore", func(t *testing.T) {
 		ds := ds.NewMapDatastore()
@@ -160,6 +180,90 @@ func testKeystoreContainsPrefixImpl(t *testing.T, store Keystore) {
 	ok, err = store.ContainsPrefix(ctx, bitstr.Key(strings.Repeat("0", 8)+"1"))
 	require.NoError(t, err)
 	require.False(t, ok)
+}
+
+func TestKeystoreKeyCount(t *testing.T) {
+	// A small prefixBits keeps the "long" prefixes that exercise count's per-key
+	// decodeKey/IsPrefix filter (those exceeding prefixBits) only a few bits
+	// long, so the rejection sampling below stays cheap.
+	const prefixBits = 8
+	bucket := bitstr.Key(strings.Repeat("0", prefixBits))      // "00000000"
+	otherBucket := bitstr.Key(strings.Repeat("1", prefixBits)) // "11111111"
+	// Generate the keys once and reuse them across both store implementations.
+	bucketKeys := genMultihashesMatchingPrefix(bucket, 3)
+	otherKeys := genMultihashesMatchingPrefix(otherBucket, 2)
+
+	t.Run("Keystore", func(t *testing.T) {
+		ds := ds.NewMapDatastore()
+		defer ds.Close()
+		store, err := NewKeystore(ds, WithPrefixBits(prefixBits))
+		require.NoError(t, err)
+		defer store.Close()
+
+		testKeystoreKeyCountImpl(t, store, bucket, bucketKeys, otherKeys)
+	})
+
+	// Exercise the ResettableKeystore in factory mode, matching how Kubo
+	// constructs it (keystore.WithDatastoreFactory). Factory mode keeps each
+	// namespace in its own datastore with no namespace.Wrap, so keys whose path
+	// starts with the active-namespace digit (e.g. bit 0 under namespace "/0")
+	// still decode correctly for prefixes longer than prefixBits. The default
+	// shared-datastore constructor has a namespace.Wrap round-trip bug on that
+	// path; Kubo sidesteps it by using factory mode, and so does this test.
+	t.Run("ResettableKeystore", func(t *testing.T) {
+		create, destroy := mapDatastoreFactory()
+		store, err := NewResettableKeystore(ds.NewMapDatastore(),
+			WithDatastoreFactory(create, destroy),
+			KeystoreOption(WithPrefixBits(prefixBits)))
+		require.NoError(t, err)
+		defer store.Close()
+
+		testKeystoreKeyCountImpl(t, store, bucket, bucketKeys, otherKeys)
+	})
+}
+
+func testKeystoreKeyCountImpl(t *testing.T, store Keystore, bucket bitstr.Key, bucketKeys, otherKeys []mh.Multihash) {
+	ctx := context.Background()
+
+	// Empty keystore counts zero.
+	n, err := store.KeyCount(ctx, bitstr.Key("1"))
+	require.NoError(t, err)
+	require.Zero(t, n)
+
+	// bucketKeys share the bucket prefix (prefixBits), so they land in one
+	// datastore bucket. A prefix longer than prefixBits then exercises count's
+	// per-key filter (decodeKey and IsPrefix), the path that differs from a
+	// plain datastore prefix scan. otherKeys live in a different bucket so counts
+	// must filter rather than just total the keystore.
+	_, err = store.Put(ctx, bucketKeys...)
+	require.NoError(t, err)
+	_, err = store.Put(ctx, otherKeys...)
+	require.NoError(t, err)
+
+	// A prefix 4 bits longer than the bucket (so > prefixBits), derived from a
+	// real key so it matches that key while the filter discards bucket peers
+	// that diverge in the extra bits.
+	longPrefix := bitstr.Key(key.BitString(keyspace.MhToBit256(bucketKeys[0]))[:len(bucket)+4])
+
+	// KeyCount must agree with len(Get) for every prefix, across the short
+	// (<=prefixBits) and long (>prefixBits) branches.
+	for _, prefix := range []bitstr.Key{"0", "1", bucket, longPrefix} {
+		got, err := store.Get(ctx, prefix)
+		require.NoError(t, err)
+		n, err := store.KeyCount(ctx, prefix)
+		require.NoError(t, err)
+		require.Equal(t, len(got), n, "KeyCount disagrees with Get for prefix %q", prefix)
+	}
+
+	// Exact counts: the full bucket, and a prefix matching neither bucket in a
+	// non-empty keystore.
+	n, err = store.KeyCount(ctx, bucket)
+	require.NoError(t, err)
+	require.Equal(t, len(bucketKeys), n)
+
+	n, err = store.KeyCount(ctx, bitstr.Key("01"))
+	require.NoError(t, err)
+	require.Zero(t, n)
 }
 
 func TestKeystoreDelete(t *testing.T) {

--- a/provider/keystore/keystore_test.go
+++ b/provider/keystore/keystore_test.go
@@ -255,11 +255,15 @@ func testKeystoreKeyCountImpl(t *testing.T, store Keystore, bucket bitstr.Key, b
 		require.Equal(t, len(got), n, "KeyCount disagrees with Get for prefix %q", prefix)
 	}
 
-	// Exact counts: the full bucket, and a prefix matching neither bucket in a
-	// non-empty keystore.
+	// Exact counts: the full bucket, empty prefix and a prefix matching neither
+	// bucket in a non-empty keystore.
 	n, err = store.KeyCount(ctx, bucket)
 	require.NoError(t, err)
 	require.Equal(t, len(bucketKeys), n)
+
+	n, err = store.KeyCount(ctx, "")
+	require.NoError(t, err)
+	require.Equal(t, len(bucketKeys)+len(otherKeys), n)
 
 	n, err = store.KeyCount(ctx, bitstr.Key("01"))
 	require.NoError(t, err)

--- a/provider/keystore/resettable_keystore.go
+++ b/provider/keystore/resettable_keystore.go
@@ -324,7 +324,7 @@ func (s *ResettableKeystore) worker() {
 				op.response <- operationResponse{size: s.size}
 
 			case opCount:
-				n, err := s.count(op.ctx, op.prefix)
+				n, err := s.countUpTo(op.ctx, op.prefix, op.limit)
 				op.response <- operationResponse{size: n, err: err}
 			}
 		case op := <-s.resetOps:

--- a/provider/keystore/resettable_keystore.go
+++ b/provider/keystore/resettable_keystore.go
@@ -322,6 +322,10 @@ func (s *ResettableKeystore) worker() {
 
 			case opSize:
 				op.response <- operationResponse{size: s.size}
+
+			case opCount:
+				n, err := s.count(op.ctx, op.prefix)
+				op.response <- operationResponse{size: n, err: err}
 			}
 		case op := <-s.resetOps:
 			s.handleResetOp(op)

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -1776,17 +1776,15 @@ func (s *SweepingProvider) batchReprovide(prefix bitstr.Key) {
 		return
 	}
 
-	// Count the keys matching the prefix without materialising them. A region
-	// can hold a very large number of multihashes; loading them all into memory
-	// here (and again for the covered prefix below) just to make routing
-	// decisions is what drives the reprovide memory spikes that have OOM-killed
-	// nodes with large keystores. The actual load is deferred until the covered
-	// prefix is known and then done exactly once. (A region that is still very
-	// large after exploration should ideally be loaded and provided in bounded
-	// chunks; see the keystore.KeyCount-based splitting discussion upstream.)
-	keyCount, err := s.keystore.KeyCount(s.ctx, prefix)
+	// Decide how to provide the region without materialising it. A region can
+	// hold a very large number of multihashes; loading them all into memory just
+	// to make a routing decision would drive up memory usage. CountKeysUpTo
+	// stops scanning once the threshold is exceeded, so this never iterates a
+	// large region, and the actual load is deferred until the covered prefix is
+	// known and then done exactly once.
+	keyCount, err := s.keystore.CountKeysUpTo(s.ctx, prefix, individualProvideThreshold+1)
 	if err != nil {
-		s.failedReprovide(prefix, fmt.Errorf("could not reprovide, error when counting keys: %s", err))
+		s.failedReprovide(prefix, fmt.Errorf("could not reprovide, error when counting keys: %w", err))
 		s.reschedulePrefix(prefix)
 		return
 	}
@@ -1795,22 +1793,15 @@ func (s *SweepingProvider) batchReprovide(prefix bitstr.Key) {
 		return
 	}
 
-	s.logger.Infof("reprovide starting for prefix %q, %d keys", prefix, keyCount)
+	s.logger.Infof("reprovide starting for prefix %q", prefix)
 	startTime := time.Now()
-	s.stats.ongoingReprovides.start(keyCount)
-	// gaugeKeys tracks how many keys were added to the ongoing-reprovides gauge
-	// (start, plus the addKeys adjustment below for a wider region) so the
-	// deferred finish always balances it, including on the error paths that
-	// return before keys is loaded.
-	gaugeKeys := keyCount
 	var keys []mh.Multihash
 	defer func() {
 		elapsed := time.Since(startTime)
-		s.stats.ongoingReprovides.finish(gaugeKeys)
 		s.stats.cycleStatsLk.Lock()
 		s.stats.reprovideDuration.Add(prefix, int64(elapsed))
 		s.stats.cycleStatsLk.Unlock()
-		s.logger.Infof("reprovide finished for prefix %q, %d keys in %s", prefix, keyCount, elapsed)
+		s.logger.Infof("reprovide finished for prefix %q, %d keys in %s", prefix, len(keys), elapsed)
 	}()
 
 	if keyCount <= individualProvideThreshold {
@@ -1818,16 +1809,12 @@ func (s *SweepingProvider) batchReprovide(prefix bitstr.Key) {
 		// keys. It isn't worth it to fully explore a region for just a few keys.
 		keys, err = s.keystore.Get(s.ctx, prefix)
 		if err != nil {
-			s.failedReprovide(prefix, fmt.Errorf("could not reprovide, error when loading keys: %s", err))
+			s.failedReprovide(prefix, fmt.Errorf("could not reprovide, error when loading keys: %w", err))
 			s.reschedulePrefix(prefix)
 			return
 		}
-		// Reconcile the gauge: the keystore may have changed between KeyCount and
-		// this load, so the count actually provided can differ from keyCount.
-		if len(keys) != keyCount {
-			s.stats.ongoingReprovides.addKeys(len(keys) - keyCount)
-			gaugeKeys = len(keys)
-		}
+		s.stats.ongoingReprovides.start(len(keys))
+		defer s.stats.ongoingReprovides.finish(len(keys))
 		s.individualProvide(prefix, keys, true)
 		return
 	}
@@ -1844,21 +1831,15 @@ func (s *SweepingProvider) batchReprovide(prefix bitstr.Key) {
 	// slice is never held across swarm exploration and is loaded exactly once.
 	keys, err = s.keystore.Get(s.ctx, coveredPrefix)
 	if err != nil {
-		s.failedReprovide(prefix, fmt.Errorf("could not reprovide, error when loading keys: %s", err))
+		s.failedReprovide(prefix, fmt.Errorf("could not reprovide, error when loading keys: %w", err))
 		s.reschedulePrefix(prefix)
 		return
 	}
+	s.stats.ongoingReprovides.start(len(keys))
+	defer s.stats.ongoingReprovides.finish(len(keys))
 
 	regions = s.claimRegionReprovide(regions)
 
-	// Reconcile the ongoing-reprovides gauge to the number of keys actually
-	// loaded. keyCount was only an estimate from KeyCount(prefix): coveredPrefix
-	// may be wider than the requested prefix, and the keystore can change
-	// between the count and the load.
-	if len(keys) != keyCount {
-		s.stats.ongoingReprovides.addKeys(len(keys) - keyCount)
-		gaugeKeys = len(keys)
-	}
 	if len(coveredPrefix) < len(prefix) {
 		prefix = coveredPrefix
 	}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -1776,14 +1776,20 @@ func (s *SweepingProvider) batchReprovide(prefix bitstr.Key) {
 		return
 	}
 
-	// Load keys matching prefix from the keystore.
-	keys, err := s.keystore.Get(s.ctx, prefix)
+	// Count the keys matching the prefix without materialising them. A region
+	// can hold a very large number of multihashes; loading them all into memory
+	// here (and again for the covered prefix below) just to make routing
+	// decisions is what drives the reprovide memory spikes that have OOM-killed
+	// nodes with large keystores. The actual load is deferred until the covered
+	// prefix is known and then done exactly once. (A region that is still very
+	// large after exploration should ideally be loaded and provided in bounded
+	// chunks; see the keystore.KeyCount-based splitting discussion upstream.)
+	keyCount, err := s.keystore.KeyCount(s.ctx, prefix)
 	if err != nil {
-		s.failedReprovide(prefix, fmt.Errorf("could not reprovide, error when loading keys: %s", err))
+		s.failedReprovide(prefix, fmt.Errorf("could not reprovide, error when counting keys: %s", err))
 		s.reschedulePrefix(prefix)
 		return
 	}
-	keyCount := len(keys)
 	if keyCount == 0 {
 		s.logger.Infof("no keys to reprovide for prefix %s", prefix)
 		return
@@ -1792,9 +1798,15 @@ func (s *SweepingProvider) batchReprovide(prefix bitstr.Key) {
 	s.logger.Infof("reprovide starting for prefix %q, %d keys", prefix, keyCount)
 	startTime := time.Now()
 	s.stats.ongoingReprovides.start(keyCount)
+	// gaugeKeys tracks how many keys were added to the ongoing-reprovides gauge
+	// (start, plus the addKeys adjustment below for a wider region) so the
+	// deferred finish always balances it, including on the error paths that
+	// return before keys is loaded.
+	gaugeKeys := keyCount
+	var keys []mh.Multihash
 	defer func() {
 		elapsed := time.Since(startTime)
-		s.stats.ongoingReprovides.finish(len(keys))
+		s.stats.ongoingReprovides.finish(gaugeKeys)
 		s.stats.cycleStatsLk.Lock()
 		s.stats.reprovideDuration.Add(prefix, int64(elapsed))
 		s.stats.cycleStatsLk.Unlock()
@@ -1804,6 +1816,12 @@ func (s *SweepingProvider) batchReprovide(prefix bitstr.Key) {
 	if keyCount <= individualProvideThreshold {
 		// Don't fully explore the region, execute simple DHT provides for these
 		// keys. It isn't worth it to fully explore a region for just a few keys.
+		keys, err = s.keystore.Get(s.ctx, prefix)
+		if err != nil {
+			s.failedReprovide(prefix, fmt.Errorf("could not reprovide, error when loading keys: %s", err))
+			s.reschedulePrefix(prefix)
+			return
+		}
 		s.individualProvide(prefix, keys, true)
 		return
 	}
@@ -1818,17 +1836,24 @@ func (s *SweepingProvider) batchReprovide(prefix bitstr.Key) {
 
 	regions = s.claimRegionReprovide(regions)
 
-	if len(coveredPrefix) < len(prefix) {
-		// Covered prefix is shorter than the requested one, load all the keys
-		// matching the covered prefix from the keystore.
-		keys, err = s.keystore.Get(s.ctx, coveredPrefix)
-		if err != nil {
-			err = fmt.Errorf("could not reprovide, error when loading keys: %s", err)
-			s.failedReprovide(prefix, err)
-			s.reschedulePrefix(prefix)
-			return
-		}
+	// Load the region keys now that the covered prefix is known, so the big
+	// slice is never held across swarm exploration and is loaded exactly once.
+	// The covered prefix may be shorter (wider) than the requested one, in which
+	// case it matches more keys than keyCount.
+	widerRegion := len(coveredPrefix) < len(prefix)
+	loadPrefix := prefix
+	if widerRegion {
+		loadPrefix = coveredPrefix
+	}
+	keys, err = s.keystore.Get(s.ctx, loadPrefix)
+	if err != nil {
+		s.failedReprovide(prefix, fmt.Errorf("could not reprovide, error when loading keys: %s", err))
+		s.reschedulePrefix(prefix)
+		return
+	}
+	if widerRegion {
 		s.stats.ongoingReprovides.addKeys(len(keys) - keyCount)
+		gaugeKeys = len(keys)
 		prefix = coveredPrefix
 	}
 

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -1834,8 +1834,6 @@ func (s *SweepingProvider) batchReprovide(prefix bitstr.Key) {
 	}
 	s.logger.Debugf("reprovide: requested prefix '%s' (len %d), prefix covered '%s' (len %d)", prefix, len(prefix), coveredPrefix, len(coveredPrefix))
 
-	regions = s.claimRegionReprovide(regions)
-
 	// Load the region keys now that the covered prefix is known, so the big
 	// slice is never held across swarm exploration and is loaded exactly once.
 	// The covered prefix may be shorter (wider) than the requested one, in which
@@ -1851,6 +1849,9 @@ func (s *SweepingProvider) batchReprovide(prefix bitstr.Key) {
 		s.reschedulePrefix(prefix)
 		return
 	}
+
+	regions = s.claimRegionReprovide(regions)
+
 	if widerRegion {
 		s.stats.ongoingReprovides.addKeys(len(keys) - keyCount)
 		gaugeKeys = len(keys)

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -1822,6 +1822,12 @@ func (s *SweepingProvider) batchReprovide(prefix bitstr.Key) {
 			s.reschedulePrefix(prefix)
 			return
 		}
+		// Reconcile the gauge: the keystore may have changed between KeyCount and
+		// this load, so the count actually provided can differ from keyCount.
+		if len(keys) != keyCount {
+			s.stats.ongoingReprovides.addKeys(len(keys) - keyCount)
+			gaugeKeys = len(keys)
+		}
 		s.individualProvide(prefix, keys, true)
 		return
 	}
@@ -1836,14 +1842,7 @@ func (s *SweepingProvider) batchReprovide(prefix bitstr.Key) {
 
 	// Load the region keys now that the covered prefix is known, so the big
 	// slice is never held across swarm exploration and is loaded exactly once.
-	// The covered prefix may be shorter (wider) than the requested one, in which
-	// case it matches more keys than keyCount.
-	widerRegion := len(coveredPrefix) < len(prefix)
-	loadPrefix := prefix
-	if widerRegion {
-		loadPrefix = coveredPrefix
-	}
-	keys, err = s.keystore.Get(s.ctx, loadPrefix)
+	keys, err = s.keystore.Get(s.ctx, coveredPrefix)
 	if err != nil {
 		s.failedReprovide(prefix, fmt.Errorf("could not reprovide, error when loading keys: %s", err))
 		s.reschedulePrefix(prefix)
@@ -1852,9 +1851,15 @@ func (s *SweepingProvider) batchReprovide(prefix bitstr.Key) {
 
 	regions = s.claimRegionReprovide(regions)
 
-	if widerRegion {
+	// Reconcile the ongoing-reprovides gauge to the number of keys actually
+	// loaded. keyCount was only an estimate from KeyCount(prefix): coveredPrefix
+	// may be wider than the requested prefix, and the keystore can change
+	// between the count and the load.
+	if len(keys) != keyCount {
 		s.stats.ongoingReprovides.addKeys(len(keys) - keyCount)
 		gaugeKeys = len(keys)
+	}
+	if len(coveredPrefix) < len(prefix) {
 		prefix = coveredPrefix
 	}
 

--- a/provider/stats_test.go
+++ b/provider/stats_test.go
@@ -700,7 +700,7 @@ func (b *blockingSizeKeystore) Get(_ context.Context, _ bitstr.Key) ([]multihash
 	return nil, nil
 }
 
-func (b *blockingSizeKeystore) KeyCount(_ context.Context, _ bitstr.Key) (int, error) {
+func (b *blockingSizeKeystore) CountKeysUpTo(_ context.Context, _ bitstr.Key, _ int) (int, error) {
 	return 0, nil
 }
 

--- a/provider/stats_test.go
+++ b/provider/stats_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -756,6 +757,125 @@ func TestStatsContextDeadline(t *testing.T) {
 		require.Emptyf(t, s, "Stats should return a zero snapshot when ctx is done")
 		require.GreaterOrEqualf(t, elapsed, deadline, "Stats should not return before the deadline elapses")
 		require.Lessf(t, elapsed, deadline+time.Second, "Stats should return shortly after the deadline elapses")
+	})
+}
+
+// reprovideKeystoreStub is a keystore.Keystore double for steering
+// batchReprovide down a chosen path. CountKeysUpTo and Get return preset
+// values, and Get counts its calls so a test can tell whether a region was
+// loaded. Methods batchReprovide never reaches return zero values.
+type reprovideKeystoreStub struct {
+	countResult int
+	countErr    error
+	getResult   []multihash.Multihash
+	getErr      error
+	getCalls    atomic.Int64
+}
+
+var _ keystore.Keystore = (*reprovideKeystoreStub)(nil)
+
+func (k *reprovideKeystoreStub) CountKeysUpTo(context.Context, bitstr.Key, int) (int, error) {
+	return k.countResult, k.countErr
+}
+
+func (k *reprovideKeystoreStub) Get(context.Context, bitstr.Key) ([]multihash.Multihash, error) {
+	k.getCalls.Add(1)
+	return k.getResult, k.getErr
+}
+
+func (k *reprovideKeystoreStub) Put(context.Context, ...multihash.Multihash) ([]multihash.Multihash, error) {
+	return nil, nil
+}
+
+func (k *reprovideKeystoreStub) ContainsPrefix(context.Context, bitstr.Key) (bool, error) {
+	return false, nil
+}
+
+func (k *reprovideKeystoreStub) Delete(context.Context, ...multihash.Multihash) error { return nil }
+
+func (k *reprovideKeystoreStub) Empty(context.Context) error { return nil }
+
+func (k *reprovideKeystoreStub) Size(context.Context) (int, error) { return 0, nil }
+
+func (k *reprovideKeystoreStub) BatchSize() int { return 256 }
+
+func (k *reprovideKeystoreStub) Close() error { return nil }
+
+// newReprovideStubProvider builds a provider wired to the given router and
+// keystore stub, with the reprovide schedule parked an hour out so only the
+// test's direct batchReprovide call runs.
+func newReprovideStubProvider(t *testing.T, router *mockRouter, ks keystore.Keystore) *SweepingProvider {
+	t.Helper()
+	pid, err := peer.Decode("12D3KooWCPQTeFYCDkru8nza3Af6u77aoVLA71Vb74eHxeR91Gka")
+	require.NoError(t, err)
+	msgSender := &mockMsgSender{
+		sendMessageFunc: func(context.Context, peer.ID, *pb.Message) error { return nil },
+	}
+	prov, err := New(
+		WithPeerID(pid),
+		WithRouter(router),
+		WithMessageSender(msgSender),
+		WithSelfAddrs(getMockAddrs(t)),
+		WithKeystore(ks),
+		WithReprovideInterval(time.Hour),
+		WithSkipBootstrapReprovide(true),
+	)
+	require.NoError(t, err)
+	return prov
+}
+
+// TestBatchReprovideSkipsLoadWhenRegionEmpty verifies that batchReprovide
+// counts a region before loading it. When CountKeysUpTo reports zero keys, the
+// region is never fetched, so Get stays untouched.
+func TestBatchReprovideSkipsLoadWhenRegionEmpty(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ks := &reprovideKeystoreStub{countResult: 0}
+		// A router that answers every lookup keeps the node online; the empty
+		// count returns before any lookup happens regardless.
+		prov := newReprovideStubProvider(t, &mockRouter{}, ks)
+		defer prov.Close()
+		synctest.Wait()
+
+		prov.batchReprovide(bitstr.Key("0"))
+
+		require.Zero(t, ks.getCalls.Load(), "an empty region must not be loaded")
+		require.Zero(t, prov.stats.ongoingReprovides.opCount.Load())
+		require.Zero(t, prov.stats.ongoingReprovides.keyCount.Load())
+	})
+}
+
+// TestBatchReprovideBalancesGaugeWhenLoadFails verifies that a failed region
+// load leaves the ongoing-reprovides gauge at zero and reschedules the prefix.
+// batchReprovide starts the gauge only after Get succeeds, so a load error adds
+// nothing to it. A small key count takes the individual-provide path, which
+// loads without exploring the swarm; the node is kept offline so the
+// late-reprovide retry loop stays idle and the gauge and queue settle.
+func TestBatchReprovideBalancesGaugeWhenLoadFails(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ks := &reprovideKeystoreStub{
+			countResult: individualProvideThreshold, // small region, individual path
+			getErr:      errors.New("datastore read failed"),
+		}
+		// A router that errors on every lookup keeps the node offline.
+		offline := &mockRouter{
+			getClosestPeersFunc: func(context.Context, string) ([]peer.ID, error) {
+				return nil, errors.New("offline")
+			},
+		}
+		prov := newReprovideStubProvider(t, offline, ks)
+		defer prov.Close()
+		synctest.Wait()
+		require.False(t, prov.connectivity.IsOnline())
+
+		prefix := bitstr.Key("0")
+		require.True(t, prov.reprovideQueue.IsEmpty(), "queue should start empty")
+
+		prov.batchReprovide(prefix)
+
+		require.Positive(t, ks.getCalls.Load(), "the individual path must attempt the load")
+		require.Zero(t, prov.stats.ongoingReprovides.opCount.Load(), "a failed load must leave no ongoing operation")
+		require.Zero(t, prov.stats.ongoingReprovides.keyCount.Load(), "a failed load must leak no key count")
+		require.Equal(t, 1, prov.reprovideQueue.Size(), "a failed reprovide must reschedule the prefix")
 	})
 }
 

--- a/provider/stats_test.go
+++ b/provider/stats_test.go
@@ -700,6 +700,10 @@ func (b *blockingSizeKeystore) Get(_ context.Context, _ bitstr.Key) ([]multihash
 	return nil, nil
 }
 
+func (b *blockingSizeKeystore) KeyCount(_ context.Context, _ bitstr.Key) (int, error) {
+	return 0, nil
+}
+
 func (b *blockingSizeKeystore) ContainsPrefix(_ context.Context, _ bitstr.Key) (bool, error) {
 	return false, nil
 }


### PR DESCRIPTION
## Problem

On nodes with large keystores, reprovide cycles spike memory hard enough to get the process OOM-killed. 

There are many sources, this PR fixes one of them, located in `batchReprovide`, which iiuc 

1. it loaded every multihash in a region with `keystore.Get` just to learn how many keys there were and make routing decisions
2. then after exploring the swarm it loaded the (often wider) covered region a second time, all while still holding the first slice. 

So a single reprovide could hold the whole region in memory _twice_ and keep it resident across a network round trip. The bigger the keystore, the bigger the spike.

## Fix

Unsure if this is the best way, but idea is to make count own op to avoid keeping big region in memory twice:

- Add `Keystore.KeyCount(prefix)`, backed by a keys-only datastore query, so the count comes back with bounded memory and without materialising a single multihash.
- Reorder `batchReprovide` to count first and load the region exactly once, after the covered prefix is known, so the large slice is never held across swarm exploration and never loaded twice.
- Balance the ongoing-reprovides key gauge on the load-error paths, which previously leaked the started count.

So the intention for this PR is to take peak memory per reprovide from two region loads down to one. 

> [!NOTE]
> @guillaumemichel This is low priority, so fine to park it until you have spare time to review. Feels like safe and easy win, but lmk if I missed anything.