### PR TITLE
fix(keystore): symmetric shared-mode prefix wrap

### DIFF
--- a/provider/keystore/resettable_keystore.go
+++ b/provider/keystore/resettable_keystore.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/ipfs/go-cid"
 	ds "github.com/ipfs/go-datastore"
-	"github.com/ipfs/go-datastore/namespace"
+	ktds "github.com/ipfs/go-datastore/keytransform"
 	"github.com/ipfs/go-datastore/query"
 	"github.com/ipfs/go-log/v2"
 	"github.com/libp2p/go-libp2p-kad-dht/provider/internal/keyspace"
@@ -51,8 +51,8 @@ type resetOp struct {
 // Two storage modes are supported:
 //
 // Shared-datastore mode (default): Both namespaces live inside the provided
-// metaDs via namespace.Wrap. The alternate namespace is emptied via
-// iterate-and-delete after each reset.
+// metaDs under the "/0" and "/1" path prefixes (see prefixWrap). The alternate
+// namespace is emptied via iterate-and-delete after each reset.
 //
 // Factory mode (WithDatastoreFactory): Each namespace is a physically separate
 // datastore created by the factory. Only the active datastore exists between
@@ -136,6 +136,28 @@ type ResettableKeystore struct {
 }
 
 var _ Keystore = (*ResettableKeystore)(nil)
+
+// prefixWrap stores every key under prefix (here "/0" or "/1"), like
+// namespace.Wrap but always adding the prefix instead of sometimes skipping it.
+//
+// namespace.Wrap does not fit this keystore. The keystore files each key under
+// a path whose leading bits are the single characters '0' and '1' (see dsKey),
+// for example "/0/1/0/...". On write, namespace.Wrap skips the prefix when the
+// key already starts with it; on read, it always strips the first component. So
+// a key whose first bit matches the namespace digit (a "/0/..." key in the "/0"
+// namespace) keeps its written form but loses a "/0" on read. That eats the
+// key's first bit and breaks lookups for prefixes longer than prefixBits. See
+// https://github.com/libp2p/go-libp2p-kad-dht/issues/1260.
+//
+// Adding the prefix to every key makes write and read symmetric: read always
+// has exactly one prefix component to strip, so no bit is lost.
+func prefixWrap(d ds.Batching, prefix ds.Key) ds.Batching {
+	pt := ktds.PrefixTransform{Prefix: prefix}
+	return ktds.Wrap(d, &ktds.Pair{
+		Convert: func(k ds.Key) ds.Key { return prefix.Child(k) },
+		Invert:  pt.InvertKey,
+	})
+}
 
 // NewResettableKeystore creates a new ResettableKeystore backed by the
 // provided datastore d.
@@ -231,8 +253,8 @@ func NewResettableKeystore(d ds.Batching, opts ...ResettableKeystoreOption) (*Re
 	} else {
 		// Shared datastore mode: both namespaces always exist
 		datastores := [2]ds.Batching{
-			namespace.Wrap(d, ds.NewKey("0")),
-			namespace.Wrap(d, ds.NewKey("1")),
+			prefixWrap(d, ds.NewKey("0")),
+			prefixWrap(d, ds.NewKey("1")),
 		}
 		primaryDs = datastores[activeIdx]
 		altDs = datastores[1-activeIdx]
@@ -517,18 +539,16 @@ func (s *ResettableKeystore) prepareAltDs(ctx context.Context) error {
 }
 
 // emptySharedAltDs deletes every key in the alternate namespace in
-// shared-datastore mode by iterating the underlying datastore directly.
-// This bypasses a quirk of namespace.Wrap's keytransform: ConvertKey
-// returns the key unchanged when it already starts with the namespace
-// prefix, so the round-trip iterate-then-delete misses any key whose
-// keystore path collides with that prefix (e.g. with namespace "/0",
-// keystore keys "/0/0/...").
+// shared-datastore mode. It reads the underlying datastore directly under the
+// namespace's path prefix ("/0" or "/1") and deletes those raw keys rather than
+// going through the prefix-wrapped view. Working on raw keys keeps it simple and
+// independent of the wrapper's key transform.
 //
 // Only valid in shared-datastore mode, where metaDs is the un-wrapped
-// underlying datastore that altDs is namespace.Wrap'd over. In factory
-// mode altDs is a physically separate datastore and metaDs holds only
-// the active-namespace marker, so this function must not be called —
-// callers gate on s.createDs == nil.
+// underlying datastore that altDs is prefix-wrapped over. In factory mode
+// altDs is a physically separate datastore and metaDs holds only the
+// active-namespace marker, so this function must not be called — callers gate
+// on s.createDs == nil.
 func (s *ResettableKeystore) emptySharedAltDs(ctx context.Context) error {
 	altPrefix := fmt.Sprintf("/%d", 1-s.activeNamespace)
 	q := query.Query{Prefix: altPrefix, KeysOnly: true}

--- a/provider/keystore/resettable_keystore_test.go
+++ b/provider/keystore/resettable_keystore_test.go
@@ -1437,23 +1437,16 @@ func pickMhsWithBit0(t *testing.T, targetBit int, n int) []mh.Multihash {
 	return out
 }
 
-// TestKeystoreResetEmptiesNamespaceCollidingKeys is a tripwire for the
-// emptySharedAltDs fix. If a future caller replaces it with the obvious
-// wrapped iterate-then-Delete path, the bug below returns silently and
-// this test catches it.
+// TestKeystoreResetEmptiesNamespaceCollidingKeys verifies that a reset fully
+// empties the alternate namespace, including keys whose first hash bit equals
+// the slot digit (the collision-prone bucket).
 //
-// Background: in shared-datastore mode the alt slot is "/0" or "/1",
-// and inside the slot each key is filed under "/<bit0>/<bit1>/...". So
-// a key whose first hash bit is 1, stored in slot "/1", lives at the
-// underlying path "/1/1/...".
-//
-// Bug: namespace.Wrap.Delete runs the key through ConvertKey, which
-// only adds the namespace prefix when it isn't already an ancestor. For
-// "/1/..." it isn't added, so Delete targets "/1/..." instead of
-// "/1/1/...". The real key stays behind on every reset.
-//
-// Fix: emptySharedAltDs talks to the unwrapped datastore directly and
-// deletes everything under the "/1" prefix as stored, with no rewrite.
+// Background: in shared-datastore mode the alt slot is "/0" or "/1", and inside
+// the slot each key is filed under "/<bit0>/<bit1>/...". So a key whose first
+// hash bit is 1, stored in slot "/1", lives under the underlying path
+// "/1/1/...". emptySharedAltDs deletes these by iterating the unwrapped
+// datastore directly under the "/1" prefix, independent of how prefixWrap maps
+// individual keys, so no colliding key is left behind.
 func TestKeystoreResetEmptiesNamespaceCollidingKeys(t *testing.T) {
 	base := dssync.MutexWrap(ds.NewMapDatastore())
 	store, err := NewResettableKeystore(base)
@@ -1499,4 +1492,125 @@ func TestKeystoreResetEmptiesNamespaceCollidingKeys(t *testing.T) {
 	require.Emptyf(t, leftover,
 		"teardown must remove all alt-namespace keys; %d orphaned: %v",
 		len(leftover), leftover)
+}
+
+// TestPrefixWrapSymmetricRoundTrip checks that prefixWrap reads back exactly
+// what it wrote, even for a key that already starts with the prefix. The stock
+// namespace.Wrap fails this: on write it skips the prefix for such a key, but on
+// read it still strips a component, so the key comes back short one component.
+// That asymmetry is the root cause of
+// https://github.com/libp2p/go-libp2p-kad-dht/issues/1260.
+func TestPrefixWrapSymmetricRoundTrip(t *testing.T) {
+	ctx := t.Context()
+	raw := ds.NewMapDatastore()
+	w := prefixWrap(raw, ds.NewKey("0"))
+
+	// "/0/a" collides with the "/0" prefix; "/1/b" does not. Both must survive
+	// the Put/Query round trip unchanged.
+	for _, k := range []ds.Key{ds.NewKey("/0/a"), ds.NewKey("/1/b")} {
+		require.NoError(t, w.Put(ctx, k, []byte(k.String())))
+	}
+
+	// Query results invert back to exactly the stored keys, with no eaten
+	// component on the colliding key.
+	var got []string
+	for res, err := range ds.QueryIter(ctx, w, query.Query{KeysOnly: true}) {
+		require.NoError(t, err)
+		got = append(got, res.Key)
+	}
+	require.ElementsMatch(t, []string{"/0/a", "/1/b"}, got)
+
+	// Physically every key lives under "/0" at full depth, including the
+	// colliding one, so InvertKey always has a component to strip.
+	var phys []string
+	for res, err := range ds.QueryIter(ctx, raw, query.Query{KeysOnly: true}) {
+		require.NoError(t, err)
+		phys = append(phys, res.Key)
+	}
+	require.ElementsMatch(t, []string{"/0/0/a", "/0/1/b"}, phys)
+
+	// The colliding key round-trips through a direct Get as well.
+	v, err := w.Get(ctx, ds.NewKey("/0/a"))
+	require.NoError(t, err)
+	require.Equal(t, "/0/a", string(v))
+}
+
+// TestKeystoreSharedModeLongPrefixCollision is a regression test for
+// https://github.com/libp2p/go-libp2p-kad-dht/issues/1260.
+//
+// In shared-datastore mode, a multihash whose first bit matches the active
+// namespace digit ("0" or "1") is stored under a path that collides with the
+// namespace prefix. Before the prefixWrap fix, reading it back corrupted the
+// key, so a lookup with a prefix longer than prefixBits (which makes the
+// keystore decode each stored key) returned the wrong keys or failed with
+// "illegal base64 data". The test reproduces the collision in the default slot,
+// then again after a reset swaps the active slot, covering both namespaces.
+func TestKeystoreSharedModeLongPrefixCollision(t *testing.T) {
+	const prefixBits = 8
+	ctx := t.Context()
+
+	// Shared-datastore mode (no WithDatastoreFactory) is the buggy path.
+	store, err := NewResettableKeystore(dssync.MutexWrap(ds.NewMapDatastore()),
+		KeystoreOption(WithPrefixBits(prefixBits)))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+
+	// verify looks up every key in present with a prefix longer than prefixBits.
+	// A long prefix forces the keystore to decode each stored key, where the
+	// collision struck. present holds keys with both first bits, so the colliding
+	// bucket is hit whichever slot is active.
+	verify := func(t *testing.T, present []mh.Multihash) {
+		t.Helper()
+		bruteCount := func(p bitstr.Key) int {
+			n := 0
+			for _, h := range present {
+				if keyspace.IsPrefix(p, keyspace.MhToBit256(h)) {
+					n++
+				}
+			}
+			return n
+		}
+		for _, target := range present {
+			longPrefix := bitstr.Key(key.BitString(keyspace.MhToBit256(target))[:prefixBits+4])
+
+			got, err := store.Get(ctx, longPrefix)
+			require.NoErrorf(t, err, "Get(%q)", longPrefix)
+			require.Equalf(t, bruteCount(longPrefix), len(got),
+				"Get(%q) returned wrong count", longPrefix)
+			require.Containsf(t, mhStrings(got), string(target),
+				"Get(%q) missing its own key", longPrefix)
+
+			ok, err := store.ContainsPrefix(ctx, longPrefix)
+			require.NoErrorf(t, err, "ContainsPrefix(%q)", longPrefix)
+			require.Truef(t, ok, "ContainsPrefix(%q) must be true", longPrefix)
+		}
+	}
+
+	// Slot 0 active: keys whose first bit is 0 collide with namespace "/0".
+	require.Equal(t, byte(0), store.activeNamespace)
+	setA := append(pickMhsWithBit0(t, 0, 4), pickMhsWithBit0(t, 1, 2)...)
+	_, err = store.Put(ctx, setA...)
+	require.NoError(t, err)
+	verify(t, setA)
+
+	// Reset swaps the active slot to 1, so now keys whose first bit is 1 collide
+	// with namespace "/1". The reset set replaces the store contents.
+	setB := append(pickMhsWithBit0(t, 1, 4), pickMhsWithBit0(t, 0, 2)...)
+	ch := make(chan cid.Cid, len(setB))
+	for _, h := range setB {
+		ch <- cid.NewCidV1(cid.Raw, h)
+	}
+	close(ch)
+	require.NoError(t, store.ResetCids(ctx, ch))
+	require.Equal(t, byte(1), store.activeNamespace)
+	verify(t, setB)
+}
+
+// mhStrings returns the multihashes as a set of strings for membership checks.
+func mhStrings(mhs []mh.Multihash) []string {
+	out := make([]string, len(mhs))
+	for i, h := range mhs {
+		out[i] = string(h)
+	}
+	return out
 }


### PR DESCRIPTION
Keeps the `/0`/`/1` reset slots but wraps them with a symmetric `prefixWrap` transform that always prepends the prefix, fixing corrupted lookups for keys whose first bit matched the active slot.

Main benefit: Backward-compatible on disk: existing `/0`/`/1` data stays in place and is reclaimed on the next reprovide, so no orphans persist.


> [!NOTE]
> 
> This is one approach that
> 
> - Fixes #1260
>
> We need to decide if we go with this or https://github.com/libp2p/go-libp2p-kad-dht/pull/1262 or sth else