### PR TITLE
 refactor(pb): bound the serialized size of a peer record 

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -144,6 +144,16 @@ func cleanRecord(rec *recpb.Record) {
 	rec.TimeReceived = ""
 }
 
+// stripPeerRecords drops the peer-record-bearing fields of a message. The PING
+// and PUT_VALUE handlers echo the request back as their response; a peer could
+// stuff CloserPeers or ProviderPeers into such a request, and echoing them would
+// re-emit peer records that never passed boundPeerRecordAddrs. Neither response
+// carries peer records legitimately, so they are safe to drop.
+func stripPeerRecords(pmes *pb.Message) {
+	pmes.CloserPeers = nil
+	pmes.ProviderPeers = nil
+}
+
 // Store a value in this peer local storage
 func (dht *IpfsDHT) handlePutValue(ctx context.Context, p peer.ID, pmes *pb.Message) (_ *pb.Message, err error) {
 	if len(pmes.GetKey()) == 0 {
@@ -211,6 +221,7 @@ func (dht *IpfsDHT) handlePutValue(ctx context.Context, p peer.ID, pmes *pb.Mess
 	}
 
 	err = dht.datastore.Put(ctx, dskey, data)
+	stripPeerRecords(pmes)
 	return pmes, err
 }
 
@@ -246,6 +257,7 @@ func (dht *IpfsDHT) getRecordFromDatastore(ctx context.Context, dskey ds.Key) (*
 
 func (dht *IpfsDHT) handlePing(_ context.Context, p peer.ID, pmes *pb.Message) (*pb.Message, error) {
 	logger.Debugf("%s Responding to ping from %s!\n", dht.self, p)
+	stripPeerRecords(pmes)
 	return pmes, nil
 }
 

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -13,6 +13,7 @@ import (
 	crypto "github.com/libp2p/go-libp2p/core/crypto"
 	peer "github.com/libp2p/go-libp2p/core/peer"
 	ma "github.com/multiformats/go-multiaddr"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -84,6 +85,43 @@ func TestBadMessage(t *testing.T) {
 			t.Fatalf("expected processing message to fail for type %s", pb.Message_FIND_NODE)
 		}
 	}
+}
+
+func TestStripPeerRecords(t *testing.T) {
+	pmes := &pb.Message{
+		Type:          pb.Message_PING,
+		CloserPeers:   []*pb.Message_Peer{{Id: []byte("closer")}},
+		ProviderPeers: []*pb.Message_Peer{{Id: []byte("provider")}},
+	}
+
+	stripPeerRecords(pmes)
+
+	require.Nilf(t, pmes.CloserPeers, "closer peers must be dropped")
+	require.Nilf(t, pmes.ProviderPeers, "provider peers must be dropped")
+	require.Equalf(t, pb.Message_PING, pmes.Type, "other fields must be left intact")
+}
+
+// TestHandlePingDropsStuffedPeerRecords checks that handlePing, which echoes the
+// request back, does not re-emit peer records a peer stuffed into the request,
+// keeping every record this node emits bounded.
+func TestHandlePingDropsStuffedPeerRecords(t *testing.T) {
+	ctx := t.Context()
+	d := setupDHT(ctx, t, false)
+
+	stuffed := []*pb.Message_Peer{{
+		Id:    []byte("stuffed-peer-id"),
+		Addrs: [][]byte{[]byte("/ip4/1.2.3.4/tcp/1")},
+	}}
+	req := &pb.Message{
+		Type:          pb.Message_PING,
+		CloserPeers:   stuffed,
+		ProviderPeers: stuffed,
+	}
+
+	resp, err := d.handlePing(ctx, d.Host().ID(), req)
+	require.NoError(t, err)
+	require.Emptyf(t, resp.CloserPeers, "ping response must not echo closer peers")
+	require.Emptyf(t, resp.ProviderPeers, "ping response must not echo provider peers")
 }
 
 func BenchmarkHandleFindPeer(b *testing.B) {

--- a/optimizations.md
+++ b/optimizations.md
@@ -5,3 +5,9 @@ This document reflects client-side optimizations that are implemented in this re
 ## Checking before Adding
 
 A Kademlia server should try to add remote peers querying it to its routing table. However, the Kademlia server has no guarantee that remote peers issuing requests are able to answer Kademlia requests correctly, even though they advertise speaking the Kademlia server protocol. It is important that only server nodes able to answer Kademlia requests end up in other peers' routing tables. Hence, before adding a remote peer to the Kademlia server's routing table, the Kademlia server will send a trivial `FIND_NODE` request to the remote peer, and add it to its routing table only if it is able to provide a valid response.
+
+## Bounding peer record size
+
+Kademlia messages carry _peer records_: a peer ID together with the multiaddresses at which that peer can be reached. They appear as the closer peers in a `FIND_NODE` or `GET_PROVIDERS` response, and as the provider records in an `ADD_PROVIDER` request. A peer record only needs an identity and enough addresses to be dialable, so this implementation bounds a single peer record to 8 KiB when serializing it, keeping the peer ID and as many addresses as fit and dropping the rest. The 8 KiB ceiling matches the budget the libp2p identify protocol allows for a peer's entire signed self-description, so it is comfortably larger than any well-formed peer requires.
+
+The bound is applied both to the records this node emits and to the records it ingests from other peers, keeping records a predictable size on the wire and in the peerstore. It requires no coordination between peers: a trimmed record is an ordinary, smaller peer record, which every Kademlia implementation already accepts.

--- a/pb/message.go
+++ b/pb/message.go
@@ -28,14 +28,9 @@ const (
 	peerConnectionField protowire.Number = 3
 )
 
-var (
-	peerAddrsTagSize = protowire.SizeTag(peerAddrsField)
-	// connectionFieldSize is the serialized size of the connection field. Every
-	// ConnectionType is a single-byte varint, so it is the field tag plus one
-	// byte. It is reserved up front because callers set Connection after the
-	// record is built, keeping the address bound valid for the finished record.
-	connectionFieldSize = protowire.SizeTag(peerConnectionField) + 1
-)
+// peerAddrsTagSize is a repeated address field's tag size, added once per
+// address when sizing a record.
+var peerAddrsTagSize = protowire.SizeTag(peerAddrsField)
 
 // boundPeerRecordAddrs trims pbp.Addrs in place, dropping trailing addresses
 // until the peer ID, addresses and connection flag serialize within
@@ -50,7 +45,13 @@ func boundPeerRecordAddrs(pbp *Message_Peer) {
 		return
 	}
 	// SizeBytes covers each length-delimited field's length prefix and bytes;
-	// SizeTag covers its field tag.
+	// SizeTag covers its field tag. The connection flag is an open proto3 enum,
+	// so a remote peer can send a value that serializes to as many as 10 bytes;
+	// size it from the actual value rather than assuming a single byte. On the
+	// send path Connection is set after bounding, but only ever to a trusted
+	// single-byte value, so the finished record stays within the bound.
+	connectionFieldSize := protowire.SizeTag(peerConnectionField) +
+		protowire.SizeVarint(uint64(int64(pbp.Connection)))
 	size := protowire.SizeTag(peerIDField) + protowire.SizeBytes(len(pbp.Id)) + connectionFieldSize
 	for i, addr := range pbp.Addrs {
 		size += peerAddrsTagSize + protowire.SizeBytes(len(addr))

--- a/pb/message.go
+++ b/pb/message.go
@@ -6,9 +6,60 @@ import (
 
 	logging "github.com/ipfs/go-log/v2"
 	ma "github.com/multiformats/go-multiaddr"
+	"google.golang.org/protobuf/encoding/protowire"
 )
 
 var log = logging.Logger("dht.pb")
+
+// MaxPeerRecordSize bounds the serialized size of a single Message_Peer on the
+// wire. A peer record needs only a peer ID, its multiaddrs and a connection
+// flag, so 8 KiB — the identify protocol's budget for a peer's entire signed
+// self-description — is a generous per-record ceiling: comfortably more than any
+// well-formed peer requires, while keeping records a predictable size both on
+// the wire and in the peerstore. Addresses past the limit are dropped; the peer
+// ID is always kept.
+const MaxPeerRecordSize = 8 << 10
+
+// Field numbers within Message.Peer (see pb/dht.proto), used to size a record's
+// framed contribution without marshalling it.
+const (
+	peerIDField         protowire.Number = 1
+	peerAddrsField      protowire.Number = 2
+	peerConnectionField protowire.Number = 3
+)
+
+var (
+	peerAddrsTagSize = protowire.SizeTag(peerAddrsField)
+	// connectionFieldSize is the serialized size of the connection field. Every
+	// ConnectionType is a single-byte varint, so it is the field tag plus one
+	// byte. It is reserved up front because callers set Connection after the
+	// record is built, keeping the address bound valid for the finished record.
+	connectionFieldSize = protowire.SizeTag(peerConnectionField) + 1
+)
+
+// boundPeerRecordAddrs trims pbp.Addrs in place, dropping trailing addresses
+// until the peer ID, addresses and connection flag serialize within
+// MaxPeerRecordSize. The peer ID and connection flag are always kept; a record
+// already within the limit is left untouched. Applied on both the send and
+// receive paths so a peer record keeps a predictable size on the wire and in
+// the peerstore. It sizes only these fields, so on a freshly built outbound
+// record that is exactly proto.Size; on a decoded inbound record it bounds the
+// address list, not any unknown fields present on the record.
+func boundPeerRecordAddrs(pbp *Message_Peer) {
+	if pbp == nil {
+		return
+	}
+	// SizeBytes covers each length-delimited field's length prefix and bytes;
+	// SizeTag covers its field tag.
+	size := protowire.SizeTag(peerIDField) + protowire.SizeBytes(len(pbp.Id)) + connectionFieldSize
+	for i, addr := range pbp.Addrs {
+		size += peerAddrsTagSize + protowire.SizeBytes(len(addr))
+		if size > MaxPeerRecordSize {
+			pbp.Addrs = pbp.Addrs[:i]
+			return
+		}
+	}
+}
 
 type PeerRoutingInfo struct {
 	peer.AddrInfo
@@ -34,6 +85,7 @@ func peerRoutingInfoToPBPeer(p PeerRoutingInfo) *Message_Peer {
 	}
 	pbp.Id = []byte(p.ID)
 	pbp.Connection = ConnectionType(p.Connectedness)
+	boundPeerRecordAddrs(pbp)
 	return pbp
 }
 
@@ -45,6 +97,7 @@ func peerInfoToPBPeer(p peer.AddrInfo) *Message_Peer {
 		pbp.Addrs[i] = maddr.Bytes() // Bytes, not String. Compressed.
 	}
 	pbp.Id = []byte(p.ID)
+	boundPeerRecordAddrs(pbp)
 	return pbp
 }
 
@@ -87,11 +140,14 @@ func PeerRoutingInfosToPBPeers(peers []PeerRoutingInfo) []*Message_Peer {
 	return pbpeers
 }
 
-// PBPeersToPeerInfos converts given []*Message_Peer into []peer.AddrInfo
-// Invalid addresses will be silently omitted.
+// PBPeersToPeerInfos converts given []*Message_Peer into []peer.AddrInfo.
+// Invalid addresses will be silently omitted. Each record's address list is
+// bounded to MaxPeerRecordSize before conversion — trimming pbps[i].Addrs in
+// place — so a peer record keeps a predictable peerstore footprint.
 func PBPeersToPeerInfos(pbps []*Message_Peer) []*peer.AddrInfo {
 	peers := make([]*peer.AddrInfo, 0, len(pbps))
 	for _, pbp := range pbps {
+		boundPeerRecordAddrs(pbp)
 		ai := PBPeerToPeerInfo(pbp)
 		peers = append(peers, &ai)
 	}

--- a/pb/message_test.go
+++ b/pb/message_test.go
@@ -1,7 +1,14 @@
 package dht_pb
 
 import (
+	"bytes"
+	"fmt"
 	"testing"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+	ma "github.com/multiformats/go-multiaddr"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestBadAddrsDontReturnNil(t *testing.T) {
@@ -12,4 +19,102 @@ func TestBadAddrsDontReturnNil(t *testing.T) {
 	if len(addrs) > 0 {
 		t.Fatal("shouldnt have any multiaddrs")
 	}
+}
+
+// rawAddrs returns n byte slices of the given length, standing in for the wire
+// bytes of multiaddrs; boundPeerRecordAddrs only reads their lengths.
+func rawAddrs(n, size int) [][]byte {
+	addrs := make([][]byte, n)
+	for i := range addrs {
+		addrs[i] = bytes.Repeat([]byte{0xAB}, size)
+	}
+	return addrs
+}
+
+func TestBoundPeerRecordAddrs(t *testing.T) {
+	id := []byte("a-peer-id-of-a-realistic-length--")
+
+	tests := []struct {
+		name  string
+		addrs [][]byte
+		// keptAll asserts every address survives; otherwise the record is
+		// expected to be trimmed to fit MaxPeerRecordSize.
+		keptAll bool
+	}{
+		{name: "no addresses", addrs: nil, keptAll: true},
+		{name: "well under the limit", addrs: rawAddrs(10, 40), keptAll: true},
+		{name: "many small addresses over the limit", addrs: rawAddrs(4000, 40)},
+		{name: "few large addresses over the limit", addrs: rawAddrs(20, 1024)},
+		{name: "single address larger than the limit", addrs: rawAddrs(1, MaxPeerRecordSize*2)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			original := append([][]byte(nil), tt.addrs...)
+			pbp := &Message_Peer{Id: id, Addrs: tt.addrs, Connection: Message_CONNECTED}
+
+			boundPeerRecordAddrs(pbp)
+
+			require.LessOrEqualf(t, proto.Size(pbp), MaxPeerRecordSize,
+				"record must serialize within MaxPeerRecordSize")
+			require.LessOrEqualf(t, len(pbp.Addrs), len(original),
+				"bounding must not add addresses")
+			require.Equalf(t, original[:len(pbp.Addrs)], pbp.Addrs,
+				"kept addresses must be a front prefix of the original")
+
+			if tt.keptAll {
+				require.Lenf(t, pbp.Addrs, len(original), "record within the limit must be untouched")
+			} else {
+				require.Lessf(t, len(pbp.Addrs), len(original), "over-limit record must be trimmed")
+			}
+		})
+	}
+}
+
+func TestBoundPeerRecordAddrsNilSafe(t *testing.T) {
+	require.NotPanics(t, func() { boundPeerRecordAddrs(nil) })
+}
+
+// manyMultiaddrs builds n distinct valid multiaddrs whose combined size far
+// exceeds MaxPeerRecordSize.
+func manyMultiaddrs(t *testing.T, n int) []ma.Multiaddr {
+	t.Helper()
+	addrs := make([]ma.Multiaddr, n)
+	for i := range addrs {
+		a, err := ma.NewMultiaddr(fmt.Sprintf("/ip4/1.2.3.4/tcp/%d", 1024+i))
+		require.NoErrorf(t, err, "building multiaddr %d", i)
+		addrs[i] = a
+	}
+	return addrs
+}
+
+func TestRawPeerInfosToPBPeersBoundsEgress(t *testing.T) {
+	const n = 4000
+	ai := peer.AddrInfo{ID: peer.ID("provider-peer-id"), Addrs: manyMultiaddrs(t, n)}
+
+	pbps := RawPeerInfosToPBPeers([]peer.AddrInfo{ai})
+
+	require.Len(t, pbps, 1)
+	require.LessOrEqualf(t, proto.Size(pbps[0]), MaxPeerRecordSize,
+		"outbound record must be bounded")
+	require.Lessf(t, len(pbps[0].Addrs), n, "outbound record must drop addresses past the limit")
+	require.NotEmptyf(t, pbps[0].Addrs, "a peer with small addresses must keep some")
+}
+
+func TestPBPeersToPeerInfosBoundsIngress(t *testing.T) {
+	const n = 4000
+	addrs := manyMultiaddrs(t, n)
+	rawAddrs := make([][]byte, n)
+	for i, a := range addrs {
+		rawAddrs[i] = a.Bytes()
+	}
+	pbp := &Message_Peer{Id: []byte("remote-peer-id"), Addrs: rawAddrs, Connection: Message_CONNECTED}
+
+	infos := PBPeersToPeerInfos([]*Message_Peer{pbp})
+
+	require.Len(t, infos, 1)
+	require.LessOrEqualf(t, proto.Size(pbp), MaxPeerRecordSize,
+		"ingested record must be bounded in place")
+	require.Lessf(t, len(infos[0].Addrs), n, "ingested addresses must be trimmed to the limit")
+	require.NotEmptyf(t, infos[0].Addrs, "valid small addresses within the limit must survive")
 }

--- a/pb/message_test.go
+++ b/pb/message_test.go
@@ -75,6 +75,61 @@ func TestBoundPeerRecordAddrsNilSafe(t *testing.T) {
 	require.NotPanics(t, func() { boundPeerRecordAddrs(nil) })
 }
 
+// peerSerializingTo builds a Message_Peer with the given connection flag whose
+// serialized size is exactly total bytes. It carries a fixed peer ID, a small
+// leading "anchor" address that always survives trimming and a trailing "filler"
+// address padded to hit total, so trimming drops the filler first.
+func peerSerializingTo(t *testing.T, total int, conn Message_ConnectionType) *Message_Peer {
+	t.Helper()
+	id := bytes.Repeat([]byte{0x01}, 32)
+	anchor := bytes.Repeat([]byte{0xAB}, 64)
+
+	fixed := &Message_Peer{Id: id, Connection: conn, Addrs: [][]byte{anchor}}
+	// A filler length in the two-byte varint range frames as tag(1)+len(2)+bytes,
+	// so subtract that 3-byte framing to land the whole record exactly on total.
+	filler := bytes.Repeat([]byte{0xCD}, total-proto.Size(fixed)-3)
+
+	pbp := &Message_Peer{Id: id, Connection: conn, Addrs: [][]byte{anchor, filler}}
+	require.Equalf(t, total, proto.Size(pbp), "constructed record must serialize to %d bytes", total)
+	return pbp
+}
+
+func TestBoundPeerRecordAddrsAtCapBoundary(t *testing.T) {
+	t.Run("exactly at the cap keeps every address", func(t *testing.T) {
+		pbp := peerSerializingTo(t, MaxPeerRecordSize, Message_CONNECTED)
+		kept := len(pbp.Addrs)
+
+		boundPeerRecordAddrs(pbp)
+
+		require.Lenf(t, pbp.Addrs, kept, "a record exactly at the cap must keep every address")
+		require.Equalf(t, MaxPeerRecordSize, proto.Size(pbp), "an untrimmed record keeps its size")
+	})
+
+	t.Run("one byte over the cap trims one address", func(t *testing.T) {
+		pbp := peerSerializingTo(t, MaxPeerRecordSize+1, Message_CONNECTED)
+		kept := len(pbp.Addrs)
+
+		boundPeerRecordAddrs(pbp)
+
+		require.Lenf(t, pbp.Addrs, kept-1, "a record one byte over the cap must trim exactly one address")
+		require.LessOrEqualf(t, proto.Size(pbp), MaxPeerRecordSize, "the trimmed record must fit the cap")
+	})
+}
+
+// TestBoundPeerRecordAddrsReservesConnection covers what PeerInfosToPBPeers does:
+// it bounds a record before setting Connection, so the bound must reserve room
+// for the connection field. A record bounded right at the cap with Connection
+// still unset must keep fitting once Connection is set to a non-default value.
+func TestBoundPeerRecordAddrsReservesConnection(t *testing.T) {
+	pbp := peerSerializingTo(t, MaxPeerRecordSize, Message_NOT_CONNECTED)
+
+	boundPeerRecordAddrs(pbp)
+	pbp.Connection = Message_CANNOT_CONNECT // set after bounding, as PeerInfosToPBPeers does
+
+	require.LessOrEqualf(t, proto.Size(pbp), MaxPeerRecordSize,
+		"setting Connection after bounding must not push the record past the cap")
+}
+
 // manyMultiaddrs builds n distinct valid multiaddrs whose combined size far
 // exceeds MaxPeerRecordSize.
 func manyMultiaddrs(t *testing.T, n int) []ma.Multiaddr {

--- a/record_size_test.go
+++ b/record_size_test.go
@@ -1,0 +1,65 @@
+package dht
+
+import (
+	"fmt"
+	"math/rand"
+	"strings"
+	"testing"
+
+	pb "github.com/libp2p/go-libp2p-kad-dht/pb"
+	crypto "github.com/libp2p/go-libp2p/core/crypto"
+	peer "github.com/libp2p/go-libp2p/core/peer"
+	ma "github.com/multiformats/go-multiaddr"
+	"github.com/stretchr/testify/require"
+)
+
+// bigAddrBytes returns the wire bytes of n distinct ~2 KiB multiaddrs, enough to
+// push a single peer record well past pb.MaxPeerRecordSize.
+func bigAddrBytes(n int) [][]byte {
+	addrs := make([][]byte, n)
+	for i := range addrs {
+		addrs[i] = ma.StringCast(fmt.Sprintf("/dns4/%s%d/tcp/1", strings.Repeat("a", 2000), i)).Bytes()
+	}
+	return addrs
+}
+
+// TestHandleAddProviderBoundsIngestedAddrs checks the receive-side effect of the
+// per-record size bound: an ADD_PROVIDER whose provider record carries a very
+// large address list has that list trimmed to pb.MaxPeerRecordSize before the
+// addresses reach the peerstore, so the peerstore records at most a per-record
+// cap's worth of addresses for the provider.
+func TestHandleAddProviderBoundsIngestedAddrs(t *testing.T) {
+	ctx := t.Context()
+	d := setupDHT(ctx, t, false)
+	// Keep the synthetic oversized addresses intact through the address filter.
+	d.addrFilter = func(addrs []ma.Multiaddr) []ma.Multiaddr { return addrs }
+
+	// A provider announcing itself under a valid peer ID with a ~4 MiB addr list.
+	_, pub, err := crypto.GenerateEd25519Key(rand.New(rand.NewSource(7)))
+	require.NoError(t, err)
+	p, err := peer.IDFromPublicKey(pub)
+	require.NoError(t, err)
+
+	const sent = 2000
+	rec := &pb.Message_Peer{Id: []byte(p), Addrs: bigAddrBytes(sent)}
+	pmes := &pb.Message{
+		Type:          pb.Message_ADD_PROVIDER,
+		Key:           []byte("some-key"),
+		ProviderPeers: []*pb.Message_Peer{rec},
+	}
+
+	_, err = d.handleAddProvider(ctx, p, pmes)
+	require.NoError(t, err)
+
+	stored := d.host.Peerstore().Addrs(p)
+	require.NotEmptyf(t, stored, "the provider's addresses must be recorded")
+	require.Lessf(t, len(stored), sent,
+		"the ingested address list must be trimmed well below what was sent")
+
+	var total int
+	for _, a := range stored {
+		total += len(a.Bytes())
+	}
+	require.LessOrEqualf(t, total, pb.MaxPeerRecordSize,
+		"stored address bytes for one peer must fit within the per-record cap")
+}

--- a/record_size_test.go
+++ b/record_size_test.go
@@ -2,7 +2,7 @@ package dht
 
 import (
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"strings"
 	"testing"
 
@@ -35,7 +35,7 @@ func TestHandleAddProviderBoundsIngestedAddrs(t *testing.T) {
 	d.addrFilter = func(addrs []ma.Multiaddr) []ma.Multiaddr { return addrs }
 
 	// A provider announcing itself under a valid peer ID with a ~4 MiB addr list.
-	_, pub, err := crypto.GenerateEd25519Key(rand.New(rand.NewSource(7)))
+	_, pub, err := crypto.GenerateEd25519Key(rand.NewChaCha8([32]byte{7}))
 	require.NoError(t, err)
 	p, err := peer.IDFromPublicKey(pub)
 	require.NoError(t, err)

--- a/record_size_test.go
+++ b/record_size_test.go
@@ -31,8 +31,6 @@ func bigAddrBytes(n int) [][]byte {
 func TestHandleAddProviderBoundsIngestedAddrs(t *testing.T) {
 	ctx := t.Context()
 	d := setupDHT(ctx, t, false)
-	// Keep the synthetic oversized addresses intact through the address filter.
-	d.addrFilter = func(addrs []ma.Multiaddr) []ma.Multiaddr { return addrs }
 
 	// A provider announcing itself under a valid peer ID with a ~4 MiB addr list.
 	_, pub, err := crypto.GenerateEd25519Key(rand.NewChaCha8([32]byte{7}))


### PR DESCRIPTION
## Summary

DHT messages carry _peer records_ — a peer ID together with the multiaddresses at which the peer can be reached — as the closer peers in a `FIND_NODE` / `GET_PROVIDERS` response and as the provider records in an `ADD_PROVIDER` request. A whole message is already bounded to `network.MessageSizeMax` on the wire, but an individual peer record within it had no size bound of its own: a record could carry an arbitrary number of addresses, making its size on the wire — and its footprint in the peerstore once ingested — effectively unbounded.

This bounds a single peer record to 8 KiB, trimming excess addresses.

## What changed

- A single `Message_Peer` is bounded to `MaxPeerRecordSize` (8 KiB) when converted to or from the wire. Addresses past the limit are dropped; the peer ID is always kept and the record is never dropped.
- The bound is applied once, at the `pb` conversion boundary, so it covers every path:
  - **Outbound** — provider records and closer peers in every handler (`GET_PROVIDERS`, `FIND_NODE`), and self-published records — via the `peerInfoToPBPeer` / `peerRoutingInfoToPBPeer` constructors.
  - **Inbound** — `ADD_PROVIDER` ingestion and the records returned to a client — via `PBPeersToPeerInfos`.
  - `fullrt` inherits both through the shared `pb` functions.
- Record size is tracked incrementally with `protowire` (O(n), no re-marshalling).
- Documented in `optimizations.md`.

## Why 8 KiB

A peer record only needs an identity and enough addresses to be dialable. [8 KiB](https://github.com/libp2p/go-libp2p/blob/v0.48.0/p2p/protocol/identify/id.go#L49) is the budget the libp2p identify protocol already allots for a peer's _entire_ signed self-description, so it is comfortably larger than any well-formed peer requires, while keeping a record a predictable size on the wire and in the peerstore.

## Compatibility

No wire-protocol, message-schema, or go-libp2p change, and no new configuration. A bounded record is an ordinary peer record with fewer addresses, which every implementation already accepts, so patched and unpatched nodes interoperate unchanged. The one new exported symbol is the `pb.MaxPeerRecordSize` constant.