### PR TITLE
fix(provider): keep reprovide history GC running

### DIFF
--- a/provider/provider.go
+++ b/provider/provider.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math"
 	"path"
 	"strconv"
 	"strings"
@@ -130,11 +129,6 @@ var (
 	// avgPrefixLenDatastoreKey is the key storing the average prefix length
 	// computed from the schedule.
 	avgPrefixLenDatastoreKey = datastore.NewKey("avg_prefix_len")
-	// maxTime is the maximum time value. math.MaxInt64 is passed as nanoseconds
-	// (not seconds): time.Unix adds the year-1-to-1970 offset to the seconds
-	// argument, so time.Unix(math.MaxInt64, _) overflows int64 and wraps to a
-	// time in the distant past.
-	maxTime = time.Unix(0, math.MaxInt64) // in year 2262
 )
 
 type KadClosestPeersRouter interface {
@@ -362,7 +356,7 @@ func New(opts ...Option) (*SweepingProvider, error) {
 		// Clear any previously stored reprovide logs, since we are off a fresh
 		// start. This results in reproviding all keys in the keystore when the
 		// node comes online.
-		prov.gcReprovideHistoryIfNeeded(maxTime)
+		prov.clearReprovideHistory()
 	}
 
 	// Don't need to start schedule timer yet
@@ -1522,6 +1516,32 @@ func (s *SweepingProvider) loadRecentlyReprovidedRegions(now time.Time) (*trie.T
 		}
 	}
 	return regions, nil
+}
+
+// clearReprovideHistory deletes every persisted reprovide-history entry. A
+// fresh start with resume disabled calls it so no region counts as recently
+// reprovided, and the node reprovides all of them once it comes online. It
+// leaves lastReprovideHistoryGC untouched, so periodic GC keeps running.
+func (s *SweepingProvider) clearReprovideHistory() {
+	q := query.Query{
+		Prefix:   reprovideHistoryKeyPrefix,
+		KeysOnly: true,
+	}
+	res, err := s.datastore.Query(s.ctx, q)
+	if err != nil {
+		s.logger.Warnf("could not query reprovide history to clear it: %s", err)
+		return
+	}
+	defer res.Close()
+	for r := range res.Next() {
+		if r.Error != nil {
+			s.logger.Warnf("could not query reprovide history to clear it: %s", r.Error)
+			return
+		}
+		if err := s.datastore.Delete(s.ctx, datastore.NewKey(r.Key)); err != nil {
+			s.logger.Warnf("could not delete reprovide history entry %s: %s", r.Key, err)
+		}
+	}
 }
 
 // gcReprovideHistoryIfNeeded removes reprovide log entries older than the

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -2104,88 +2104,116 @@ func TestSkipBootstrapReprovide(t *testing.T) {
 	}
 }
 
