### PR TITLE
fix(provider): cover full keyspace when peers cluster under one prefix

### DIFF
--- a/provider/internal/keyspace/trie.go
+++ b/provider/internal/keyspace/trie.go
@@ -614,39 +614,38 @@ type Region struct {
 }
 
 // RegionsFromPeers returns the keyspace regions of size at least `regionSize`
-// from the given `peers` sorted according to `order` along with the Common
-// Prefix shared by all peers.
-func RegionsFromPeers(peers []peer.ID, regionSize int, order bit256.Key) ([]Region, bitstr.Key) {
+// from the given `peers` sorted according to `order`.
+//
+// Regions are rooted at `coveredPrefix`, the keyspace zone these peers are
+// responsible for, rather than at the peers' incidental common prefix. All
+// peers are expected to match `coveredPrefix`. This ensures region prefixes
+// describe the keyspace they cover, so that every key matching `coveredPrefix`
+// is assigned to exactly one region.
+func RegionsFromPeers(peers []peer.ID, regionSize int, order bit256.Key, coveredPrefix bitstr.Key) []Region {
 	if len(peers) == 0 {
-		return []Region{}, ""
+		return []Region{}
 	}
 	peersTrie := trie.New[bit256.Key, peer.ID]()
-	minCpl := KeyLen
-	firstPeerKey := PeerIDToBit256(peers[0])
 	peerEntries := make([]trie.Entry[bit256.Key, peer.ID], len(peers))
 	for i, p := range peers {
-		k := PeerIDToBit256(p)
-		peerEntries[i] = trie.Entry[bit256.Key, peer.ID]{Key: k, Data: p}
-		minCpl = min(minCpl, firstPeerKey.CommonPrefixLength(k))
+		peerEntries[i] = trie.Entry[bit256.Key, peer.ID]{Key: PeerIDToBit256(p), Data: p}
 	}
 	peersTrie.AddMany(peerEntries...)
-	commonPrefix := bitstr.Key(key.BitString(firstPeerKey)[:minCpl])
 
-	// Navigate to the subtrie at the common prefix depth before extracting regions.
-	// This ensures extractMinimalRegions checks branches at the correct depth.
-	subtrie := peersTrie
-	for i := range commonPrefix {
-		if subtrie.IsLeaf() {
+	// Navigate to the subtrie rooted at the covered prefix before extracting
+	// regions. This ensures extractMinimalRegions checks branches at the correct
+	// depth and that region prefixes are rooted at the covered keyspace zone.
+	for i := range coveredPrefix {
+		if peersTrie.IsLeaf() {
 			break
 		}
-		subtrie = subtrie.Branch(int(commonPrefix.Bit(i)))
-		if subtrie == nil || subtrie.IsEmptyLeaf() {
-			return nil, commonPrefix
+		peersTrie = peersTrie.Branch(int(coveredPrefix.Bit(i)))
+		if peersTrie == nil || peersTrie.IsEmptyLeaf() {
+			return nil
 		}
 	}
 
-	regions := extractMinimalRegions(subtrie, commonPrefix, regionSize, order)
-	return regions, commonPrefix
+	return extractMinimalRegions(peersTrie, coveredPrefix, regionSize, order)
 }
 
 // extractMinimalRegions returns the list of all non-overlapping subtries of
@@ -666,23 +665,50 @@ func extractMinimalRegions(t *trie.Trie[bit256.Key, peer.ID], path bitstr.Key, s
 }
 
 // AssignKeysToRegions assigns the provided keys to the regions based on their
-// kademlia identifier key.
+// kademlia identifier key. Each key is assigned to the region whose prefix it
+// matches, or, if it matches none, to the region whose prefix shares the
+// longest common prefix with it. This guarantees that no key is silently
+// dropped, even if the regions don't fully cover the key's keyspace zone.
 func AssignKeysToRegions(regions []Region, keys []mh.Multihash) []Region {
+	if len(regions) == 0 {
+		return regions
+	}
 	for i := range regions {
 		regions[i].Keys = trie.New[bit256.Key, mh.Multihash]()
 	}
 	keyEntriesByRegion := make(map[bitstr.Key][]trie.Entry[bit256.Key, mh.Multihash], len(regions))
+nextKey:
 	for _, k := range keys {
 		h := MhToBit256(k)
 		for _, r := range regions {
 			if IsPrefix(r.Prefix, h) {
 				keyEntriesByRegion[r.Prefix] = append(keyEntriesByRegion[r.Prefix], trie.Entry[bit256.Key, mh.Multihash]{Key: h, Data: k})
-				break
+				continue nextKey
 			}
 		}
+		// Key matches no region; assign it to the closest region so it isn't
+		// silently dropped.
+		prefix := closestRegionPrefix(regions, h)
+		keyEntriesByRegion[prefix] = append(keyEntriesByRegion[prefix], trie.Entry[bit256.Key, mh.Multihash]{Key: h, Data: k})
 	}
 	for _, r := range regions {
 		r.Keys.AddMany(keyEntriesByRegion[r.Prefix]...)
 	}
 	return regions
+}
+
+// closestRegionPrefix returns the prefix of the region sharing the longest
+// common prefix with `h`. It is used as a fallback for keys that match no
+// region, so they are assigned to the nearest region rather than dropped.
+func closestRegionPrefix(regions []Region, h bit256.Key) bitstr.Key {
+	best := regions[0].Prefix
+	bestCpl := -1
+	for _, r := range regions {
+		cpl := key.CommonPrefixLength(r.Prefix, h)
+		if cpl > bestCpl {
+			bestCpl = cpl
+			best = r.Prefix
+		}
+	}
+	return best
 }

--- a/provider/internal/keyspace/trie_test.go
+++ b/provider/internal/keyspace/trie_test.go
@@ -1370,32 +1370,31 @@ func TestAllocateToKClosest(t *testing.T) {
 
 func TestRegionsFromPeers(t *testing.T) {
 	// No peers
-	regions, commonPrefix := RegionsFromPeers(nil, 1, bit256.ZeroKey())
+	regions := RegionsFromPeers(nil, 1, bit256.ZeroKey(), "")
 	require.Empty(t, regions)
-	require.Equal(t, bitstr.Key(""), commonPrefix)
 
-	// Single peer
+	// Single peer: the peer fully covers its own key.
 	p0 := random.Peers(1)[0]
-	regions, commonPrefix = RegionsFromPeers([]peer.ID{p0}, 1, bit256.ZeroKey())
-	require.Len(t, regions, 1)
 	bstrPid0 := bitstr.Key(key.BitString(PeerIDToBit256(p0)))
-	require.Equal(t, bstrPid0, commonPrefix)
-
-	// Two peers
-	p1 := random.Peers(1)[0]
-	regions, commonPrefix = RegionsFromPeers([]peer.ID{p0, p1}, 2, bit256.ZeroKey())
+	regions = RegionsFromPeers([]peer.ID{p0}, 1, bit256.ZeroKey(), bstrPid0)
 	require.Len(t, regions, 1)
+	require.Equal(t, bstrPid0, regions[0].Prefix)
+
+	// Two peers: regions are rooted at the peers' common prefix.
+	p1 := random.Peers(1)[0]
 	cpl := key.CommonPrefixLength(bstrPid0, PeerIDToBit256(p1))
 	common := bstrPid0[:cpl]
-	require.Equal(t, common, commonPrefix)
+	regions = RegionsFromPeers([]peer.ID{p0, p1}, 2, bit256.ZeroKey(), common)
+	require.Len(t, regions, 1)
+	require.Equal(t, common, regions[0].Prefix)
 
 	// Three peers
 	p2 := random.Peers(1)[0]
-	regions, commonPrefix = RegionsFromPeers([]peer.ID{p0, p1, p2}, 2, bit256.ZeroKey())
-	require.Len(t, regions, 1)
 	cpl = key.CommonPrefixLength(common, PeerIDToBit256(p2))
 	common = common[:cpl]
-	require.Equal(t, common, commonPrefix)
+	regions = RegionsFromPeers([]peer.ID{p0, p1, p2}, 2, bit256.ZeroKey(), common)
+	require.Len(t, regions, 1)
+	require.Equal(t, common, regions[0].Prefix)
 
 	// From 4 peers onwards, there is a probability of having more than 1
 	// regions. Refer to TestExtractMinimalRegions.
@@ -1495,8 +1494,9 @@ func TestRegionsFromPeersSplitting(t *testing.T) {
 					peers = append(peers, peer.ID(p))
 				}
 			}
-			regions, coveredPrefix := RegionsFromPeers(peers, regionSize, zeroKey)
-			require.Equal(t, tc.expectedCoveredPrefix, coveredPrefix)
+			// The covered prefix (peers' common prefix) is supplied by the
+			// caller; regions are rooted there.
+			regions := RegionsFromPeers(peers, regionSize, zeroKey, tc.expectedCoveredPrefix)
 			require.Equal(t, tc.expectedNumRegions, len(regions))
 			totalSize := 0
 			for _, r := range regions {

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -969,31 +969,25 @@ func (s *SweepingProvider) closestPeersToPrefix(prefix bitstr.Key) ([]peer.ID, b
 			coverageTrie.Add(coveredPrefix, struct{}{})
 		}
 
-		// Widen `prefix` to the zone the gathered peers actually occupy. When the
-		// closest peers to `prefix` sit in a sibling branch (sparse or clustered
-		// swarm, typically with replicationFactor < bucket size), `prefix` would
-		// otherwise be reported covered as soon as one sub-cluster yields enough
-		// peers, leaving the sibling that holds the rest of the responsible peers
-		// unexplored and its keys dropped. Widening here makes the gap check below
-		// explore those branches before breaking.
-		prefix = commonAncestorPrefix(prefix, allClosestPeers)
-
 		gaps = keyspace.TrieGaps(coverageTrie, prefix, s.order)
 		fullKeyLogKey := fmt.Sprintf("fullKey[:%d]", maxLoggedKeyLength) // for logging purposes
 		if len(gaps) == 0 {
-			if len(allClosestPeers) >= s.replicationFactor {
-				// We have full coverage of `prefix`.
-				s.logger.Debugw("closestPeersToPrefix", "i", i, "prefix", prefix, "prevPrefix", nextPrefix, fullKeyLogKey, fullKey[:maxLoggedKeyLength], "coveredPrefix", coveredPrefix, "len(coveredPeers)", len(coveredPeers), "len(allClosestPeers)", len(allClosestPeers), "gaps", gaps)
-				break
-			}
-			for len(gaps) == 0 && len(prefix) > 0 {
-				// We don't have enough peers, but we have covered the prefix. Let's
-				// cover a shorter prefix.
+			// `prefix` is fully covered. Broaden it while fewer than
+			// replicationFactor gathered peers actually fall under it. When the
+			// closest peers to `prefix` sit in a sibling branch (sparse or clustered
+			// swarm with replicationFactor < bucket size), broadening surfaces that
+			// sibling as a new gap to explore, so every responsible peer is
+			// discovered instead of dropped. We count peers under `prefix` rather
+			// than the whole gathered set, so a prefix that already has enough peers
+			// is not widened just because a GetClosestPeers response also returned
+			// farther siblings.
+			for len(gaps) == 0 && len(prefix) > 0 && peersUnderPrefix(prefix, allClosestPeers) < s.replicationFactor {
 				prefix = prefix[:len(prefix)-1]
 				gaps = keyspace.TrieGaps(coverageTrie, prefix, s.order)
 			}
 			if len(gaps) == 0 {
-				// We don't have enough peers, but we have covered the whole keyspace.
+				// Either `prefix` holds enough peers, or the whole keyspace is
+				// covered with all the peers we could find.
 				s.logger.Debugw("closestPeersToPrefix", "i", i, "prefix", prefix, "prevPrefix", nextPrefix, fullKeyLogKey, fullKey[:maxLoggedKeyLength], "coveredPrefix", coveredPrefix, "len(coveredPeers)", len(coveredPeers), "len(allClosestPeers)", len(allClosestPeers), "gaps", gaps)
 				break
 			}
@@ -1011,28 +1005,32 @@ func (s *SweepingProvider) closestPeersToPrefix(prefix bitstr.Key) ([]peer.ID, b
 	}
 	s.logger.Debugf("region %s exploration required %d requests to discover %d peers in %s", prefix, i+1, len(allClosestPeers), time.Since(startTime))
 
-	// Safety net for the early-break paths (no fresh peers, or iteration cap)
-	// that bypass the in-loop widening above: the covered prefix must enclose
-	// every gathered peer, otherwise it points at an empty branch and
-	// RegionsFromPeers drops every key for this region.
-	prefix = commonAncestorPrefix(prefix, allClosestPeers)
+	// Safety net for the early-break paths that bypass the in-loop broadening
+	// above: the no-fresh-peers break, the iteration cap, and — most commonly —
+	// a single-peer network (the len(closestPeers)==1 branch never records empty
+	// siblings, so `prefix` is never covered and the in-loop broaden never runs).
+	// Broaden the covered prefix until at least replicationFactor gathered peers
+	// fall under it (or it is empty), so it never points at a branch with too few
+	// peers and RegionsFromPeers never drops keys for this region (#1263).
+	for len(prefix) > 0 && peersUnderPrefix(prefix, allClosestPeers) < s.replicationFactor {
+		prefix = prefix[:len(prefix)-1]
+	}
 	return peers, prefix, nil
 }
 
-// commonAncestorPrefix widens `prefix` to the deepest prefix it shares with
-// every peer in `peers`. The result is an ancestor of, or equal to, `prefix`
-// that encloses all gathered peers, so it never points at a branch the peers
-// don't occupy. An empty `peers` map leaves `prefix` unchanged.
-func commonAncestorPrefix(prefix bitstr.Key, peers map[peer.ID]struct{}) bitstr.Key {
+// peersUnderPrefix counts the peers in `peers` whose kademlia identifier falls
+// under `prefix`. An empty prefix matches every peer.
+func peersUnderPrefix(prefix bitstr.Key, peers map[peer.ID]struct{}) int {
+	if len(prefix) == 0 {
+		return len(peers)
+	}
+	n := 0
 	for p := range peers {
-		if len(prefix) == 0 {
-			break // fully broadened, nothing left to clamp
-		}
-		if cpl := key.CommonPrefixLength(prefix, keyspace.PeerIDToBit256(p)); cpl < len(prefix) {
-			prefix = prefix[:cpl]
+		if keyspace.IsPrefix(prefix, keyspace.PeerIDToBit256(p)) {
+			n++
 		}
 	}
-	return prefix
+	return n
 }
 
 // closestPeersToKey returns a valid peer ID sharing a long common prefix with

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -864,14 +864,14 @@ func (s *SweepingProvider) vanillaProvide(k mh.Multihash, reprovide bool) (bitst
 // returned regions combined. It is different to the supplied `prefix` if there
 // aren't enough peers matching `prefix`.
 func (s *SweepingProvider) exploreSwarm(prefix bitstr.Key) (regions []keyspace.Region, coveredPrefix bitstr.Key, err error) {
-	peers, err := s.closestPeersToPrefix(prefix)
+	peers, coveredPrefix, err := s.closestPeersToPrefix(prefix)
 	if err != nil {
 		return nil, "", fmt.Errorf("exploreSwarm '%s': %w", prefix, err)
 	}
 	if len(peers) == 0 {
 		return nil, "", fmt.Errorf("no peers found when exploring prefix %s", prefix)
 	}
-	regions, coveredPrefix = keyspace.RegionsFromPeers(peers, s.replicationFactor, s.order)
+	regions = keyspace.RegionsFromPeers(peers, s.replicationFactor, s.order, coveredPrefix)
 	s.logger.Debugw("exploreSwarm", "requestedPrefix", prefix, "coveredPrefix", coveredPrefix, "numRegions", len(regions))
 	for _, r := range regions {
 		s.stats.regionSize.Add(int64(r.Peers.Size()))
@@ -884,7 +884,13 @@ func (s *SweepingProvider) exploreSwarm(prefix bitstr.Key) (regions []keyspace.R
 // prefix. In the case there aren't enough peers matching the provided prefix,
 // it will find and return the closest peers to the prefix, even if they don't
 // exactly match it.
-func (s *SweepingProvider) closestPeersToPrefix(prefix bitstr.Key) ([]peer.ID, error) {
+//
+// It also returns the covered prefix: the keyspace zone the returned peers are
+// responsible for. It equals the requested prefix when enough matching peers
+// are found, and is broadened (a shorter prefix, possibly empty) when the
+// prefix had to be widened to gather enough peers. The covered prefix is always
+// an ancestor of, or equal to, the requested prefix.
+func (s *SweepingProvider) closestPeersToPrefix(prefix bitstr.Key) ([]peer.ID, bitstr.Key, error) {
 	allClosestPeers := make(map[peer.ID]struct{})
 
 	nextPrefix := prefix
@@ -896,20 +902,20 @@ func (s *SweepingProvider) closestPeersToPrefix(prefix bitstr.Key) ([]peer.ID, e
 	// Go down the trie to fully cover prefix.
 	for ; i < maxExplorationPrefixSearches; i++ {
 		if s.closed() {
-			return nil, ErrClosed
+			return nil, "", ErrClosed
 		}
 		if !s.connectivity.IsOnline() {
-			return nil, errors.New("node is offline")
+			return nil, "", errors.New("node is offline")
 		}
 		fullKey := keyspace.FirstFullKeyWithPrefix(nextPrefix, s.order)
 		closestPeers, err := s.closestPeersToKey(fullKey)
 		if err != nil {
 			// We only get an err if something really bad happened, e.g no peers in
 			// routing table, invalid key, etc.
-			return nil, err
+			return nil, "", err
 		}
 		if len(closestPeers) == 0 {
-			return nil, errors.New("dht lookup did not return any peers")
+			return nil, "", errors.New("dht lookup did not return any peers")
 		}
 
 		var coveredPrefix bitstr.Key
@@ -995,7 +1001,7 @@ func (s *SweepingProvider) closestPeersToPrefix(prefix bitstr.Key) ([]peer.ID, e
 		peers = append(peers, p)
 	}
 	s.logger.Debugf("region %s exploration required %d requests to discover %d peers in %s", prefix, i+1, len(allClosestPeers), time.Since(startTime))
-	return peers, nil
+	return peers, prefix, nil
 }
 
 // closestPeersToKey returns a valid peer ID sharing a long common prefix with

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -969,6 +969,15 @@ func (s *SweepingProvider) closestPeersToPrefix(prefix bitstr.Key) ([]peer.ID, b
 			coverageTrie.Add(coveredPrefix, struct{}{})
 		}
 
+		// Widen `prefix` to the zone the gathered peers actually occupy. When the
+		// closest peers to `prefix` sit in a sibling branch (sparse or clustered
+		// swarm, typically with replicationFactor < bucket size), `prefix` would
+		// otherwise be reported covered as soon as one sub-cluster yields enough
+		// peers, leaving the sibling that holds the rest of the responsible peers
+		// unexplored and its keys dropped. Widening here makes the gap check below
+		// explore those branches before breaking.
+		prefix = commonAncestorPrefix(prefix, allClosestPeers)
+
 		gaps = keyspace.TrieGaps(coverageTrie, prefix, s.order)
 		fullKeyLogKey := fmt.Sprintf("fullKey[:%d]", maxLoggedKeyLength) // for logging purposes
 		if len(gaps) == 0 {
@@ -1001,7 +1010,29 @@ func (s *SweepingProvider) closestPeersToPrefix(prefix bitstr.Key) ([]peer.ID, b
 		peers = append(peers, p)
 	}
 	s.logger.Debugf("region %s exploration required %d requests to discover %d peers in %s", prefix, i+1, len(allClosestPeers), time.Since(startTime))
+
+	// Safety net for the early-break paths (no fresh peers, or iteration cap)
+	// that bypass the in-loop widening above: the covered prefix must enclose
+	// every gathered peer, otherwise it points at an empty branch and
+	// RegionsFromPeers drops every key for this region.
+	prefix = commonAncestorPrefix(prefix, allClosestPeers)
 	return peers, prefix, nil
+}
+
+// commonAncestorPrefix widens `prefix` to the deepest prefix it shares with
+// every peer in `peers`. The result is an ancestor of, or equal to, `prefix`
+// that encloses all gathered peers, so it never points at a branch the peers
+// don't occupy. An empty `peers` map leaves `prefix` unchanged.
+func commonAncestorPrefix(prefix bitstr.Key, peers map[peer.ID]struct{}) bitstr.Key {
+	for p := range peers {
+		if len(prefix) == 0 {
+			break // fully broadened, nothing left to clamp
+		}
+		if cpl := key.CommonPrefixLength(prefix, keyspace.PeerIDToBit256(p)); cpl < len(prefix) {
+			prefix = prefix[:cpl]
+		}
+	}
+	return prefix
 }
 
 // closestPeersToKey returns a valid peer ID sharing a long common prefix with

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -511,6 +511,57 @@ func TestExploreSwarmClusteredPeersCoversAllKeys(t *testing.T) {
 	})
 }
 
+// TestExploreSwarmClusteredPeersBelowBucketSizeCoversAllKeys is the
+// rf < bucketSize variant of #1263. With a custom WithReplicationFactor set
+// below the bucket size, closestPeersToPrefix can satisfy the enough-peers
+// break (len(allClosestPeers) >= replicationFactor) before the requested prefix
+// is broadened, returning a coveredPrefix that points at an empty branch. Unless
+// the covered prefix is clamped to what the gathered peers actually share,
+// RegionsFromPeers walks into that empty branch, returns no regions, and every
+// key for the region is silently dropped.
+func TestExploreSwarmClusteredPeersBelowBucketSizeCoversAllKeys(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		// rf below the bucket size, clustered swarm: 12 peers all under "11",
+		// split 6 under "110" and 6 under "111". None under the requested "10".
+		replFactor := 4
+		peers := append(genPeersWithPrefix("110", 6), genPeersWithPrefix("111", 6)...)
+
+		router := &mockRouter{
+			getClosestPeersFunc: func(ctx context.Context, k string) ([]peer.ID, error) {
+				return peers, nil
+			},
+		}
+
+		prov := SweepingProvider{
+			router:            router,
+			logger:            defaultLogger,
+			connectivity:      noopConnectivityChecker(),
+			replicationFactor: replFactor,
+			stats:             newOperationStats(time.Hour, time.Minute),
+		}
+		prov.connectivity.Start()
+		defer prov.connectivity.Close()
+
+		synctest.Wait()
+		require.True(t, prov.connectivity.IsOnline())
+
+		keys := genBalancedMultihashes(2)
+
+		// Reprovide a region that does NOT match the peer cluster.
+		regions, _, err := prov.exploreSwarm("10")
+		require.NoError(t, err)
+
+		regions = keyspace.AssignKeysToRegions(regions, keys)
+
+		assigned := 0
+		for _, r := range regions {
+			assigned += r.Keys.Size()
+		}
+		require.Equalf(t, len(keys), assigned,
+			"keys silently dropped: only %d/%d keys were assigned to a region", assigned, len(keys))
+	})
+}
+
 func TestGroupAndScheduleKeysByPrefix(t *testing.T) {
 	prov := SweepingProvider{
 		order:             bit256.ZeroKey(),

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"errors"
+	"math/rand"
 	"slices"
 	"strconv"
 	"strings"
@@ -582,6 +583,357 @@ func TestExploreSwarmClusteredPeersBelowBucketSizeCoversAllKeys(t *testing.T) {
 		}
 		require.Equalf(t, len(keys), assigned,
 			"keys silently dropped: only %d/%d keys were assigned to a region", assigned, len(keys))
+	})
+}
+
+// TestExploreSwarmPrefixWithEnoughPeersNotOverBroadened guards against
+// over-broadening: when the requested prefix already has >= replicationFactor
+// peers under it, exploreSwarm must NOT widen the covered prefix just because a
+// GetClosestPeers response also returned farther sibling peers (which happens
+// whenever the prefix's subtree is smaller than the bucket size). Over-broadening
+// would make a reprovide of "111" reprovide the whole "1" subtree and collapse
+// the schedule.
+func TestExploreSwarmPrefixWithEnoughPeersNotOverBroadened(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		replFactor := 4
+		// "111" has 5 peers (>= rf). Siblings exist so GetClosestPeers responses
+		// for a "111" query also include peers outside "111".
+		under111 := genPeersWithPrefix("111", 5)
+		peers := slices.Concat(
+			under111,
+			genPeersWithPrefix("110", 3),
+			genPeersWithPrefix("10", 4),
+			genPeersWithPrefix("0", 8),
+		)
+
+		router := &mockRouter{
+			getClosestPeersFunc: func(ctx context.Context, k string) ([]peer.ID, error) {
+				return peers, nil
+			},
+		}
+
+		prov := SweepingProvider{
+			router:            router,
+			logger:            defaultLogger,
+			connectivity:      noopConnectivityChecker(),
+			replicationFactor: replFactor,
+			stats:             newOperationStats(time.Hour, time.Minute),
+		}
+		prov.connectivity.Start()
+		defer prov.connectivity.Close()
+
+		synctest.Wait()
+		require.True(t, prov.connectivity.IsOnline())
+
+		regions, coveredPrefix, err := prov.exploreSwarm("111")
+		require.NoError(t, err)
+
+		require.Equalf(t, bitstr.Key("111"), coveredPrefix,
+			"requested '111' (5 >= rf peers) but covered prefix widened to %q", coveredPrefix)
+
+		foundPeers := make(map[peer.ID]struct{})
+		for _, r := range regions {
+			for _, p := range keyspace.AllValues(r.Peers, bit256.ZeroKey()) {
+				foundPeers[p] = struct{}{}
+			}
+		}
+		require.Lenf(t, foundPeers, len(under111),
+			"region holds %d peers, expected the %d peers under '111'", len(foundPeers), len(under111))
+		for _, p := range under111 {
+			require.Containsf(t, foundPeers, p, "peer under '111' missing from region")
+		}
+	})
+}
+
+// peersToTrie builds a kademlia-id trie from a list of peers.
+func peersToTrie(peers []peer.ID) *trie.Trie[bit256.Key, peer.ID] {
+	t := trie.New[bit256.Key, peer.ID]()
+	for _, p := range peers {
+		t.Add(keyspace.PeerIDToBit256(p), p)
+	}
+	return t
+}
+
+// peersUnderTrie returns all peers in `peersTrie` whose kademlia id is under
+// `prefix`.
+func peersUnderTrie(peersTrie *trie.Trie[bit256.Key, peer.ID], prefix bitstr.Key) []peer.ID {
+	sub, ok := keyspace.FindSubtrie(peersTrie, prefix)
+	if !ok {
+		return nil
+	}
+	return keyspace.AllValues(sub, bit256.ZeroKey())
+}
+
+// referenceCoveredPrefix independently computes the prefix exploreSwarm should
+// cover for a request: the longest ancestor-or-equal of `prefix` whose subtrie
+// holds at least `rf` peers, or "" if even the whole network has fewer.
+func referenceCoveredPrefix(peersTrie *trie.Trie[bit256.Key, peer.ID], prefix bitstr.Key, rf int) bitstr.Key {
+	cp := prefix
+	for {
+		size := 0
+		if sub, ok := keyspace.FindSubtrie(peersTrie, cp); ok {
+			size = sub.Size()
+		}
+		if size >= rf || len(cp) == 0 {
+			return cp
+		}
+		cp = cp[:len(cp)-1]
+	}
+}
+
+// realisticRouter mimics a real DHT GetClosestPeers: it returns the bucketSize
+// peers closest to the queried key, unlike the all-peers mocks used elsewhere.
+func realisticRouter(peers []peer.ID, bucketSize int) *mockRouter {
+	return &mockRouter{
+		getClosestPeersFunc: func(ctx context.Context, k string) ([]peer.ID, error) {
+			sorted := kb.SortClosestPeers(peers, kb.ConvertKey(k))
+			return sorted[:min(bucketSize, len(sorted))], nil
+		},
+	}
+}
+
+// TestExploreSwarmDifferential cross-checks exploreSwarm against an independent
+// reference across many network topologies, requested prefixes, and replication
+// factors, using a realistic SortClosestPeers[:bucketSize] router with
+// rf < bucketSize (the regime where queries also return sibling peers). For
+// every case it asserts the covered prefix equals the reference and the regions
+// hold exactly the peers under it (i.e. the responsible zone was fully explored,
+// neither under- nor over-broadened), and that no key is dropped.
+func TestExploreSwarmDifferential(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		const bucketSize = 20
+		networks := map[string][]peer.ID{
+			"uniform-100":         random.Peers(100),
+			"uniform-60":          random.Peers(60),
+			"uniform-25":          random.Peers(25),
+			"cluster-10-under-10": genPeersWithPrefix("10", 10),
+			"dense-under-1":       genPeersWithPrefix("1", 50),
+			"split-110-111":       slices.Concat(genPeersWithPrefix("110", 6), genPeersWithPrefix("111", 6)),
+			"skewed-1-vs-11":      slices.Concat(genPeersWithPrefix("100", 1), genPeersWithPrefix("101", 11)),
+			"deep-cluster-1011":   genPeersWithPrefix("1011", 8),
+			"far-clusters":        slices.Concat(genPeersWithPrefix("0", 15), genPeersWithPrefix("111", 5)),
+		}
+		prefixes := []bitstr.Key{"", "0", "1", "00", "01", "10", "11", "000", "001", "010", "011", "100", "101", "110", "111"}
+		rfs := []int{1, 3, 5, 8}
+
+		keys := genBalancedMultihashes(4)
+
+		for name, peers := range networks {
+			peersTrie := peersToTrie(peers)
+			for _, rf := range rfs {
+				prov := SweepingProvider{
+					router:            realisticRouter(peers, bucketSize),
+					order:             bit256.ZeroKey(),
+					logger:            defaultLogger,
+					connectivity:      noopConnectivityChecker(),
+					replicationFactor: rf,
+					stats:             newOperationStats(time.Hour, time.Minute),
+				}
+				prov.connectivity.Start()
+				synctest.Wait()
+				require.True(t, prov.connectivity.IsOnline())
+
+				for _, prefix := range prefixes {
+					regions, coveredPrefix, err := prov.exploreSwarm(prefix)
+					require.NoErrorf(t, err, "net=%s rf=%d prefix=%q", name, rf, prefix)
+
+					wantPrefix := referenceCoveredPrefix(peersTrie, prefix, rf)
+					require.Equalf(t, wantPrefix, coveredPrefix,
+						"net=%s rf=%d prefix=%q: wrong covered prefix", name, rf, prefix)
+
+					regionPeers := []peer.ID{}
+					for _, r := range regions {
+						regionPeers = append(regionPeers, keyspace.AllValues(r.Peers, bit256.ZeroKey())...)
+					}
+					require.ElementsMatchf(t, peersUnderTrie(peersTrie, wantPrefix), regionPeers,
+						"net=%s rf=%d prefix=%q: regions don't hold exactly the peers under %q",
+						name, rf, prefix, wantPrefix)
+
+					// No under-replication: when the covered zone holds enough
+					// peers, every region must too (extractMinimalRegions only
+					// splits when both sides keep >= rf peers).
+					if len(regionPeers) >= rf {
+						for _, r := range regions {
+							require.GreaterOrEqualf(t, r.Peers.Size(), rf,
+								"net=%s rf=%d prefix=%q: region %q has %d < rf peers",
+								name, rf, prefix, r.Prefix, r.Peers.Size())
+						}
+					}
+
+					assigned := 0
+					for _, r := range keyspace.AssignKeysToRegions(regions, keys) {
+						assigned += r.Keys.Size()
+					}
+					require.Equalf(t, len(keys), assigned,
+						"net=%s rf=%d prefix=%q: %d/%d keys dropped", name, rf, prefix, assigned, len(keys))
+				}
+				prov.connectivity.Close()
+			}
+		}
+	})
+}
+
+// TestExploreSwarmFuzz randomizes network size, membership, requested prefix,
+// and replication factor (rf < bucketSize) against the realistic router, and
+// checks the same invariants as the differential test: the covered prefix and
+// the explored peer set must match the independent reference for every case.
+func TestExploreSwarmFuzz(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		const bucketSize = 20
+		rng := rand.New(rand.NewSource(1))
+		pool := random.Peers(200)
+
+		checker := noopConnectivityChecker()
+		checker.Start()
+		defer checker.Close()
+		synctest.Wait()
+		require.True(t, checker.IsOnline())
+
+		prov := SweepingProvider{
+			order:        bit256.ZeroKey(),
+			logger:       defaultLogger,
+			connectivity: checker,
+			stats:        newOperationStats(time.Hour, time.Minute),
+		}
+
+		for c := range 250 {
+			size := 1 + rng.Intn(len(pool))
+			peers := make([]peer.ID, size)
+			for i, idx := range rng.Perm(len(pool))[:size] {
+				peers[i] = pool[idx]
+			}
+			peersTrie := peersToTrie(peers)
+			rf := 1 + rng.Intn(12)
+
+			var sb strings.Builder
+			for range rng.Intn(7) {
+				sb.WriteByte('0' + byte(rng.Intn(2)))
+			}
+			prefix := bitstr.Key(sb.String())
+
+			prov.router = realisticRouter(peers, bucketSize)
+			prov.replicationFactor = rf
+
+			regions, coveredPrefix, err := prov.exploreSwarm(prefix)
+			require.NoErrorf(t, err, "case=%d size=%d rf=%d prefix=%q", c, size, rf, prefix)
+
+			wantPrefix := referenceCoveredPrefix(peersTrie, prefix, rf)
+			require.Equalf(t, wantPrefix, coveredPrefix,
+				"case=%d size=%d rf=%d prefix=%q: wrong covered prefix", c, size, rf, prefix)
+
+			regionPeers := []peer.ID{}
+			for _, r := range regions {
+				regionPeers = append(regionPeers, keyspace.AllValues(r.Peers, bit256.ZeroKey())...)
+			}
+			require.ElementsMatchf(t, peersUnderTrie(peersTrie, wantPrefix), regionPeers,
+				"case=%d size=%d rf=%d prefix=%q: regions don't hold exactly the peers under %q",
+				c, size, rf, prefix, wantPrefix)
+		}
+	})
+}
+
+// TestExploreSwarmTinyNetwork covers networks smaller than the replication
+// factor: exploreSwarm must broaden all the way to the empty prefix, return
+// every peer, and never drop a key, for any requested prefix.
+func TestExploreSwarmTinyNetwork(t *testing.T) {
+	for _, nPeers := range []int{1, 2, 3} {
+		t.Run(strconv.Itoa(nPeers), func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				peers := random.Peers(nPeers)
+				prov := SweepingProvider{
+					router:            realisticRouter(peers, 20),
+					order:             bit256.ZeroKey(),
+					logger:            defaultLogger,
+					connectivity:      noopConnectivityChecker(),
+					replicationFactor: 8, // larger than the network
+					stats:             newOperationStats(time.Hour, time.Minute),
+				}
+				prov.connectivity.Start()
+				defer prov.connectivity.Close()
+				synctest.Wait()
+				require.True(t, prov.connectivity.IsOnline())
+
+				keys := genBalancedMultihashes(3)
+				for _, prefix := range []bitstr.Key{"", "0", "1", "01", "10", "111"} {
+					regions, coveredPrefix, err := prov.exploreSwarm(prefix)
+					require.NoErrorf(t, err, "prefix=%q", prefix)
+					require.Emptyf(t, coveredPrefix,
+						"network smaller than rf must broaden to empty prefix, got %q for %q", coveredPrefix, prefix)
+
+					regionPeers := []peer.ID{}
+					for _, r := range regions {
+						regionPeers = append(regionPeers, keyspace.AllValues(r.Peers, bit256.ZeroKey())...)
+					}
+					require.ElementsMatchf(t, peers, regionPeers, "prefix=%q: not all peers returned", prefix)
+
+					assigned := 0
+					for _, r := range keyspace.AssignKeysToRegions(regions, keys) {
+						assigned += r.Keys.Size()
+					}
+					require.Equalf(t, len(keys), assigned, "prefix=%q: keys dropped", prefix)
+				}
+			})
+		})
+	}
+}
+
+// TestProvidePipelineRoutesKeysToClosestPeers is the end-to-end correctness
+// property: a key explored, regioned, and assigned must land in a region that
+// contains the key's true rf closest peers in the whole network. If exploration
+// missed a peer, mis-split a region, or mis-assigned a key, the record would be
+// sent to the wrong peers — this catches all three.
+func TestProvidePipelineRoutesKeysToClosestPeers(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		const bucketSize = 20
+		networks := map[string][]peer.ID{
+			"uniform-80":     random.Peers(80),
+			"split-110-111":  slices.Concat(genPeersWithPrefix("110", 7), genPeersWithPrefix("111", 7)),
+			"skewed-1-vs-11": slices.Concat(genPeersWithPrefix("100", 1), genPeersWithPrefix("101", 13)),
+			"far-clusters":   slices.Concat(genPeersWithPrefix("0", 18), genPeersWithPrefix("111", 6)),
+		}
+		keys := genMultihashes(64)
+
+		for _, rf := range []int{3, 6} {
+			for name, peers := range networks {
+				prov := SweepingProvider{
+					router:            realisticRouter(peers, bucketSize),
+					order:             bit256.ZeroKey(),
+					logger:            defaultLogger,
+					connectivity:      noopConnectivityChecker(),
+					replicationFactor: rf,
+					stats:             newOperationStats(time.Hour, time.Minute),
+				}
+				prov.connectivity.Start()
+				synctest.Wait()
+				require.True(t, prov.connectivity.IsOnline())
+
+				for _, k := range keys {
+					prefix := bitstr.Key(key.BitString(keyspace.MhToBit256(k))[:4])
+					regions, _, err := prov.exploreSwarm(prefix)
+					require.NoErrorf(t, err, "net=%s rf=%d key prefix=%q", name, rf, prefix)
+					regions = keyspace.AssignKeysToRegions(regions, []mh.Multihash{k})
+
+					var region *keyspace.Region
+					for i := range regions {
+						if regions[i].Keys.Size() > 0 {
+							region = &regions[i]
+							break
+						}
+					}
+					require.NotNilf(t, region, "net=%s rf=%d: key not assigned to any region", name, rf)
+
+					wantClosest := kb.SortClosestPeers(peers, kb.ConvertKey(string(k)))
+					wantClosest = wantClosest[:min(rf, len(wantClosest))]
+					regionPeers := keyspace.AllValues(region.Peers, bit256.ZeroKey())
+					for _, want := range wantClosest {
+						require.Containsf(t, regionPeers, want,
+							"net=%s rf=%d: key's region %q missing one of its %d closest peers",
+							name, rf, region.Prefix, len(wantClosest))
+					}
+				}
+				prov.connectivity.Close()
+			}
+		}
 	})
 }
 

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -514,17 +514,20 @@ func TestExploreSwarmClusteredPeersCoversAllKeys(t *testing.T) {
 // TestExploreSwarmClusteredPeersBelowBucketSizeCoversAllKeys is the
 // rf < bucketSize variant of #1263. With a custom WithReplicationFactor set
 // below the bucket size, closestPeersToPrefix can satisfy the enough-peers
-// break (len(allClosestPeers) >= replicationFactor) before the requested prefix
-// is broadened, returning a coveredPrefix that points at an empty branch. Unless
-// the covered prefix is clamped to what the gathered peers actually share,
-// RegionsFromPeers walks into that empty branch, returns no regions, and every
-// key for the region is silently dropped.
+// break (len(allClosestPeers) >= replicationFactor) after exploring only one
+// sub-cluster of a clustered swarm. exploreSwarm must keep exploring until the
+// zone the gathered peers actually occupy is fully covered, so that both
+// sub-clusters are discovered. Otherwise the unexplored sibling's peers are
+// missing, its keys are provided to the wrong peers (or dropped), and that
+// sibling is collapsed into the broadened prefix and never reprovided.
 func TestExploreSwarmClusteredPeersBelowBucketSizeCoversAllKeys(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		// rf below the bucket size, clustered swarm: 12 peers all under "11",
 		// split 6 under "110" and 6 under "111". None under the requested "10".
 		replFactor := 4
-		peers := append(genPeersWithPrefix("110", 6), genPeersWithPrefix("111", 6)...)
+		under110 := genPeersWithPrefix("110", 6)
+		under111 := genPeersWithPrefix("111", 6)
+		peers := append(append([]peer.ID{}, under110...), under111...)
 
 		router := &mockRouter{
 			getClosestPeersFunc: func(ctx context.Context, k string) ([]peer.ID, error) {
@@ -548,8 +551,28 @@ func TestExploreSwarmClusteredPeersBelowBucketSizeCoversAllKeys(t *testing.T) {
 		keys := genBalancedMultihashes(2)
 
 		// Reprovide a region that does NOT match the peer cluster.
-		regions, _, err := prov.exploreSwarm("10")
+		regions, coveredPrefix, err := prov.exploreSwarm("10")
 		require.NoError(t, err)
+
+		// The covered prefix must enclose every gathered peer (all peers sit
+		// under "11", so the broadened zone is "1").
+		require.Equalf(t, bitstr.Key("1"), coveredPrefix,
+			"covered prefix %q does not match the peers' common ancestor", coveredPrefix)
+
+		// Both sub-clusters must be fully discovered: missing peers mean keys
+		// would be provided to the wrong peers.
+		foundPeers := make(map[peer.ID]struct{})
+		for _, r := range regions {
+			for _, p := range keyspace.AllValues(r.Peers, bit256.ZeroKey()) {
+				foundPeers[p] = struct{}{}
+			}
+		}
+		require.Lenf(t, foundPeers, len(peers),
+			"exploration found %d/%d peers; a sub-cluster was left unexplored", len(foundPeers), len(peers))
+		for _, p := range peers {
+			require.Containsf(t, foundPeers, p, "peer %s under %s was not discovered", p,
+				key.BitString(keyspace.PeerIDToBit256(p))[:3])
+		}
 
 		regions = keyspace.AssignKeysToRegions(regions, keys)
 

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -97,6 +97,19 @@ func genMultihashesMatchingPrefix(prefix bitstr.Key, n int) []mh.Multihash {
 	return mhs
 }
 
+// genPeersWithPrefix generates n peer IDs whose kademlia identifiers all share
+// the given common prefix, simulating a small clustered DHT.
+func genPeersWithPrefix(prefix bitstr.Key, n int) []peer.ID {
+	peers := make([]peer.ID, 0, n)
+	for len(peers) < n {
+		p := random.Peers(1)[0]
+		if keyspace.IsPrefix(prefix, keyspace.PeerIDToBit256(p)) {
+			peers = append(peers, p)
+		}
+	}
+	return peers
+}
+
 func getMockAddrs(t *testing.T) func() []ma.Multiaddr {
 	return func() []ma.Multiaddr {
 		addr, err := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/4001")
@@ -445,6 +458,56 @@ func TestClosestPeersToPrefixSinglePeer(t *testing.T) {
 			require.Len(t, closestPeers, 1)
 			require.Contains(t, closestPeers, p)
 		}
+	})
+}
+
+// TestExploreSwarmClusteredPeersCoversAllKeys reproduces #1263: in a small DHT
+// where all peers share a common prefix (e.g. "11"), exploreSwarm must still
+// produce regions that cover the entire keyspace, since these peers are the
+// closest peers to every key. Otherwise keys outside the peers' common prefix
+// are silently dropped when assigned to regions, which is what causes
+// batchReprovide to drop them and the schedule to collapse to a single prefix.
+func TestExploreSwarmClusteredPeersCoversAllKeys(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		replFactor := 20
+		// Small DHT: 4 peers, all sharing the common prefix "11".
+		peers := genPeersWithPrefix("11", 4)
+
+		router := &mockRouter{
+			getClosestPeersFunc: func(ctx context.Context, k string) ([]peer.ID, error) {
+				return peers, nil
+			},
+		}
+
+		prov := SweepingProvider{
+			router:            router,
+			logger:            defaultLogger,
+			connectivity:      noopConnectivityChecker(),
+			replicationFactor: replFactor,
+			stats:             newOperationStats(time.Hour, time.Minute),
+		}
+		prov.connectivity.Start()
+		defer prov.connectivity.Close()
+
+		synctest.Wait()
+		require.True(t, prov.connectivity.IsOnline())
+
+		// Keys spread uniformly across the keyspace: one per 2-bit prefix
+		// (00, 01, 10, 11).
+		keys := genBalancedMultihashes(2)
+
+		// Reprovide a region that does NOT match the peer cluster.
+		regions, _, err := prov.exploreSwarm("10")
+		require.NoError(t, err)
+
+		regions = keyspace.AssignKeysToRegions(regions, keys)
+
+		assigned := 0
+		for _, r := range regions {
+			assigned += r.Keys.Size()
+		}
+		require.Equalf(t, len(keys), assigned,
+			"keys silently dropped: only %d/%d keys were assigned to a region", assigned, len(keys))
 	})
 }
 

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -351,7 +351,7 @@ func TestClosestPeersToPrefixRandom(t *testing.T) {
 		require.True(t, r.connectivity.IsOnline())
 
 		for _, prefix := range []bitstr.Key{"", "0", "1", "00", "01", "10", "11", "000", "001", "010", "011", "100", "101", "110", "111"} {
-			closestPeers, err := r.closestPeersToPrefix(prefix)
+			closestPeers, _, err := r.closestPeersToPrefix(prefix)
 			require.NoError(t, err, "failed for prefix %s", prefix)
 			subtrieSize := 0
 			currPrefix := prefix
@@ -411,7 +411,7 @@ func TestClosestPeersToPrefixSameCPL(t *testing.T) {
 		// No matter what the requested prefix is, the returned closest peers
 		// should be the ones supplied by the GetClosestPeers function.
 		for _, prefix := range []bitstr.Key{"1111", "0111", "0011", "0001", "0000", "1", ""} {
-			closestPeers, err := prov.closestPeersToPrefix(prefix)
+			closestPeers, _, err := prov.closestPeersToPrefix(prefix)
 			require.NoError(t, err)
 			require.ElementsMatch(t, peers, closestPeers)
 		}
@@ -453,7 +453,7 @@ func TestClosestPeersToPrefixSinglePeer(t *testing.T) {
 		// No matter what the requested prefix is, the closest peers to prefix
 		// should always be the only peer.
 		for _, prefix := range []bitstr.Key{"1111", "0111", "0011", "0001", "0000", "1", ""} {
-			closestPeers, err := prov.closestPeersToPrefix(prefix)
+			closestPeers, _, err := prov.closestPeersToPrefix(prefix)
 			require.NoError(t, err)
 			require.Len(t, closestPeers, 1)
 			require.Contains(t, closestPeers, p)
@@ -1826,7 +1826,7 @@ func TestClosestPeersToPrefixErrors(t *testing.T) {
 		}
 
 		prefix := bitstr.Key("0101")
-		_, err = prov.closestPeersToPrefix(prefix)
+		_, _, err = prov.closestPeersToPrefix(prefix)
 
 		require.Error(t, err)
 		require.Equal(t, int32(0), callCount.Load(), "router should not be called when offline")
@@ -1856,7 +1856,7 @@ func TestClosestPeersToPrefixErrors(t *testing.T) {
 			require.True(t, prov.connectivity.IsOnline())
 
 			prefix := bitstr.Key("0101")
-			_, err := prov.closestPeersToPrefix(prefix)
+			_, _, err := prov.closestPeersToPrefix(prefix)
 
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "network timeout")


### PR DESCRIPTION
Closes #1263.

## Problem

In a small/clustered DHT where the closest peers to a target prefix don't actually match it (e.g. all peer IDs share the prefix `11`), `SweepingProvider` silently drops keys for every other prefix and the reprovide schedule collapses to a single entry, so remote `FindProviders` returns empty once records expire.

## Cause

`RegionsFromPeers` rooted regions at the peers' *common prefix* (where the peers physically sit, `11`) rather than the *keyspace zone they're responsible for*. When those peers are the global-closest to every key, that zone is the whole keyspace (`""`). The mismatch meant keys outside `11` matched no region and were dropped by `AssignKeysToRegions`, and the wrong region prefix was rescheduled/unscheduled, collapsing the schedule.

## Fix

Derive the region root and the covered prefix from one authoritative value: the prefix `closestPeersToPrefix` already broadens to while gathering enough peers (always an ancestor of, or equal to, the requested prefix).

- `closestPeersToPrefix` now returns that covered prefix.
- `RegionsFromPeers` roots regions at the covered prefix instead of the peers' common prefix.
- `exploreSwarm` threads it through; `batchProvide`/`batchReprovide` need no change — their existing broaden-and-reload path now receives a correct value.
- `AssignKeysToRegions` assigns any non-matching key to the closest region instead of silently dropping it (defense-in-depth; not hit in normal operation once regions are rooted correctly).

In a clustered swarm this yields a single whole-keyspace region: all keys are reprovided each cycle and the schedule stably converges to `[""]`, re-expanding automatically if the network grows.

## Tests

Added `TestExploreSwarmClusteredPeersCoversAllKeys` reproducing the silent key-drop, and updated existing `RegionsFromPeers`/`closestPeersToPrefix` tests for the new signatures.

cc: @nullptroot @phillebaba 