### PR TITLE
upgrade go-test to v0.4.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/ipfs/go-dsqueue v0.2.0
 	github.com/ipfs/go-libdht v0.5.0
 	github.com/ipfs/go-log/v2 v2.9.2
-	github.com/ipfs/go-test v0.3.0
+	github.com/ipfs/go-test v0.3.1-0.20260710003812-19fc05678b70
 	github.com/libp2p/go-libp2p v0.48.0
 	github.com/libp2p/go-libp2p-kbucket v0.8.0
 	github.com/libp2p/go-libp2p-record v0.3.1

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/ipfs/go-dsqueue v0.2.0
 	github.com/ipfs/go-libdht v0.5.0
 	github.com/ipfs/go-log/v2 v2.9.2
-	github.com/ipfs/go-test v0.3.1-0.20260710003812-19fc05678b70
+	github.com/ipfs/go-test v0.4.0
 	github.com/libp2p/go-libp2p v0.48.0
 	github.com/libp2p/go-libp2p-kbucket v0.8.0
 	github.com/libp2p/go-libp2p-record v0.3.1

--- a/go.sum
+++ b/go.sum
@@ -162,8 +162,8 @@ github.com/ipfs/go-libdht v0.5.0/go.mod h1:L3YiuFXecLeZZFuuVRM0hjg1GgVhARzUdahFs
 github.com/ipfs/go-log v0.0.1/go.mod h1:kL1d2/hzSpI0thNYjiKfjanbVNU+IIGA/WnNESY9leM=
 github.com/ipfs/go-log/v2 v2.9.2 h1:O/5BB0elpkRILvT24rCJ5976wWd7u0nJ436T3rdYdc4=
 github.com/ipfs/go-log/v2 v2.9.2/go.mod h1:RziRwwXWhndlk8L75RnEe0zeAYaq2heKtEMc3jqUov0=
-github.com/ipfs/go-test v0.3.1-0.20260710003812-19fc05678b70 h1:TuI1kKVWMz3PgGYocqQ3YK4HLFR/ShkrekUvBYZKJSs=
-github.com/ipfs/go-test v0.3.1-0.20260710003812-19fc05678b70/go.mod h1:JK+U8pRpATZb7lsYNSJlCj3WYB3cFfWIbI6nWRM/GFk=
+github.com/ipfs/go-test v0.4.0 h1:9tXekF1a80k5mCFZ4+Whc43FTtJJ7WqPz57vXezAg/E=
+github.com/ipfs/go-test v0.4.0/go.mod h1:JK+U8pRpATZb7lsYNSJlCj3WYB3cFfWIbI6nWRM/GFk=
 github.com/ipld/go-ipld-prime v0.24.0 h1:6th8Z6Peh5bCWuRAVZcDO1sHzZdVF6F2cCCDG3681tg=
 github.com/ipld/go-ipld-prime v0.24.0/go.mod h1:DYZxr/5caLNFbcuU6zLOgwSW7CgUEoC4wJiZMEU8Zhs=
 github.com/jackpal/go-nat-pmp v1.0.2 h1:KzKSgb7qkJvOUTqYl9/Hg/me3pWgBmERKrTGD7BdWus=

--- a/go.sum
+++ b/go.sum
@@ -162,8 +162,8 @@ github.com/ipfs/go-libdht v0.5.0/go.mod h1:L3YiuFXecLeZZFuuVRM0hjg1GgVhARzUdahFs
 github.com/ipfs/go-log v0.0.1/go.mod h1:kL1d2/hzSpI0thNYjiKfjanbVNU+IIGA/WnNESY9leM=
 github.com/ipfs/go-log/v2 v2.9.2 h1:O/5BB0elpkRILvT24rCJ5976wWd7u0nJ436T3rdYdc4=
 github.com/ipfs/go-log/v2 v2.9.2/go.mod h1:RziRwwXWhndlk8L75RnEe0zeAYaq2heKtEMc3jqUov0=
-github.com/ipfs/go-test v0.3.0 h1:0Y4Uve3tp9HI+2lIJjfOliOrOgv/YpXg/l1y3P4DEYE=
-github.com/ipfs/go-test v0.3.0/go.mod h1:JK+U8pRpATZb7lsYNSJlCj3WYB3cFfWIbI6nWRM/GFk=
+github.com/ipfs/go-test v0.3.1-0.20260710003812-19fc05678b70 h1:TuI1kKVWMz3PgGYocqQ3YK4HLFR/ShkrekUvBYZKJSs=
+github.com/ipfs/go-test v0.3.1-0.20260710003812-19fc05678b70/go.mod h1:JK+U8pRpATZb7lsYNSJlCj3WYB3cFfWIbI6nWRM/GFk=
 github.com/ipld/go-ipld-prime v0.24.0 h1:6th8Z6Peh5bCWuRAVZcDO1sHzZdVF6F2cCCDG3681tg=
 github.com/ipld/go-ipld-prime v0.24.0/go.mod h1:DYZxr/5caLNFbcuU6zLOgwSW7CgUEoC4wJiZMEU8Zhs=
 github.com/jackpal/go-nat-pmp v1.0.2 h1:KzKSgb7qkJvOUTqYl9/Hg/me3pWgBmERKrTGD7BdWus=