+// resumeFixture holds the setup shared by the resume tests. The provider is
+// created by the caller so each test controls New and Close across restarts;
+// the message sender and helpers always act on the current instance through
+// the prov pointer passed to newResumeFixture.
+type resumeFixture struct {
+	reprovidedLk               *sync.Mutex
+	reprovided                 map[bitstr.Key]struct{}
+	requireNoPendingReprovides func()
+	provDs                     datastore.Batching
+	baseOpts                   []Option
+}
+
+func newResumeFixture(t *testing.T, reprovideInterval time.Duration, prov **SweepingProvider) resumeFixture {
+	pid, err := peer.Decode("12D3KooWCPQTeFYCDkru8nza3Af6u77aoVLA71Vb74eHxeR91Gka") // kadid starts with 16*"0"
+	require.NoError(t, err)
+
+	replicationFactor := 4
+	peerPrefixBitlen := 6
+	require.LessOrEqual(t, peerPrefixBitlen, bitsPerByte)
+	var nPeers byte = 1 << peerPrefixBitlen // 2**peerPrefixBitlen
+	peers := make([]peer.ID, nPeers)
+	for i := range nPeers {
+		b := i << (bitsPerByte - peerPrefixBitlen)
+		k := [32]byte{b}
+		peers[i], err = kb.GenRandPeerIDWithCPL(k[:], uint(peerPrefixBitlen))
+		require.NoError(t, err)
+	}
+
+	router := &mockRouter{
+		getClosestPeersFunc: func(ctx context.Context, k string) ([]peer.ID, error) {
+			sortedPeers := kb.SortClosestPeers(peers, kb.ConvertKey(k))
+			return sortedPeers[:min(replicationFactor, len(peers))], nil
+		},
+	}
+
+	getPrefixFromSchedule := func(k bit256.Key) bitstr.Key {
+		(*prov).activeReprovidesLk.Lock()
+		defer (*prov).activeReprovidesLk.Unlock()
+		prefix, ok := keyspace.FindPrefixOfKey((*prov).activeReprovides, k)
+		require.True(t, ok)
+		return prefix
+	}
+
+	reprovidedLk := &sync.Mutex{}
+	reprovided := make(map[bitstr.Key]struct{})
+	msgSender := &mockMsgSender{
+		sendMessageFunc: func(ctx context.Context, p peer.ID, m *pb.Message) error {
+			h, err := mh.Cast(m.GetKey())
+			require.NoError(t, err)
+			k := keyspace.MhToBit256(h)
+			regionalPrefix := getPrefixFromSchedule(k)
+
+			reprovidedLk.Lock()
+			reprovided[regionalPrefix] = struct{}{}
+			reprovidedLk.Unlock()
+			return nil
+		},
+	}
+
+	requireNoPendingReprovides := func() {
+		(*prov).activeReprovidesLk.Lock()
+		require.Zero(t, (*prov).activeReprovides.Size())
+		(*prov).activeReprovidesLk.Unlock()
+		require.Zero(t, (*prov).reprovideQueue.Size())
+	}
+
+	ds := dssync.MutexWrap(datastore.NewMapDatastore())
+	ks, err := keystore.NewKeystore(ds)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, ks.Close()) })
+	provDs := namespace.Wrap(ds, datastore.NewKey("provider"))
+
+	mhs := genBalancedMultihashes(10)
+	_, err = ks.Put(t.Context(), mhs...)
+	require.NoError(t, err)
+
+	baseOpts := []Option{
+		WithReprovideInterval(reprovideInterval),
+		WithReplicationFactor(replicationFactor),
+		WithMaxWorkers(1),
+		WithDedicatedBurstWorkers(0),
+		WithDedicatedPeriodicWorkers(0),
+		WithPeerID(pid),
+		WithRouter(router),
+		WithMessageSender(msgSender),
+		WithSelfAddrs(getMockAddrs(t)),
+		WithDatastore(provDs),
+		WithKeystore(ks),
+	}
+
+	return resumeFixture{
+		reprovidedLk:               reprovidedLk,
+		reprovided:                 reprovided,
+		requireNoPendingReprovides: requireNoPendingReprovides,
+		provDs:                     provDs,
+		baseOpts:                   baseOpts,
+	}
+}
+
 func TestResumeReprovides(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
-		ctx := context.Background()
-		pid, err := peer.Decode("12D3KooWCPQTeFYCDkru8nza3Af6u77aoVLA71Vb74eHxeR91Gka") // kadid starts with 16*"0"
-		require.NoError(t, err)
-
-		replicationFactor := 4
-		peerPrefixBitlen := 6
-		require.LessOrEqual(t, peerPrefixBitlen, bitsPerByte)
-		var nPeers byte = 1 << peerPrefixBitlen // 2**peerPrefixBitlen
-		peers := make([]peer.ID, nPeers)
-		for i := range nPeers {
-			b := i << (bitsPerByte - peerPrefixBitlen)
-			k := [32]byte{b}
-			peers[i], err = kb.GenRandPeerIDWithCPL(k[:], uint(peerPrefixBitlen))
-			require.NoError(t, err)
-		}
-
 		reprovideInterval := time.Hour
 
-		router := &mockRouter{
-			getClosestPeersFunc: func(ctx context.Context, k string) ([]peer.ID, error) {
-				sortedPeers := kb.SortClosestPeers(peers, kb.ConvertKey(k))
-				return sortedPeers[:min(replicationFactor, len(peers))], nil
-			},
-		}
-
 		var prov *SweepingProvider
-		getPrefixFromSchedule := func(k bit256.Key) bitstr.Key {
-			prov.activeReprovidesLk.Lock()
-			defer prov.activeReprovidesLk.Unlock()
-			prefix, ok := keyspace.FindPrefixOfKey(prov.activeReprovides, k)
-			require.True(t, ok)
-			return prefix
-		}
+		fx := newResumeFixture(t, reprovideInterval, &prov)
+		reprovided, reprovidedLk := fx.reprovided, fx.reprovidedLk
+		requireNoPendingReprovides := fx.requireNoPendingReprovides
+		opts := fx.baseOpts
 
-		reprovidedLk := sync.Mutex{}
-		reprovided := make(map[bitstr.Key]struct{})
-		msgSender := &mockMsgSender{
-			sendMessageFunc: func(ctx context.Context, p peer.ID, m *pb.Message) error {
-				h, err := mh.Cast(m.GetKey())
-				require.NoError(t, err)
-				k := keyspace.MhToBit256(h)
-				regionalPrefix := getPrefixFromSchedule(k)
-
-				reprovidedLk.Lock()
-				reprovided[regionalPrefix] = struct{}{}
-				reprovidedLk.Unlock()
-				return nil
-			},
-		}
-
-		requireNoPendingReprovides := func() {
-			prov.activeReprovidesLk.Lock()
-			require.Zero(t, prov.activeReprovides.Size())
-			prov.activeReprovidesLk.Unlock()
-			require.Zero(t, prov.reprovideQueue.Size())
-		}
-
-		ds := dssync.MutexWrap(datastore.NewMapDatastore())
-		ks, err := keystore.NewKeystore(ds)
-		provDs := namespace.Wrap(ds, datastore.NewKey("provider"))
-		require.NoError(t, err)
-		defer ks.Close()
-
-		mhs := genBalancedMultihashes(10)
-		ks.Put(ctx, mhs...)
-
-		opts := []Option{
-			WithReprovideInterval(reprovideInterval),
-			WithReplicationFactor(replicationFactor),
-			WithMaxWorkers(1),
-			WithDedicatedBurstWorkers(0),
-			WithDedicatedPeriodicWorkers(0),
-			WithPeerID(pid),
-			WithRouter(router),
-			WithMessageSender(msgSender),
-			WithSelfAddrs(getMockAddrs(t)),
-			WithDatastore(provDs),
-			WithKeystore(ks),
-		}
-		prov, err = New(opts...)
+		prov, err := New(opts...)
 		require.NoError(t, err)
 
 		synctest.Wait()
@@ -2306,90 +2334,19 @@ func TestResumeReprovides(t *testing.T) {
 // reprovided ASAP.
 func TestResumeDisabledReprovidesAllRegions(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
-		ctx := context.Background()
-		pid, err := peer.Decode("12D3KooWCPQTeFYCDkru8nza3Af6u77aoVLA71Vb74eHxeR91Gka") // kadid starts with 16*"0"
-		require.NoError(t, err)
-
-		replicationFactor := 4
-		peerPrefixBitlen := 6
-		require.LessOrEqual(t, peerPrefixBitlen, bitsPerByte)
-		var nPeers byte = 1 << peerPrefixBitlen // 2**peerPrefixBitlen
-		peers := make([]peer.ID, nPeers)
-		for i := range nPeers {
-			b := i << (bitsPerByte - peerPrefixBitlen)
-			k := [32]byte{b}
-			peers[i], err = kb.GenRandPeerIDWithCPL(k[:], uint(peerPrefixBitlen))
-			require.NoError(t, err)
-		}
-
 		reprovideInterval := time.Hour
 
-		router := &mockRouter{
-			getClosestPeersFunc: func(ctx context.Context, k string) ([]peer.ID, error) {
-				sortedPeers := kb.SortClosestPeers(peers, kb.ConvertKey(k))
-				return sortedPeers[:min(replicationFactor, len(peers))], nil
-			},
-		}
-
 		var prov *SweepingProvider
-		getPrefixFromSchedule := func(k bit256.Key) bitstr.Key {
-			prov.activeReprovidesLk.Lock()
-			defer prov.activeReprovidesLk.Unlock()
-			prefix, ok := keyspace.FindPrefixOfKey(prov.activeReprovides, k)
-			require.True(t, ok)
-			return prefix
-		}
-
-		reprovidedLk := sync.Mutex{}
-		reprovided := make(map[bitstr.Key]struct{})
-		msgSender := &mockMsgSender{
-			sendMessageFunc: func(ctx context.Context, p peer.ID, m *pb.Message) error {
-				h, err := mh.Cast(m.GetKey())
-				require.NoError(t, err)
-				k := keyspace.MhToBit256(h)
-				regionalPrefix := getPrefixFromSchedule(k)
-
-				reprovidedLk.Lock()
-				reprovided[regionalPrefix] = struct{}{}
-				reprovidedLk.Unlock()
-				return nil
-			},
-		}
-
-		requireNoPendingReprovides := func() {
-			prov.activeReprovidesLk.Lock()
-			require.Zero(t, prov.activeReprovides.Size())
-			prov.activeReprovidesLk.Unlock()
-			require.Zero(t, prov.reprovideQueue.Size())
-		}
-
-		ds := dssync.MutexWrap(datastore.NewMapDatastore())
-		ks, err := keystore.NewKeystore(ds)
-		provDs := namespace.Wrap(ds, datastore.NewKey("provider"))
-		require.NoError(t, err)
-		defer func() { require.NoError(t, ks.Close()) }()
-
-		mhs := genBalancedMultihashes(10)
-		ks.Put(ctx, mhs...)
-
-		baseOpts := []Option{
-			WithReprovideInterval(reprovideInterval),
-			WithReplicationFactor(replicationFactor),
-			WithMaxWorkers(1),
-			WithDedicatedBurstWorkers(0),
-			WithDedicatedPeriodicWorkers(0),
-			WithPeerID(pid),
-			WithRouter(router),
-			WithMessageSender(msgSender),
-			WithSelfAddrs(getMockAddrs(t)),
-			WithDatastore(provDs),
-			WithKeystore(ks),
-		}
+		fx := newResumeFixture(t, reprovideInterval, &prov)
+		reprovided, reprovidedLk := fx.reprovided, fx.reprovidedLk
+		requireNoPendingReprovides := fx.requireNoPendingReprovides
+		baseOpts := fx.baseOpts
+		provDs := fx.provDs
 
 		// First run with resume enabled (the default). Let it run long enough
 		// that every region is reprovided and recorded in the persisted
 		// reprovide history.
-		prov, err = New(baseOpts...)
+		prov, err := New(baseOpts...)
 		require.NoError(t, err)
 
 		synctest.Wait()
@@ -2449,7 +2406,7 @@ func TestResumeDisabledReprovidesAllRegions(t *testing.T) {
 		// poisoned with a far-future timestamp would let history accumulate every
 		// cycle.
 		countHistory := func() int {
-			res, err := provDs.Query(ctx, query.Query{Prefix: reprovideHistoryKeyPrefix, KeysOnly: true})
+			res, err := provDs.Query(t.Context(), query.Query{Prefix: reprovideHistoryKeyPrefix, KeysOnly: true})
 			require.NoError(t, err)
 			defer res.Close()
 			n := 0

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-datastore/namespace"
+	"github.com/ipfs/go-datastore/query"
 	dssync "github.com/ipfs/go-datastore/sync"
 	pebble "github.com/ipfs/go-ds-pebble"
 	logging "github.com/ipfs/go-log/v2"
@@ -2439,6 +2440,30 @@ func TestResumeDisabledReprovidesAllRegions(t *testing.T) {
 		require.Len(t, reprovided, nRegions,
 			"resume disabled must reprovide all regions ASAP on restart")
 		reprovidedLk.Unlock()
+		requireNoPendingReprovides()
+
+		// Clearing the history on a resume-disabled start must not disable
+		// periodic GC. Each successful reprovide writes a history entry, and GC
+		// prunes entries older than one interval, so the keyspace stays bounded.
+		// Run a few more cycles and check it does not keep growing; a GC throttle
+		// poisoned with a far-future timestamp would let history accumulate every
+		// cycle.
+		countHistory := func() int {
+			res, err := provDs.Query(ctx, query.Query{Prefix: reprovideHistoryKeyPrefix, KeysOnly: true})
+			require.NoError(t, err)
+			defer res.Close()
+			n := 0
+			for r := range res.Next() {
+				require.NoError(t, r.Error)
+				n++
+			}
+			return n
+		}
+
+		time.Sleep(3 * reprovideInterval)
+		synctest.Wait()
+		require.LessOrEqual(t, countHistory(), 2*nRegions,
+			"history GC must keep pruning after a resume-disabled restart")
 		requireNoPendingReprovides()
 	})
 }


### PR DESCRIPTION
Builds on #1267.

## Problem

#1267 makes a resume-disabled node reprovide every region on startup by clearing its reprovide history first. It clears by calling the periodic history GC with a year-2262 sentinel time, which the GC records as its last-run time. From then on every GC sees a last run far in the future and skips, so it never runs again for the life of the process and reprovide-history entries grow in the datastore without bound.

## Fix

- Clear the history with a dedicated `clearReprovideHistory` that deletes the entries directly and leaves the GC's last-run marker untouched, so periodic GC keeps running.
- Drop the now-unused `maxTime` sentinel.
- `TestResumeDisabledReprovidesAllRegions` now runs past the restart and fails if periodic GC stops running.

This keeps #1267's behavior and restores the missing GC. It doesn't touch the resume-enabled path. The two resume tests now share one setup fixture.