--- a/provider/internal/keyspace/key_test.go
+++ b/provider/internal/keyspace/key_test.go
@@ -176,10 +176,11 @@ func TestShortestCoveredPrefix(t *testing.T) {
 
 	// Test with random peer ids
 	nIterations := 64
+	rnd := random.New()
 	for range nIterations {
 		minCpl := KeyLen
 		largestCplCount := 0
-		peers = random.Peers(nPeers)
+		peers = rnd.Peers(nPeers)
 		peers = kb.SortClosestPeers(peers, target[:])
 		for i := range peers {
 			cpl = kb.CommonPrefixLen(kb.ConvertPeerID(peers[i]), target[:])
@@ -203,7 +204,7 @@ func TestShortestCoveredPrefix(t *testing.T) {
 
 	// Supply a single peer exactly matching the target, it should be returned
 	// and covered prefix should match the target.
-	p := random.Peers(1)[0]
+	p := rnd.Peers(1)[0]
 	bstrTarget = bitstr.Key(key.BitString(PeerIDToBit256(p)))
 	peers = []peer.ID{p}
 	prefix, coveredPeers = ShortestCoveredPrefix(bstrTarget, peers)

--- a/provider/internal/keyspace/trie_test.go
+++ b/provider/internal/keyspace/trie_test.go
@@ -1373,15 +1373,17 @@ func TestRegionsFromPeers(t *testing.T) {
 	regions := RegionsFromPeers(nil, 1, bit256.ZeroKey(), "")
 	require.Empty(t, regions)
 
+	randPeers := random.Peers(3)
+
 	// Single peer: the peer fully covers its own key.
-	p0 := random.Peers(1)[0]
+	p0 := randPeers[0]
 	bstrPid0 := bitstr.Key(key.BitString(PeerIDToBit256(p0)))
 	regions = RegionsFromPeers([]peer.ID{p0}, 1, bit256.ZeroKey(), bstrPid0)
 	require.Len(t, regions, 1)
 	require.Equal(t, bstrPid0, regions[0].Prefix)
 
 	// Two peers: regions are rooted at the peers' common prefix.
-	p1 := random.Peers(1)[0]
+	p1 := randPeers[1]
 	cpl := key.CommonPrefixLength(bstrPid0, PeerIDToBit256(p1))
 	common := bstrPid0[:cpl]
 	regions = RegionsFromPeers([]peer.ID{p0, p1}, 2, bit256.ZeroKey(), common)
@@ -1389,7 +1391,7 @@ func TestRegionsFromPeers(t *testing.T) {
 	require.Equal(t, common, regions[0].Prefix)
 
 	// Three peers
-	p2 := random.Peers(1)[0]
+	p2 := randPeers[2]
 	cpl = key.CommonPrefixLength(common, PeerIDToBit256(p2))
 	common = common[:cpl]
 	regions = RegionsFromPeers([]peer.ID{p0, p1, p2}, 2, bit256.ZeroKey(), common)

--- a/provider/internal/queue/provide_test.go
+++ b/provider/internal/queue/provide_test.go
@@ -18,15 +18,19 @@ import (
 )
 
 func genMultihashesMatchingPrefix(prefix bitstr.Key, n int) []mh.Multihash {
+	rnd := random.New()
 	mhs := make([]mh.Multihash, 0, n)
-	for i := 0; len(mhs) < n; i++ {
-		h := random.Multihashes(1)[0]
-		k := keyspace.MhToBit256(h)
-		if keyspace.IsPrefix(prefix, k) {
-			mhs = append(mhs, h)
+	for {
+		for _, h := range rnd.Multihashes(max(n-len(mhs), 8)) {
+			k := keyspace.MhToBit256(h)
+			if keyspace.IsPrefix(prefix, k) {
+				mhs = append(mhs, h)
+				if len(mhs) == n {
+					return mhs
+				}
+			}
 		}
 	}
-	return mhs
 }
 
 func TestProvideEnqueueSimple(t *testing.T) {

--- a/provider/keystore/keystore_test.go
+++ b/provider/keystore/keystore_test.go
@@ -44,6 +44,8 @@ func TestKeystorePutAndGet(t *testing.T) {
 }
 
 func testKeyStorePutAndGetImpl(t *testing.T, store Keystore) {
+	ctx := t.Context()
+
 	mhs := make([]mh.Multihash, 6)
 	for i := range mhs {
 		h, err := mh.Sum([]byte{byte(i)}, mh.SHA2_256, -1)
@@ -51,17 +53,17 @@ func testKeyStorePutAndGetImpl(t *testing.T, store Keystore) {
 		mhs[i] = h
 	}
 
-	added, err := store.Put(context.Background(), mhs...)
+	added, err := store.Put(ctx, mhs...)
 	require.NoError(t, err)
 	require.Len(t, added, len(mhs))
 
-	added, err = store.Put(context.Background(), mhs...)
+	added, err = store.Put(ctx, mhs...)
 	require.NoError(t, err)
 	require.Empty(t, added)
 
 	for _, h := range mhs {
 		prefix := bitstr.Key(key.BitString(keyspace.MhToBit256(h))[:6])
-		got, err := store.Get(context.Background(), prefix)
+		got, err := store.Get(ctx, prefix)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -76,12 +78,12 @@ func testKeyStorePutAndGetImpl(t *testing.T, store Keystore) {
 	}
 
 	p := bitstr.Key(key.BitString(keyspace.MhToBit256(mhs[0]))[:3])
-	res, err := store.Get(context.Background(), p)
+	res, err := store.Get(ctx, p)
 	require.NoError(t, err)
 	require.NotEmpty(t, res, "expected results for prefix %s", p)
 
 	longPrefix := bitstr.Key(key.BitString(keyspace.MhToBit256(mhs[0]))[:15])
-	res, err = store.Get(context.Background(), longPrefix)
+	res, err = store.Get(ctx, longPrefix)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -92,9 +94,10 @@ func testKeyStorePutAndGetImpl(t *testing.T, store Keystore) {
 }
 
 func genMultihashesMatchingPrefix(prefix bitstr.Key, n int) []mh.Multihash {
+	rnd := random.New()
 	mhs := make([]mh.Multihash, 0, n)
 	for i := 0; len(mhs) < n; i++ {
-		h := random.Multihashes(1)[0]
+		h := rnd.Multihashes(1)[0]
 		k := keyspace.MhToBit256(h)
 		if keyspace.IsPrefix(prefix, k) {
 			mhs = append(mhs, h)
@@ -146,7 +149,7 @@ func TestKeyStoreContainsPrefix(t *testing.T) {
 }
 
 func testKeystoreContainsPrefixImpl(t *testing.T, store Keystore) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	ok, err := store.ContainsPrefix(ctx, bitstr.Key("0000"))
 	require.NoError(t, err)
@@ -234,7 +237,7 @@ func TestKeystoreCountKeysUpTo(t *testing.T) {
 }
 
 func testKeystoreCountKeysUpToImpl(t *testing.T, store Keystore, bucket bitstr.Key, bucketKeys, otherKeys []mh.Multihash) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Empty keystore counts zero (limit 0 means no cap).
 	n, err := store.CountKeysUpTo(ctx, bitstr.Key("1"), 0)
@@ -336,6 +339,7 @@ func (c *countingDatastore) Query(ctx context.Context, q query.Query) (query.Res
 }
 
 func TestKeystoreCountKeysUpToStopsEarly(t *testing.T) {
+	ctx := t.Context()
 	// prefixBits 0 keeps every key under a single datastore path, so a non-empty
 	// prefix always takes countUpTo's per-key filter branch (BitLen > prefixBits)
 	// while the empty prefix takes the query.Limit-delegation branch. Every key
@@ -348,7 +352,7 @@ func TestKeystoreCountKeysUpToStopsEarly(t *testing.T) {
 		c := &countingDatastore{Batching: ds.NewMapDatastore()}
 		store, err := NewKeystore(c, WithPrefixBits(0))
 		require.NoError(t, err)
-		_, err = store.Put(context.Background(), keys...)
+		_, err = store.Put(ctx, keys...)
 		require.NoError(t, err)
 		c.reads.Store(0) // discard reads from setup
 		t.Cleanup(func() { _ = store.Close() })
@@ -362,7 +366,7 @@ func TestKeystoreCountKeysUpToStopsEarly(t *testing.T) {
 		// keys-only read-ahead buffer, not the whole bucket).
 		const limit = 3
 		store, c := newStore(t)
-		n, err := store.CountKeysUpTo(context.Background(), "0", limit)
+		n, err := store.CountKeysUpTo(ctx, "0", limit)
 		require.NoError(t, err)
 		require.Equal(t, limit, n)
 		require.Lessf(t, c.reads.Load(), int64(total),
@@ -371,7 +375,7 @@ func TestKeystoreCountKeysUpToStopsEarly(t *testing.T) {
 
 	t.Run("filter branch scans everything when uncapped", func(t *testing.T) {
 		store, c := newStore(t)
-		n, err := store.CountKeysUpTo(context.Background(), "0", 0)
+		n, err := store.CountKeysUpTo(ctx, "0", 0)
 		require.NoError(t, err)
 		require.Equal(t, total, n)
 		require.Equalf(t, int64(total), c.reads.Load(),
@@ -383,7 +387,7 @@ func TestKeystoreCountKeysUpToStopsEarly(t *testing.T) {
 		// query.Limit and the datastore hands back exactly the cap entries.
 		for _, limit := range []int{1, 3, 50} {
 			store, c := newStore(t)
-			n, err := store.CountKeysUpTo(context.Background(), "", limit)
+			n, err := store.CountKeysUpTo(ctx, "", limit)
 			require.NoError(t, err)
 			require.Equal(t, limit, n)
 			require.Equalf(t, int64(limit), c.reads.Load(),
@@ -413,7 +417,7 @@ func (d *failingQueryDatastore) Query(ctx context.Context, q query.Query) (query
 // region when this count fails, so a swallowed error would silently skip that
 // reschedule.
 func TestKeystoreCountKeysUpToPropagatesQueryError(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	wantErr := errors.New("datastore query failed")
 	d := &failingQueryDatastore{Batching: ds.NewMapDatastore(), err: wantErr}
 
@@ -437,7 +441,7 @@ func TestKeystoreCountKeysUpToPropagatesQueryError(t *testing.T) {
 // countUpTo decode every matching datastore key to filter it, so a stored key
 // with a corrupt suffix must turn into an error rather than a wrong count.
 func TestKeystoreCountKeysUpToPropagatesDecodeError(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	const prefixBits = 8
 	d := ds.NewMapDatastore()
 
@@ -479,20 +483,23 @@ func TestKeystoreDelete(t *testing.T) {
 }
 
 func testKeystoreDeleteImpl(t *testing.T, store Keystore) {
-	mhs := random.Multihashes(3)
+	ctx := t.Context()
+	rnd := random.New()
+
+	mhs := rnd.Multihashes(3)
 	for i := range mhs {
 		h, err := mh.Sum([]byte{byte(i)}, mh.SHA2_256, -1)
 		require.NoError(t, err)
 		mhs[i] = h
 	}
-	_, err := store.Put(context.Background(), mhs...)
+	_, err := store.Put(ctx, mhs...)
 	require.NoError(t, err)
 
 	delPrefix := bitstr.Key(key.BitString(keyspace.MhToBit256(mhs[0]))[:6])
-	err = store.Delete(context.Background(), mhs[0])
+	err = store.Delete(ctx, mhs[0])
 	require.NoError(t, err)
 
-	res, err := store.Get(context.Background(), delPrefix)
+	res, err := store.Get(ctx, delPrefix)
 	require.NoError(t, err)
 	for _, h := range res {
 		require.NotEqual(t, string(h), string(mhs[0]), "expected deleted hash to be gone")
@@ -500,7 +507,7 @@ func testKeystoreDeleteImpl(t *testing.T, store Keystore) {
 
 	// other hashes should still be retrievable
 	otherPrefix := bitstr.Key(key.BitString(keyspace.MhToBit256(mhs[1]))[:6])
-	res, err = store.Get(context.Background(), otherPrefix)
+	res, err = store.Get(ctx, otherPrefix)
 	require.NoError(t, err)
 	require.NotEmpty(t, res, "expected remaining hashes for other prefix")
 }
@@ -528,9 +535,10 @@ func TestKeystoreSize(t *testing.T) {
 }
 
 func testKeystoreSizeImpl(t *testing.T, store Keystore) {
-	ctx := context.Background()
+	ctx := t.Context()
+	rnd := random.New()
 
-	mhs0 := random.Multihashes(128)
+	mhs0 := rnd.Multihashes(128)
 	_, err := store.Put(ctx, mhs0...)
 	require.NoError(t, err)
 
@@ -541,7 +549,7 @@ func testKeystoreSizeImpl(t *testing.T, store Keystore) {
 	nKeys := 1 << 12
 	batches := 1 << 6
 	for range batches {
-		mhs1 := random.Multihashes(nKeys / batches)
+		mhs1 := rnd.Multihashes(nKeys / batches)
 		_, err = store.Put(ctx, mhs1...)
 		require.NoError(t, err)
 	}
@@ -572,14 +580,15 @@ func TestKeystoreSizePersistence(t *testing.T) {
 }
 
 func testKeystoreSizePersistenceImpl(t *testing.T, datastore ds.Batching, newStore func(ds.Batching) (Keystore, error)) {
-	ctx := context.Background()
+	ctx := t.Context()
+	rnd := random.New()
 
 	// Create keystore, add keys, and close it
 	store, err := newStore(datastore)
 	require.NoError(t, err)
 
 	const initialKeys = 100
-	mhs := random.Multihashes(initialKeys)
+	mhs := rnd.Multihashes(initialKeys)
 	_, err = store.Put(ctx, mhs...)
 	require.NoError(t, err)
 
@@ -603,7 +612,7 @@ func testKeystoreSizePersistenceImpl(t *testing.T, datastore ds.Batching, newSto
 
 	// Add more keys to verify it continues to work
 	const additionalKeys = 50
-	moreMhs := random.Multihashes(additionalKeys)
+	moreMhs := rnd.Multihashes(additionalKeys)
 	_, err = store2.Put(ctx, moreMhs...)
 	require.NoError(t, err)
 
@@ -644,14 +653,15 @@ func TestKeystoreSizeFallbackOnCorruption(t *testing.T) {
 }
 
 func testKeystoreSizeMissingKeyImpl(t *testing.T, datastore ds.Batching, newStore func(ds.Batching) (Keystore, error)) {
-	ctx := context.Background()
+	ctx := t.Context()
+	rnd := random.New()
 
 	// Create keystore and add keys, but don't close it (simulates crash)
 	store, err := newStore(datastore)
 	require.NoError(t, err)
 
 	const numKeys = 50
-	mhs := random.Multihashes(numKeys)
+	mhs := rnd.Multihashes(numKeys)
 	_, err = store.Put(ctx, mhs...)
 	require.NoError(t, err)
 
@@ -669,14 +679,15 @@ func testKeystoreSizeMissingKeyImpl(t *testing.T, datastore ds.Batching, newStor
 }
 
 func testKeystoreSizeCleanRestartImpl(t *testing.T, datastore ds.Batching, newStore func(ds.Batching) (Keystore, error)) {
-	ctx := context.Background()
+	ctx := t.Context()
+	rnd := random.New()
 
 	// Create keystore, add keys, and properly close
 	store, err := newStore(datastore)
 	require.NoError(t, err)
 
 	const numKeys = 75
-	mhs := random.Multihashes(numKeys)
+	mhs := rnd.Multihashes(numKeys)
 	_, err = store.Put(ctx, mhs...)
 	require.NoError(t, err)
 
@@ -729,11 +740,12 @@ func TestKeystoreSizeWithDeleteAndEmpty(t *testing.T) {
 }
 
 func testKeystoreSizeAfterDeletesImpl(t *testing.T, store Keystore) {
-	ctx := context.Background()
+	ctx := t.Context()
+	rnd := random.New()
 
 	// Add keys
 	const totalKeys = 100
-	mhs := random.Multihashes(totalKeys)
+	mhs := rnd.Multihashes(totalKeys)
 	_, err := store.Put(ctx, mhs...)
 	require.NoError(t, err)
 
@@ -769,11 +781,12 @@ func testKeystoreSizeAfterDeletesImpl(t *testing.T, store Keystore) {
 }
 
 func testKeystoreSizeAfterEmptyImpl(t *testing.T, store Keystore) {
-	ctx := context.Background()
+	ctx := t.Context()
+	rnd := random.New()
 
 	// Add keys
 	const initialKeys = 200
-	mhs := random.Multihashes(initialKeys)
+	mhs := rnd.Multihashes(initialKeys)
 	_, err := store.Put(ctx, mhs...)
 	require.NoError(t, err)
 
@@ -791,7 +804,7 @@ func testKeystoreSizeAfterEmptyImpl(t *testing.T, store Keystore) {
 
 	// Verify we can add keys again
 	const keysAfterEmpty = 50
-	newMhs := random.Multihashes(keysAfterEmpty)
+	newMhs := rnd.Multihashes(keysAfterEmpty)
 	_, err = store.Put(ctx, newMhs...)
 	require.NoError(t, err)
 
@@ -801,10 +814,11 @@ func testKeystoreSizeAfterEmptyImpl(t *testing.T, store Keystore) {
 }
 
 func testKeystoreSizeWithDuplicatePutsImpl(t *testing.T, store Keystore) {
-	ctx := context.Background()
+	ctx := t.Context()
+	rnd := random.New()
 
 	const initialKeys = 50
-	mhs := random.Multihashes(initialKeys)
+	mhs := rnd.Multihashes(initialKeys)
 
 	// First put
 	added, err := store.Put(ctx, mhs...)
@@ -827,7 +841,7 @@ func testKeystoreSizeWithDuplicatePutsImpl(t *testing.T, store Keystore) {
 	// Mixed put: some new, some existing
 	const newKeysInMix = 30
 	const existingKeysInMix = 20
-	newMhs := random.Multihashes(newKeysInMix)
+	newMhs := rnd.Multihashes(newKeysInMix)
 	mixed := append(mhs[:existingKeysInMix], newMhs...)
 	added, err = store.Put(ctx, mixed...)
 	require.NoError(t, err)

--- a/provider/keystore/resettable_keystore_test.go
+++ b/provider/keystore/resettable_keystore_test.go
@@ -43,7 +43,9 @@ func TestKeystoreReset(t *testing.T) {
 		require.NoError(t, err)
 		first[i] = h
 	}
-	_, err = store.Put(context.Background(), first...)
+
+	ctx := t.Context()
+	_, err = store.Put(ctx, first...)
 	require.NoError(t, err)
 
 	const numSecondKeys = 2
@@ -58,14 +60,14 @@ func TestKeystoreReset(t *testing.T) {
 	}
 	close(secondChan)
 
-	err = store.ResetCids(context.Background(), secondChan)
+	err = store.ResetCids(ctx, secondChan)
 	require.NoError(t, err)
 
 	// old hashes should not be present
 	const prefixBits = 6
 	for _, h := range first {
 		prefix := bitstr.Key(key.BitString(keyspace.MhToBit256(h))[:prefixBits])
-		got, err := store.Get(context.Background(), prefix)
+		got, err := store.Get(ctx, prefix)
 		require.NoError(t, err)
 		for _, m := range got {
 			require.NotEqual(t, string(m), string(h), "expected old hash %v to be removed", h)
@@ -75,7 +77,7 @@ func TestKeystoreReset(t *testing.T) {
 	// new hashes should be retrievable
 	for _, h := range second {
 		prefix := bitstr.Key(key.BitString(keyspace.MhToBit256(h))[:prefixBits])
-		got, err := store.Get(context.Background(), prefix)
+		got, err := store.Get(ctx, prefix)
 		require.NoError(t, err)
 		found := false
 		for _, m := range got {
@@ -96,11 +98,12 @@ func TestKeystoreResetSize(t *testing.T) {
 	require.NoError(t, err)
 	defer store.Close()
 
-	ctx := context.Background()
+	ctx := t.Context()
+	rnd := random.New()
 
 	// Add initial keys
 	const initialKeys = 100
-	initial := random.Multihashes(initialKeys)
+	initial := rnd.Multihashes(initialKeys)
 	_, err = store.Put(ctx, initial...)
 	require.NoError(t, err)
 
@@ -111,7 +114,7 @@ func TestKeystoreResetSize(t *testing.T) {
 	// Reset with fewer keys
 	const firstResetKeys = 50
 	resetChan := make(chan cid.Cid, firstResetKeys)
-	resetMhs := random.Multihashes(firstResetKeys)
+	resetMhs := rnd.Multihashes(firstResetKeys)
 	for _, h := range resetMhs {
 		resetChan <- cid.NewCidV1(cid.Raw, h)
 	}
@@ -128,7 +131,7 @@ func TestKeystoreResetSize(t *testing.T) {
 	// Reset with more keys
 	const secondResetKeys = 200
 	resetChan2 := make(chan cid.Cid, secondResetKeys)
-	resetMhs2 := random.Multihashes(secondResetKeys)
+	resetMhs2 := rnd.Multihashes(secondResetKeys)
 	for _, h := range resetMhs2 {
 		resetChan2 <- cid.NewCidV1(cid.Raw, h)
 	}
@@ -162,12 +165,13 @@ func TestKeystoreResetSizeAcrossMultipleCycles(t *testing.T) {
 	require.NoError(t, err)
 	defer store.Close()
 
-	ctx := context.Background()
+	ctx := t.Context()
+	rnd := random.New()
 
 	// First reset with 100 keys
 	const firstResetKeys = 100
 	resetChan := make(chan cid.Cid, firstResetKeys)
-	firstMhs := random.Multihashes(firstResetKeys)
+	firstMhs := rnd.Multihashes(firstResetKeys)
 	for _, h := range firstMhs {
 		resetChan <- cid.NewCidV1(cid.Raw, h)
 	}
@@ -189,7 +193,7 @@ func TestKeystoreResetSizeAcrossMultipleCycles(t *testing.T) {
 	for i := range overlappingKeys {
 		resetChan2 <- cid.NewCidV1(cid.Raw, firstMhs[i])
 	}
-	newMhs := random.Multihashes(newKeys)
+	newMhs := rnd.Multihashes(newKeys)
 	for _, h := range newMhs {
 		resetChan2 <- cid.NewCidV1(cid.Raw, h)
 	}
@@ -212,11 +216,12 @@ func TestKeystoreResetSizeWithConcurrentPuts(t *testing.T) {
 	require.NoError(t, err)
 	defer store.Close()
 
-	ctx := context.Background()
+	ctx := t.Context()
+	rnd := random.New()
 
 	// Add initial keys
 	const initialKeys = 50
-	initial := random.Multihashes(initialKeys)
+	initial := rnd.Multihashes(initialKeys)
 	_, err = store.Put(ctx, initial...)
 	require.NoError(t, err)
 
@@ -224,8 +229,8 @@ func TestKeystoreResetSizeWithConcurrentPuts(t *testing.T) {
 	const resetKeys = 80
 	const concurrentKeys = 30
 	resetChan := make(chan cid.Cid)
-	resetMhs := random.Multihashes(resetKeys)
-	newMhs := random.Multihashes(concurrentKeys)
+	resetMhs := rnd.Multihashes(resetKeys)
+	newMhs := rnd.Multihashes(concurrentKeys)
 
 	// Start reset in a goroutine first
 	resetDone := make(chan error, 1)
@@ -266,7 +271,7 @@ func TestKeystoreResetSizePersistence(t *testing.T) {
 	store, err := NewResettableKeystore(ds)
 	require.NoError(t, err)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Add keys WITHOUT reset
 	const numKeys = 75
@@ -296,7 +301,8 @@ func TestKeystoreActiveNamespacePersistenceX(t *testing.T) {
 	ds := ds.NewMapDatastore()
 	defer ds.Close()
 
-	ctx := context.Background()
+	ctx := t.Context()
+	rnd := random.New()
 
 	// Create initial keystore
 	store, err := NewResettableKeystore(ds)
@@ -304,7 +310,7 @@ func TestKeystoreActiveNamespacePersistenceX(t *testing.T) {
 
 	// Add initial keys
 	const initialKeys = 50
-	initialMhs := random.Multihashes(initialKeys)
+	initialMhs := rnd.Multihashes(initialKeys)
 	_, err = store.Put(ctx, initialMhs...)
 	require.NoError(t, err)
 
@@ -315,7 +321,7 @@ func TestKeystoreActiveNamespacePersistenceX(t *testing.T) {
 
 	// Perform reset with different keys
 	const resetKeys = 75
-	resetMhs := random.Multihashes(resetKeys)
+	resetMhs := rnd.Multihashes(resetKeys)
 	resetChan := make(chan cid.Cid, resetKeys)
 	for _, h := range resetMhs {
 		resetChan <- cid.NewCidV1(cid.Raw, h)
@@ -375,7 +381,8 @@ func TestKeystoreActiveNamespacePersistenceMultipleResets(t *testing.T) {
 	ds := ds.NewMapDatastore()
 	defer ds.Close()
 
-	ctx := context.Background()
+	ctx := t.Context()
+	rnd := random.New()
 
 	// Create initial keystore
 	store, err := NewResettableKeystore(ds)
@@ -383,7 +390,7 @@ func TestKeystoreActiveNamespacePersistenceMultipleResets(t *testing.T) {
 
 	// Perform first reset
 	const firstResetKeys = 100
-	firstResetMhs := random.Multihashes(firstResetKeys)
+	firstResetMhs := rnd.Multihashes(firstResetKeys)
 	resetChan1 := make(chan cid.Cid, firstResetKeys)
 	for _, h := range firstResetMhs {
 		resetChan1 <- cid.NewCidV1(cid.Raw, h)
@@ -407,7 +414,7 @@ func TestKeystoreActiveNamespacePersistenceMultipleResets(t *testing.T) {
 
 	// Perform second reset
 	const secondResetKeys = 50
-	secondResetMhs := random.Multihashes(secondResetKeys)
+	secondResetMhs := rnd.Multihashes(secondResetKeys)
 	resetChan2 := make(chan cid.Cid, secondResetKeys)
 	for _, h := range secondResetMhs {
 		resetChan2 <- cid.NewCidV1(cid.Raw, h)
@@ -468,7 +475,7 @@ func TestKeystoreCloseDuringReset(t *testing.T) {
 	store, err := NewResettableKeystore(ds)
 	require.NoError(t, err)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Create a slow channel that will feed keys gradually
 	const resetKeys = 1000
@@ -511,7 +518,7 @@ func TestKeystoreCloseDuringReset(t *testing.T) {
 }
 
 func TestKeystoreFactoryMode(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	baseDir := t.TempDir()
 
 	// Meta datastore for the active-namespace marker, owned by the caller.
@@ -535,7 +542,8 @@ func TestKeystoreFactoryMode(t *testing.T) {
 	require.NoError(t, err)
 
 	const initialKeys = 50
-	initialMhs := random.Multihashes(initialKeys)
+	rnd := random.New()
+	initialMhs := rnd.Multihashes(initialKeys)
 	_, err = store.Put(ctx, initialMhs...)
 	require.NoError(t, err)
 
@@ -546,7 +554,7 @@ func TestKeystoreFactoryMode(t *testing.T) {
 	// --- Phase 2: reset with new keys ---
 
 	const resetKeys = 30
-	resetMhs := random.Multihashes(resetKeys)
+	resetMhs := rnd.Multihashes(resetKeys)
 	resetChan := make(chan cid.Cid, resetKeys)
 	for _, h := range resetMhs {
 		resetChan <- cid.NewCidV1(cid.Raw, h)
@@ -629,7 +637,7 @@ func TestKeystoreFactoryMode(t *testing.T) {
 }
 
 func TestKeystoreFactoryModeCrashRecovery(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	baseDir := t.TempDir()
 
 	metaDs := ds.NewMapDatastore()
@@ -648,7 +656,8 @@ func TestKeystoreFactoryModeCrashRecovery(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	initialMhs := random.Multihashes(20)
+	rnd := random.New()
+	initialMhs := rnd.Multihashes(20)
 	_, err = store.Put(ctx, initialMhs...)
 	require.NoError(t, err)
 
@@ -658,7 +667,7 @@ func TestKeystoreFactoryModeCrashRecovery(t *testing.T) {
 	// garbage keys from an incomplete prior reset.
 	staleDs, err := create("1")
 	require.NoError(t, err)
-	staleMhs := random.Multihashes(10)
+	staleMhs := rnd.Multihashes(10)
 	b, err := staleDs.Batch(ctx)
 	require.NoError(t, err)
 	for _, h := range staleMhs {
@@ -676,7 +685,7 @@ func TestKeystoreFactoryModeCrashRecovery(t *testing.T) {
 	require.NoError(t, err)
 
 	const resetKeys = 15
-	freshMhs := random.Multihashes(resetKeys)
+	freshMhs := rnd.Multihashes(resetKeys)
 	ch := make(chan cid.Cid, resetKeys)
 	for _, h := range freshMhs {
 		ch <- cid.NewCidV1(cid.Raw, h)
@@ -718,7 +727,7 @@ func (d *closeErrDs) Close() error {
 }
 
 func TestKeystoreFactoryModeTeardownCloseError(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	baseDir := t.TempDir()
 
 	metaDs := ds.NewMapDatastore()
@@ -745,7 +754,8 @@ func TestKeystoreFactoryModeTeardownCloseError(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	_, err = store.Put(ctx, random.Multihashes(10)...)
+	rnd := random.New()
+	_, err = store.Put(ctx, rnd.Multihashes(10)...)
 	require.NoError(t, err)
 
 	// Enable close errors. The alt datastore created during reset (and the
@@ -754,7 +764,7 @@ func TestKeystoreFactoryModeTeardownCloseError(t *testing.T) {
 	failClose = true
 
 	ch := make(chan cid.Cid, 5)
-	for _, h := range random.Multihashes(5) {
+	for _, h := range rnd.Multihashes(5) {
 		ch <- cid.NewCidV1(cid.Raw, h)
 	}
 	close(ch)
@@ -775,7 +785,7 @@ func TestKeystoreFactoryModeTeardownCloseError(t *testing.T) {
 }
 
 func TestKeystoreCorruptedMarkerRecovery(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("shared datastore mode", func(t *testing.T) {
 		metaDs := ds.NewMapDatastore()
@@ -809,7 +819,8 @@ func TestKeystoreCorruptedMarkerRecovery(t *testing.T) {
 		// Create a stale datastore at "0" with leftover keys.
 		staleDs, err := pebble.NewDatastore(filepath.Join(baseDir, "0"), nil)
 		require.NoError(t, err)
-		staleMhs := random.Multihashes(5)
+		rnd := random.New()
+		staleMhs := rnd.Multihashes(5)
 		b, err := staleDs.Batch(ctx)
 		require.NoError(t, err)
 		for _, h := range staleMhs {
@@ -842,11 +853,11 @@ func TestKeystoreCorruptedMarkerRecovery(t *testing.T) {
 		require.Equal(t, 0, size, "stale data should be purged on corrupted marker")
 
 		// Verify put + reset cycle works on the recovered keystore.
-		freshMhs := random.Multihashes(10)
+		freshMhs := rnd.Multihashes(10)
 		_, err = store.Put(ctx, freshMhs...)
 		require.NoError(t, err)
 
-		resetMhs := random.Multihashes(5)
+		resetMhs := rnd.Multihashes(5)
 		ch := make(chan cid.Cid, len(resetMhs))
 		for _, h := range resetMhs {
 			ch <- cid.NewCidV1(cid.Raw, h)
@@ -863,7 +874,7 @@ func TestKeystoreCorruptedMarkerRecovery(t *testing.T) {
 }
 
 func TestKeystoreOptionAdapter(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	baseDir := t.TempDir()
 
 	metaDs := ds.NewMapDatastore()
@@ -986,16 +997,17 @@ func TestKeystoreWorkerResponsiveWhileAltDsWedged(t *testing.T) {
 		slow.slowPrefix = sharedSlotPrefix[1-store.activeNamespace].String()
 
 		ctx := t.Context()
+		rnd := random.New()
 
 		// Pre-populate primary so Size has a non-zero baseline.
 		const initial = 10
-		_, err = store.Put(ctx, random.Multihashes(initial)...)
+		_, err = store.Put(ctx, rnd.Multihashes(initial)...)
 		require.NoError(t, err)
 
 		// Start a reset. ResetCids' first altPutBlind reaches altDs.Sync,
 		// which blocks until release is closed.
 		resetChan := make(chan cid.Cid, 1)
-		resetChan <- cid.NewCidV1(cid.Raw, random.Multihashes(1)[0])
+		resetChan <- cid.NewCidV1(cid.Raw, rnd.Multihashes(1)[0])
 		close(resetChan)
 		resetDone := make(chan error, 1)
 		go func() {
@@ -1020,7 +1032,7 @@ func TestKeystoreWorkerResponsiveWhileAltDsWedged(t *testing.T) {
 			require.Equal(t, expected, size)
 
 			const probePuts = 3
-			_, err = store.Put(probeCtx, random.Multihashes(probePuts)...)
+			_, err = store.Put(probeCtx, rnd.Multihashes(probePuts)...)
 			require.NoError(t, err, "Put must return while altDs is wedged")
 			expected += probePuts
 		}
@@ -1072,11 +1084,12 @@ func TestKeystoreResetBufferBackpressure(t *testing.T) {
 		slow.slowPrefix = sharedSlotPrefix[1-store.activeNamespace].String()
 
 		ctx := t.Context()
+		rnd := random.New()
 
 		// Start a reset that wedges in Phase A's altDs.Sync so it can't drain
 		// the buffer.
 		resetChan := make(chan cid.Cid, 1)
-		resetChan <- cid.NewCidV1(cid.Raw, random.Multihashes(1)[0])
+		resetChan <- cid.NewCidV1(cid.Raw, rnd.Multihashes(1)[0])
 		close(resetChan)
 		resetDone := make(chan error, 1)
 		go func() {
@@ -1093,7 +1106,7 @@ func TestKeystoreResetBufferBackpressure(t *testing.T) {
 		}
 
 		// Fill the buffer exactly to capacity.
-		_, err = store.Put(ctx, random.Multihashes(bufCap)...)
+		_, err = store.Put(ctx, rnd.Multihashes(bufCap)...)
 		require.NoError(t, err, "filling the buffer to capacity should succeed")
 
 		// The next Put must block; it cannot be accepted without dropping
@@ -1102,7 +1115,7 @@ func TestKeystoreResetBufferBackpressure(t *testing.T) {
 		// than any wall-clock delay.
 		blocked := make(chan error, 1)
 		go func() {
-			_, err := store.Put(ctx, random.Multihashes(1)...)
+			_, err := store.Put(ctx, rnd.Multihashes(1)...)
 			blocked <- err
 		}()
 		synctest.Wait()
@@ -1153,9 +1166,10 @@ func TestKeystoreResetBufferLargerThanCap(t *testing.T) {
 		slow.slowPrefix = sharedSlotPrefix[1-store.activeNamespace].String()
 
 		ctx := t.Context()
+		rnd := random.New()
 
 		resetChan := make(chan cid.Cid, 1)
-		resetMh := random.Multihashes(1)[0]
+		resetMh := rnd.Multihashes(1)[0]
 		resetChan <- cid.NewCidV1(cid.Raw, resetMh)
 		close(resetChan)
 		resetDone := make(chan error, 1)
@@ -1177,7 +1191,7 @@ func TestKeystoreResetBufferLargerThanCap(t *testing.T) {
 		// drains.
 		const factor = 2
 		putN := factor * bufCap
-		putMhs := random.Multihashes(putN)
+		putMhs := rnd.Multihashes(putN)
 		putDone := make(chan error, 1)
 		go func() {
 			_, err := store.Put(ctx, putMhs...)
@@ -1251,8 +1265,9 @@ func TestKeystoreResetCtxCancelDoesNotDeadlock(t *testing.T) {
 		resetCtx, resetCancel := context.WithCancel(t.Context())
 		defer resetCancel()
 
+		rnd := random.New()
 		resetChan := make(chan cid.Cid, 1)
-		resetChan <- cid.NewCidV1(cid.Raw, random.Multihashes(1)[0])
+		resetChan <- cid.NewCidV1(cid.Raw, rnd.Multihashes(1)[0])
 		close(resetChan)
 		resetDone := make(chan error, 1)
 		go func() {
@@ -1270,7 +1285,7 @@ func TestKeystoreResetCtxCancelDoesNotDeadlock(t *testing.T) {
 		ctx := t.Context()
 
 		// Fill the buffer exactly to capacity.
-		_, err = store.Put(ctx, random.Multihashes(bufCap)...)
+		_, err = store.Put(ctx, rnd.Multihashes(bufCap)...)
 		require.NoError(t, err, "filling the buffer to capacity should succeed")
 
 		// One more Put must block in bufferKeys: buffer is full, no drain
@@ -1278,7 +1293,7 @@ func TestKeystoreResetCtxCancelDoesNotDeadlock(t *testing.T) {
 		// keysChan is already drained).
 		blocked := make(chan error, 1)
 		go func() {
-			_, err := store.Put(ctx, random.Multihashes(1)...)
+			_, err := store.Put(ctx, rnd.Multihashes(1)...)
 			blocked <- err
 		}()
 		synctest.Wait()
@@ -1300,7 +1315,7 @@ func TestKeystoreResetCtxCancelDoesNotDeadlock(t *testing.T) {
 
 		// Keystore must remain responsive after the cancelled reset.
 		const post = 3
-		_, err = store.Put(ctx, random.Multihashes(post)...)
+		_, err = store.Put(ctx, rnd.Multihashes(post)...)
 		require.NoError(t, err)
 		size, err := store.Size(ctx)
 		require.NoError(t, err)
@@ -1334,10 +1349,12 @@ func TestKeystoreResetPhaseATickerDrainsSlowKeysChan(t *testing.T) {
 			resetDone <- store.ResetCids(ctx, resetChan)
 		}()
 
+		rnd := random.New()
+
 		// Deliver one key so the channel send unblocks once Phase A picks it
 		// up — guarantees opStart finished and resetInProgress is true before
 		// the concurrent Put fires.
-		syncMh := random.Multihashes(1)[0]
+		syncMh := rnd.Multihashes(1)[0]
 		resetChan <- cid.NewCidV1(cid.Raw, syncMh)
 
 		// Concurrent Put of 5x capacity keys, more than the 3x ceiling
@@ -1347,7 +1364,7 @@ func TestKeystoreResetPhaseATickerDrainsSlowKeysChan(t *testing.T) {
 		// would never drain and the Put would block until close(resetChan).
 		const factor = 5
 		putN := factor * bufCap
-		putMhs := random.Multihashes(putN)
+		putMhs := rnd.Multihashes(putN)
 		putDone := make(chan error, 1)
 		go func() {
 			_, err := store.Put(ctx, putMhs...)
@@ -1494,9 +1511,10 @@ func mhStrings(mhs []mh.Multihash) []string {
 // pickMhsWithBits picks n multihashes whose leading Kademlia bits equal bits.
 func pickMhsWithBits(t *testing.T, bits []int, n int) []mh.Multihash {
 	t.Helper()
+	rnd := random.New()
 	out := make([]mh.Multihash, 0, n)
 	for tries := 0; tries < 1<<16 && len(out) < n; tries++ {
-		h := random.Multihashes(1)[0]
+		h := rnd.Multihashes(1)[0]
 		k := keyspace.MhToBit256(h)
 		match := true
 		for i, b := range bits {

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -19,6 +19,7 @@ package provider
 
 import (
 	"context"
+	"crypto/rand"
 	"errors"
 	"fmt"
 	"path"
@@ -39,11 +40,11 @@ import (
 	"github.com/ipfs/go-datastore/query"
 	dssync "github.com/ipfs/go-datastore/sync"
 	"github.com/ipfs/go-log/v2"
-	"github.com/ipfs/go-test/random"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/peerstore"
 	ma "github.com/multiformats/go-multiaddr"
+	"github.com/multiformats/go-multihash"
 	mh "github.com/multiformats/go-multihash"
 
 	"github.com/ipfs/go-libdht/kad/key"
@@ -701,7 +702,9 @@ func (s *SweepingProvider) approxPrefixLen() {
 	for range approxPrefixLenGCPCount {
 		go func() {
 			defer wg.Done()
-			randomMh := random.Multihashes(1)[0]
+			var b [32]byte
+			rand.Read(b[:])
+			randomMh, _ := multihash.Encode(b[:], multihash.SHA2_256)
 			for {
 				if s.closed() || !s.connectivity.IsOnline() {
 					return

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -44,7 +44,6 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/peerstore"
 	ma "github.com/multiformats/go-multiaddr"
-	"github.com/multiformats/go-multihash"
 	mh "github.com/multiformats/go-multihash"
 
 	"github.com/ipfs/go-libdht/kad/key"
@@ -704,7 +703,7 @@ func (s *SweepingProvider) approxPrefixLen() {
 			defer wg.Done()
 			var b [32]byte
 			rand.Read(b[:])
-			randomMh, _ := multihash.Encode(b[:], multihash.SHA2_256)
+			randomMh, _ := mh.Encode(b[:], mh.SHA2_256)
 			for {
 				if s.closed() || !s.connectivity.IsOnline() {
 					return

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -88,23 +88,28 @@ func genBalancedMultihashes(exponent int) []mh.Multihash {
 }
 
 func genMultihashesMatchingPrefix(prefix bitstr.Key, n int) []mh.Multihash {
+	rnd := random.New()
 	mhs := make([]mh.Multihash, 0, n)
-	for i := 0; len(mhs) < n; i++ {
-		h := random.Multihashes(1)[0]
-		k := keyspace.MhToBit256(h)
-		if keyspace.IsPrefix(prefix, k) {
-			mhs = append(mhs, h)
+	for {
+		for _, h := range rnd.Multihashes(max(n-len(mhs), 8)) {
+			k := keyspace.MhToBit256(h)
+			if keyspace.IsPrefix(prefix, k) {
+				mhs = append(mhs, h)
+				if len(mhs) == n {
+					return mhs
+				}
+			}
 		}
 	}
-	return mhs
 }
 
 // genPeersWithPrefix generates n peer IDs whose kademlia identifiers all share
 // the given common prefix, simulating a small clustered DHT.
 func genPeersWithPrefix(prefix bitstr.Key, n int) []peer.ID {
+	rnd := random.New()
 	peers := make([]peer.ID, 0, n)
 	for len(peers) < n {
-		p := random.Peers(1)[0]
+		p := rnd.Peers(1)[0]
 		if keyspace.IsPrefix(prefix, keyspace.PeerIDToBit256(p)) {
 			peers = append(peers, p)
 		}
@@ -703,10 +708,11 @@ func realisticRouter(peers []peer.ID, bucketSize int) *mockRouter {
 func TestExploreSwarmDifferential(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		const bucketSize = 20
+		rnd := random.New()
 		networks := map[string][]peer.ID{
-			"uniform-100":         random.Peers(100),
-			"uniform-60":          random.Peers(60),
-			"uniform-25":          random.Peers(25),
+			"uniform-100":         rnd.Peers(100),
+			"uniform-60":          rnd.Peers(60),
+			"uniform-25":          rnd.Peers(25),
 			"cluster-10-under-10": genPeersWithPrefix("10", 10),
 			"dense-under-1":       genPeersWithPrefix("1", 50),
 			"split-110-111":       slices.Concat(genPeersWithPrefix("110", 6), genPeersWithPrefix("111", 6)),

--- a/records_test.go
+++ b/records_test.go
@@ -124,7 +124,7 @@ func TestPubkeyNotFound(t *testing.T) {
 
 	connect(t, ctx, dhtA, dhtB)
 
-	r := random.NewSeededRand(15) // generate deterministic keypair
+	r := random.New()
 	_, pubk, err := ci.GenerateKeyPairWithReader(ci.RSA, 2048, r)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
`go-libp2p-kad-dht` builds and operates just fine without any code changes, when upgrading to `go-test v0.4.0`. However, code changes have been included in this PR to take advantage of new capabilities in `go-test v0.4.0`.

- Upgrade to `go-test v0.4.0` that uses `math/rand/v2` and has reusable generator
- Reuse random number source for generating data in the same goroutine
- Only use go-test from test code.